### PR TITLE
Expand the headline area of the timetable detail screen to fill entire width of the screen 

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimeTableItemDetailHeadline.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimeTableItemDetailHeadline.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -37,7 +38,8 @@ fun TimeTableItemDetailHeadline(
         modifier = modifier
             // FIXME: Implement and use a theme color instead of fixed colors like RoomColors.primary and RoomColors.primaryDim
             .background(Color(0xFF132417))
-            .padding(8.dp),
+            .padding(8.dp)
+            .fillMaxWidth(),
     ) {
         Row {
             TagView(


### PR DESCRIPTION
## Issue
- This PR fixes implementation oversight in https://github.com/DroidKaigi/conference-app-2024/issues/59 🙇

## Overview (Required)
- 

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2024/assets/73375669/1cb16d00-46aa-46b8-9249-bd3b67ee4955" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2024/assets/73375669/bdb22728-879e-4fac-b6fe-75c9b48aebe9" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
