### PR TITLE
Support English on the detail screen title

### DIFF
--- a/feature/sessions/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/sessions/src/commonMain/composeResources/values-ja/strings.xml
@@ -26,4 +26,8 @@
     <string name="content_description_location">場所</string>
     <string name="content_description_language">言語</string>
     <string name="content_description_category">カテゴリ</string>
+    <string name="schedule_title">日時</string>
+    <string name="location_title">場所</string>
+    <string name="language_title">対応言語</string>
+    <string name="category_title">カテゴリ</string>
 </resources>

--- a/feature/sessions/src/commonMain/composeResources/values/strings.xml
+++ b/feature/sessions/src/commonMain/composeResources/values/strings.xml
@@ -26,4 +26,8 @@
     <string name="content_description_location">Location</string>
     <string name="content_description_language">Language</string>
     <string name="content_description_category">Category</string>
+    <string name="schedule_title">Date/Time</string>
+    <string name="location_title">Location</string>
+    <string name="language_title">Supported Languages</string>
+    <string name="category_title">Category</string>
 </resources>

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailSummaryCard.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailSummaryCard.kt
@@ -25,10 +25,14 @@ import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
+import conference_app_2024.feature.sessions.generated.resources.category_title
 import conference_app_2024.feature.sessions.generated.resources.content_description_category
 import conference_app_2024.feature.sessions.generated.resources.content_description_language
 import conference_app_2024.feature.sessions.generated.resources.content_description_location
 import conference_app_2024.feature.sessions.generated.resources.content_description_schedule
+import conference_app_2024.feature.sessions.generated.resources.language_title
+import conference_app_2024.feature.sessions.generated.resources.location_title
+import conference_app_2024.feature.sessions.generated.resources.schedule_title
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.designsystem.theme.LocalRoomTheme
 import io.github.droidkaigi.confsched.model.Locale
@@ -70,7 +74,7 @@ fun TimetableItemDetailSummaryCard(
             modifier = Modifier.fillMaxWidth(),
             imageVector = Icons.Outlined.Schedule,
             contentDescription = stringResource(SessionsRes.string.content_description_schedule),
-            title = "日時",
+            title = stringResource(SessionsRes.string.schedule_title),
             description = timetableItem.formattedDateTimeString,
         )
         Spacer(Modifier.height(8.dp))
@@ -78,7 +82,7 @@ fun TimetableItemDetailSummaryCard(
             modifier = Modifier.fillMaxWidth(),
             imageVector = Icons.Outlined.LocationOn,
             contentDescription = stringResource(SessionsRes.string.content_description_location),
-            title = "場所",
+            title = stringResource(SessionsRes.string.location_title),
             description = timetableItem.room.nameAndFloor,
         )
         Spacer(Modifier.height(8.dp))
@@ -86,7 +90,7 @@ fun TimetableItemDetailSummaryCard(
             modifier = Modifier.fillMaxWidth(),
             imageVector = Icons.Outlined.Language,
             contentDescription = stringResource(SessionsRes.string.content_description_language),
-            title = "対応言語",
+            title = stringResource(SessionsRes.string.language_title),
             description = timetableItem.getSupportedLangString(
                 getDefaultLocale() == Locale.JAPAN,
             ),
@@ -96,7 +100,7 @@ fun TimetableItemDetailSummaryCard(
             modifier = Modifier.fillMaxWidth(),
             imageVector = Icons.Outlined.Category,
             contentDescription = stringResource(SessionsRes.string.content_description_category),
-            title = "カテゴリ",
+            title = stringResource(SessionsRes.string.category_title),
             description = timetableItem.category.title.currentLangTitle,
         )
     }


### PR DESCRIPTION
## Issue
- close #221 

## Overview (Required)
- The title was previously hard-coded and did not used the string resources.
- I added a string key that supports both Japanese and English to the `:feature:session` module and implemented the key.

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/83a8606c-13bb-4792-8756-3a3bc2c6f6b7" width="300" /> | <img src="https://github.com/user-attachments/assets/9864e590-efab-493b-8876-a3a51a387a60" width="300" />
