### PR TITLE
Quick build fix (revert change where code referenced is not included.

### DIFF
--- a/app-ios/Sources/App/ContentView.swift
+++ b/app-ios/Sources/App/ContentView.swift
@@ -41,9 +41,9 @@ public struct ContentView: View {
 struct ContributorComposeViewControllerWrapper: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewController {
         let container = Container.shared
-        let repositories: Repositories = container.get(type: Repositories.self)
+        let repositories: ContributorsRepository = container.get(type: ContributorsRepository.self)
         return DarwinContributorsKt.contributorViewController(
-            repositories: repositories,
+            contributorsRepository: repositories,
             onContributorItemClick: {_ in}
         )
     }


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- The last commit broke the build. It included a change from "ContributorsRepository" to "Repository" but its not clear where the Repository code is being referenced from. Returning to "ContributorsRepository" appears to fix the build.

