### PR TITLE
Ignore KGP cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ app-ios/fastlane/report.xml
 app-android/src/prod/google-services.json
 keystore.properties
 droidkaigi2023.keystore
+
+# Kotlin Gradle Plugin cache
+.kotlin


### PR DESCRIPTION
## Overview (Required)
- Starting from kotlin 2.0, a cache is created in `.kotlin`. Since this results in a large number of files appearing as changes, I have configured it to be ignored.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
