### PR TITLE
Fix Package.swift

### DIFF
--- a/app-ios/Package.swift
+++ b/app-ios/Package.swift
@@ -17,19 +17,18 @@ let package = Package(
     targets: [
         .target(
             name: "App",
-            dependencies: [
-                "KmpModule",
-            ]
+            dependencies: [.kmpModule]
         ),
         .testTarget(
             name: "AppTests",
-            dependencies: ["App"]
+            dependencies: [.app]
         ),
-        // For debug
-        // Please run ./gradlew app-ios-shared:linkDebugFrameworkIosSimulatorArm64 first
-        .binaryTarget(name: "KmpModule", path: "../app-ios-shared/build/bin/iosSimulatorArm64/debugFramework/shared.framework"),
-        // For release
         // Please run ./gradlew app-ios-shared:assembleSharedXCFramework first
-        //   .binaryTarget(name: "KmpModule", path: "../app-ios-shared/build/XCFrameworks/release/shared.xcframework"),
+        .binaryTarget(name: "KmpModule", path: "../app-ios-shared/build/XCFrameworks/release/shared.xcframework"),
     ]
 )
+
+extension Target.Dependency {
+    static let app: Target.Dependency = "App"
+    static let kmpModule: Target.Dependency = "KmpModule"
+}


### PR DESCRIPTION
## Issue
Package.swift has been modified to import XCFramework since the Framework cannot be imported by Swift Package.

## Overview (Required)
- 

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
