### PR TITLE
[iOS]Added logic to open video and slide web view

### DIFF
--- a/app-ios/Sources/TimetableDetailFeature/Component/LanguageTag.swift
+++ b/app-ios/Sources/TimetableDetailFeature/Component/LanguageTag.swift
@@ -2,25 +2,14 @@ import SwiftUI
 import Theme
 
 struct LanguageTag: View {
-    enum Language {
-        case japanese, english
-        
-        var text: String {
-            switch self {
-            case .japanese: "JA"
-            case .english: "EN"
-            }
-        }
-    }
-
-    let language: Language
+    let languageLabel: String
     
-    init(_ language: Language) {
-        self.language = language
+    init(_ languageLabel: String) {
+        self.languageLabel = languageLabel
     }
 
     var body: some View {
-        Text(language.text)
+        Text(languageLabel)
             .textStyle(.labelMedium)
             .foregroundStyle(AssetColors.Surface.onSurfaceVariant.swiftUIColor)
             .padding(.horizontal, 4)
@@ -32,5 +21,5 @@ struct LanguageTag: View {
 }
 
 #Preview {
-    LanguageTag(.english)
+    LanguageTag("EN")
 }

--- a/app-ios/Sources/TimetableDetailFeature/TimetableDetailReducer.swift
+++ b/app-ios/Sources/TimetableDetailFeature/TimetableDetailReducer.swift
@@ -23,7 +23,7 @@ public struct TimetableDetailReducer: Sendable {
         var timetableItem: TimetableItem
         var isBookmarked = false
         var toast: ToastState?
-        var tappedUrl: IdentifiableURL?
+        var url: IdentifiableURL?
         @Presents var confirmationDialog: ConfirmationDialogState<ConfirmationDialog>?
     }
 
@@ -38,8 +38,8 @@ public struct TimetableDetailReducer: Sendable {
         public enum View {
             case bookmarkButtonTapped
             case calendarButtonTapped
-            case slideButtonTapped
-            case videoButtonTapped
+            case slideButtonTapped(URL)
+            case videoButtonTapped(URL)
             case urlTapped(URL)
         }
     }
@@ -90,14 +90,16 @@ public struct TimetableDetailReducer: Sendable {
                 print(error.localizedDescription)
                 return .none
 
-            case .view(.slideButtonTapped):
+            case let .view(.slideButtonTapped(url)):
+                state.url = IdentifiableURL(url)
                 return .none
 
-            case .view(.videoButtonTapped):
+            case let .view(.videoButtonTapped(url)):
+                state.url = IdentifiableURL(url)
                 return .none
                 
             case let .view(.urlTapped(url)):
-                state.tappedUrl = IdentifiableURL(url)
+                state.url = IdentifiableURL(url)
                 return .none
 
             case .bookmarkResponse(.success):

--- a/app-ios/Sources/TimetableDetailFeature/TimetableDetailView.swift
+++ b/app-ios/Sources/TimetableDetailFeature/TimetableDetailView.swift
@@ -21,8 +21,11 @@ public struct TimetableDetailView: View {
                         .padding(.horizontal, 16)
                     targetAudience
                         .padding(16)
-                    archive
-                        .padding(16)
+                    if store.timetableItem.asset.videoUrl != nil || 
+                       store.timetableItem.asset.slideUrl != nil {
+                        archive
+                            .padding(16)
+                    }
                 }
                 .toast($store.toast)
                 
@@ -39,7 +42,7 @@ public struct TimetableDetailView: View {
                 action: \.confirmationDialog
             )
         )
-        .sheet(item: $store.tappedUrl) { url in
+        .sheet(item: $store.url) { url in
             SafariView(url: url.id)
                 .ignoresSafeArea()
         }
@@ -92,8 +95,9 @@ public struct TimetableDetailView: View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 4) {
                 RoomTag(.arcticFox)
-                LanguageTag(.japanese)
-                LanguageTag(.english)
+                ForEach(store.timetableItem.language.labels, id: \.self) { label in
+                    LanguageTag(label)
+                }
             }
             .padding(.bottom, 8)
 
@@ -192,41 +196,47 @@ public struct TimetableDetailView: View {
                 .foregroundStyle(AssetColors.Custom.arcticFox.swiftUIColor)
 
             HStack {
-                Button {
-                    store.send(.view(.slideButtonTapped))
-                } label: {
-                    VStack {
-                        Label(
-                            title: {
-                                Text(String(localized: "TimeTableDetailSlide", bundle: .module))
-                                    .textStyle(.labelLarge)
-                                    .foregroundStyle(AssetColors.Primary.onPrimary.swiftUIColor)
-                            },
-                            icon: { Image(.icDocument) }
-                        )
+                if let slideUrlString = store.timetableItem.asset.slideUrl,
+                   let slideUrl = URL(string: slideUrlString) {
+                    Button {
+                        store.send(.view(.slideButtonTapped(slideUrl)))
+                    } label: {
+                        VStack {
+                            Label(
+                                title: {
+                                    Text(String(localized: "TimeTableDetailSlide", bundle: .module))
+                                        .textStyle(.labelLarge)
+                                        .foregroundStyle(AssetColors.Primary.onPrimary.swiftUIColor)
+                                },
+                                icon: { Image(.icDocument) }
+                            )
+                        }
+                        .frame(height: 40)
+                        .frame(maxWidth: .infinity)
+                        .background(AssetColors.Custom.arcticFox.swiftUIColor)
+                        .clipShape(Capsule())
                     }
-                    .frame(height: 40)
-                    .frame(maxWidth: .infinity)
-                    .background(AssetColors.Custom.arcticFox.swiftUIColor)
-                    .clipShape(Capsule())
                 }
-                Button {
-                    store.send(.view(.videoButtonTapped))
-                } label: {
-                    VStack {
-                        Label(
-                            title: {
-                                Text(String(localized: "TimeTableDetailVideo", bundle: .module))
-                                    .textStyle(.labelLarge)
-                                    .foregroundStyle(AssetColors.Primary.onPrimary.swiftUIColor)
-                            },
-                            icon: { Image(.icPlay) }
-                        )
+                if let videoUrlString = store.timetableItem.asset.videoUrl,
+                   let videoUrl = URL(string: videoUrlString) {
+                    Button {
+                        store.send(.view(.videoButtonTapped(videoUrl)))
+                    } label: {
+                        VStack {
+                            Label(
+                                title: {
+                                    Text(String(localized: "TimeTableDetailVideo", bundle: .module))
+                                        .textStyle(.labelLarge)
+                                        .foregroundStyle(AssetColors.Primary.onPrimary.swiftUIColor)
+                                },
+                                icon: { Image(.icPlay) }
+                            )
+                        }
+                        .frame(height: 40)
+                        .frame(maxWidth: .infinity)
+                        .background(AssetColors.Custom.arcticFox.swiftUIColor)
+                        .clipShape(Capsule())
                     }
-                    .frame(height: 40)
-                    .frame(maxWidth: .infinity)
-                    .background(AssetColors.Custom.arcticFox.swiftUIColor)
-                    .clipShape(Capsule())
                 }
             }
         }

--- a/app-ios/Tests/TimetableDetailFeatureTests/TimetableDetailTests.swift
+++ b/app-ios/Tests/TimetableDetailFeatureTests/TimetableDetailTests.swift
@@ -44,7 +44,7 @@ final class TimetableDetail_iosTests: XCTestCase {
         }
         let url = URL(string: "https://github.com/DroidKaigi/conference-app-2023")!
         await store.send(.view(.urlTapped(url))) {
-            $0.tappedUrl = IdentifiableURL(url)
+            $0.url = IdentifiableURL(url)
         }
     }
     
@@ -71,6 +71,26 @@ final class TimetableDetail_iosTests: XCTestCase {
             $0.confirmationDialog = nil
         }
         await store.receive(\.addEventResponse)
+    }
+    
+    @MainActor func testTappedVideoButton() async throws {
+        let store = TestStore(initialState: TimetableDetailReducer.State(timetableItem: TimetableItem.Session.companion.fake(), isBookmarked: false)) {
+            TimetableDetailReducer()
+        }
+        let videoUrl = URL(string: "https://www.youtube.com/watch?v=hFdKCyJ-Z9A")!
+        await store.send(.view(.videoButtonTapped(videoUrl))) {
+            $0.url = IdentifiableURL(videoUrl)
+        }
+    }
+    
+    @MainActor func testTappedSlideButton() async throws {
+        let store = TestStore(initialState: TimetableDetailReducer.State(timetableItem: TimetableItem.Session.companion.fake(), isBookmarked: false)) {
+            TimetableDetailReducer()
+        }
+        let videoUrl = URL(string: "https://droidkaigi.jp/2021/")!
+        await store.send(.view(.slideButtonTapped(videoUrl))) {
+            $0.url = IdentifiableURL(videoUrl)
+        }
     }
 }
 


### PR DESCRIPTION
## Overview (Required)
Added logic to open video and slide web view.

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="https://github.com/user-attachments/assets/bdbe49e6-89e9-4919-aa92-7619c2bb53d7" width="300" >
