### PR TITLE
Fix "Readmore" text to "More" in session detail screen

### DIFF
--- a/feature/sessions/src/commonMain/composeResources/values/strings.xml
+++ b/feature/sessions/src/commonMain/composeResources/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="not_bookmarked">Not Bookmarked</string>
     <string name="image">image</string>
     <string name="special">Special</string>
-    <string name="read_more">Read more</string>
+    <string name="read_more">More</string>
     <string name="target_audience">Target Audience</string>
     <string name="archive">Archive</string>
     <string name="slide">Slide</string>


### PR DESCRIPTION
## Issue
- close #209 

## Overview (Required)
- "Readmore" on the session details screen updated to "More" when the app language is English

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/64415298-585c-4e92-a380-b9ac2c4f2a6d" width="300" /> | <img src="https://github.com/user-attachments/assets/74b44abb-07dd-4998-8062-e6f552d9fd66" width="300" />



