### PR TITLE
update configuration-cache settings and change value to fail

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.caching=true
 org.gradle.parallel=true
 # configuration-cache
 org.gradle.configuration-cache=true
-org.gradle.configuration-cache-problems=error
+org.gradle.configuration-cache.problems=fail
 org.gradle.configuration-cache.max-problems=5
 
 # android


### PR DESCRIPTION
## Issue

## Overview (Required)

- Update configuration-cache settings and change the value of org.gradle.configuration-cache.problems to fail.
  - The current org.gradle.configuration-cache.problems settings use the notation from when it was an incubating feature.

## Links

- https://docs.gradle.org/8.0.2/userguide/configuration_cache.html
- https://docs.gradle.org/8.3/userguide/configuration_cache.html

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
