### PR TITLE
Add color alias tokens

### DIFF
--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Arctic Fox Container.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Arctic Fox Container.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.100",
+          "blue" : "0x61",
+          "green" : "0xE7",
+          "red" : "0x45"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Arctic Fox Dim.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Arctic Fox Dim.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x17",
+          "green" : "0x24",
+          "red" : "0x13"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Bumblebee Container.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Bumblebee Container.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.100",
+          "blue" : "0x3C",
+          "green" : "0xD3",
+          "red" : "0xDD"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Bumblebee Dim.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Bumblebee Dim.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x13",
+          "green" : "0x22",
+          "red" : "0x22"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Bumblebee.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Bumblebee.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x3C",
+          "green" : "0xD3",
+          "red" : "0xDD"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Chipmunk Container.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Chipmunk Container.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.100",
+          "blue" : "0x4B",
+          "green" : "0x97",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Chipmunk Dim.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Chipmunk Dim.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x15",
+          "green" : "0x1C",
+          "red" : "0x25"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Chipmunk.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Chipmunk.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x4B",
+          "green" : "0x97",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Dolphin Container.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Dolphin Container.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.100",
+          "blue" : "0xFF",
+          "green" : "0x85",
+          "red" : "0xBB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Dolphin Dim.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Dolphin Dim.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x27",
+          "green" : "0x1A",
+          "red" : "0x1E"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Dolphin.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Dolphin.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x85",
+          "red" : "0xBB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Electric eel Container.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Electric eel Container.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.100",
+          "blue" : "0xE7",
+          "green" : "0xAD",
+          "red" : "0x44"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Electric eel Dim.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Electric eel Dim.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x25",
+          "green" : "0x1E",
+          "red" : "0x12"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Electric eel.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Custom/Electric eel.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE7",
+          "green" : "0xAD",
+          "red" : "0x44"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Error/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Error/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Error/Error Container.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Error/Error Container.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x0A",
+          "green" : "0x00",
+          "red" : "0x93"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Error/Error.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Error/Error.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xAB",
+          "green" : "0xB4",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Error/On Error Container.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Error/On Error Container.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD6",
+          "green" : "0xDA",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Error/On Error.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Error/On Error.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x05",
+          "green" : "0x00",
+          "red" : "0x69"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Inverse/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Inverse/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Inverse/Inverse On Surface.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Inverse/Inverse On Surface.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x31",
+          "green" : "0x31",
+          "red" : "0x2F"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Inverse/Inverse Primary.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Inverse/Inverse Primary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2E",
+          "green" : "0x6E",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Inverse/Inverse Surface.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Inverse/Inverse Surface.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE2",
+          "green" : "0xE2",
+          "red" : "0xE3"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Primary/On Primary Container.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Primary/On Primary Container.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1D",
+          "green" : "0x4A",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Primary/On Primary Fixed Variant.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Primary/On Primary Fixed Variant.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x21",
+          "green" : "0x53",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Primary/On Primary Fixed.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Primary/On Primary Fixed.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x09",
+          "green" : "0x21",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Primary/Primary Container.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Primary/Primary Container.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x77",
+          "green" : "0xF3",
+          "red" : "0x38"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Primary/Primary Fixed Dim.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Primary/Primary Fixed Dim.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x6B",
+          "green" : "0xE4",
+          "red" : "0x1C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Primary/Primary Fixed.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Primary/Primary Fixed.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x8D",
+          "green" : "0xFF",
+          "red" : "0x67"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Primary/Primary.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Primary/Primary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE0",
+          "green" : "0xD3",
+          "red" : "0x82"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Scrim/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Scrim/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Scrim/Scrim.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Scrim/Scrim.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Secondary/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Secondary/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Secondary/On Secondary Container.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Secondary/On Secondary Container.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xAA",
+          "green" : "0xF1",
+          "red" : "0xA0"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Secondary/On Secondary Fixed Variant.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Secondary/On Secondary Fixed Variant.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x21",
+          "green" : "0x53",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Secondary/On Secondary Fixed.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Secondary/On Secondary Fixed.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x09",
+          "green" : "0x21",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Secondary/On Secondary.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Secondary/On Secondary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x15",
+          "green" : "0x39",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Secondary/Secondary Container.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Secondary/Secondary Container.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x21",
+          "green" : "0x52",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Secondary/Secondary Fixed Dim.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Secondary/Secondary Fixed Dim.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x93",
+          "green" : "0xD8",
+          "red" : "0x88"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Secondary/Secondary Fixed.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Secondary/Secondary Fixed.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xAD",
+          "green" : "0xF5",
+          "red" : "0xA3"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Secondary/Secondary.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Secondary/Secondary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x93",
+          "green" : "0xD8",
+          "red" : "0x88"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Shadow/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Shadow/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Shadow/Shadow.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Shadow/Shadow.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Surface/Surface Bright.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Surface/Surface Bright.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x39",
+          "green" : "0x39",
+          "red" : "0x38"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Surface/Surface Container High.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Surface/Surface Container High.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2A",
+          "green" : "0x2A",
+          "red" : "0x29"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Surface/Surface Container Highest.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Surface/Surface Container Highest.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x35",
+          "green" : "0x35",
+          "red" : "0x34"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Surface/Surface Container Low.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Surface/Surface Container Low.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1C",
+          "green" : "0x1C",
+          "red" : "0x1A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Surface/Surface Container Lowest.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Surface/Surface Container Lowest.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x0F",
+          "green" : "0x0E",
+          "red" : "0x0D"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Surface/Surface Dim.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Surface/Surface Dim.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x14",
+          "green" : "0x14",
+          "red" : "0x12"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Tertiary/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Tertiary/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Tertiary/On Tertiary Container.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Tertiary/On Tertiary Container.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x42",
+          "green" : "0x00",
+          "red" : "0x4C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Tertiary/On Tertiary Fixed Variant.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Tertiary/On Tertiary Fixed Variant.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x6B",
+          "green" : "0x1F",
+          "red" : "0x7B"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Tertiary/On Tertiary Fixed.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Tertiary/On Tertiary Fixed.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x32",
+          "green" : "0x00",
+          "red" : "0x3A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Tertiary/On Tertiary.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Tertiary/On Tertiary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x52",
+          "green" : "0x00",
+          "red" : "0x5E"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Tertiary/Tertiary Container.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Tertiary/Tertiary Container.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xDD",
+          "green" : "0x8C",
+          "red" : "0xF9"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Tertiary/Tertiary Fixed Dim.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Tertiary/Tertiary Fixed Dim.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE7",
+          "green" : "0xAC",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Tertiary/Tertiary Fixed.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Tertiary/Tertiary Fixed.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF0",
+          "green" : "0xD7",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app-ios/Sources/Theme/Resources/Colors.xcassets/Tertiary/Tertiary.colorset/Contents.json
+++ b/app-ios/Sources/Theme/Resources/Colors.xcassets/Tertiary/Tertiary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xED",
+          "green" : "0xCC",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## Overview (Required)
Add color alias tokens.
Only the Content.json file was added.

## Figma
https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=49823-12142&t=oxJbVdlXGh3PlRZv-4

## Screenshot
<img width="844" alt="スクリーンショット 2024-06-25 0 48 38" src="https://github.com/DroidKaigi/conference-app-2024/assets/59346949/0081de65-766f-4d14-a7e9-457663eea17b">
