### PR TITLE
Revert "Add compileKotlinIosSimulatorArm64 to CI"

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -38,7 +38,6 @@ jobs:
           path: ${{ github.event_path }}
 
       - run: ./gradlew detekt --stacktrace
-      - run: ./gradlew compileKotlinIosSimulatorArm64
 
       - run: ./gradlew testDevDebugUnitTest testDebugUnitTest --stacktrace
 


### PR DESCRIPTION
Reverts DroidKaigi/conference-app-2024#121

It seems that tasks are skipped because it runs on linux