### PR TITLE
Support color constrast theming

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched/KaigiApp.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched
 
 import android.annotation.SuppressLint
+import android.app.UiModeManager
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
@@ -14,6 +15,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -31,6 +33,7 @@ import io.github.droidkaigi.confsched.about.aboutScreenRoute
 import io.github.droidkaigi.confsched.about.navigateAboutScreen
 import io.github.droidkaigi.confsched.contributors.contributorsScreenRoute
 import io.github.droidkaigi.confsched.contributors.contributorsScreens
+import io.github.droidkaigi.confsched.designsystem.theme.ColorContrast
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.eventmap.eventMapScreens
 import io.github.droidkaigi.confsched.eventmap.navigateEventMapScreen
@@ -69,7 +72,9 @@ fun KaigiApp(
     displayFeatures: PersistentList<DisplayFeature>,
     modifier: Modifier = Modifier,
 ) {
-    KaigiTheme {
+    KaigiTheme(
+        colorContrast = colorContrast(),
+    ) {
         Surface(
             modifier = modifier.fillMaxSize(),
             color = MaterialTheme.colorScheme.background,
@@ -339,5 +344,22 @@ private class ExternalNavController(
             .setShowTitle(true)
             .build()
             .launchUrl(context, uri)
+    }
+}
+
+@Composable
+@ReadOnlyComposable
+private fun colorContrast(): ColorContrast {
+    val uiModeManager =
+        LocalContext.current.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        when (uiModeManager.contrast) {
+            in 0.0f..0.33f -> ColorContrast.Default
+            in 0.34f..0.66f -> ColorContrast.Medium
+            in 0.67f..1.0f -> ColorContrast.High
+            else -> ColorContrast.Default
+        }
+    } else {
+        ColorContrast.Default
     }
 }

--- a/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/theme/Theme.kt
@@ -8,6 +8,9 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
+import io.github.droidkaigi.confsched.designsystem.theme.ColorContrast.Default
+import io.github.droidkaigi.confsched.designsystem.theme.ColorContrast.High
+import io.github.droidkaigi.confsched.designsystem.theme.ColorContrast.Medium
 
 private val lightScheme = lightColorScheme(
     primary = primaryLight,
@@ -251,9 +254,14 @@ private val fixedAccentColors = FixedAccentColors(
 
 @Composable
 fun KaigiTheme(
+    colorContrast: ColorContrast = Default,
     content: @Composable () -> Unit,
 ) {
-    val colorScheme = darkScheme
+    val colorScheme = when (colorContrast) {
+        Default -> darkScheme
+        Medium -> mediumContrastDarkColorScheme
+        High -> highContrastDarkColorScheme
+    }
 
     MaterialTheme(
         colorScheme = colorScheme,
@@ -265,4 +273,8 @@ fun KaigiTheme(
             )
         },
     )
+}
+
+enum class ColorContrast {
+    Default, Medium, High
 }


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Support for color contrast features on Android 14 and later.
  - The colors in the generated ColorScheme support contrast switching, but the room color and fixed color are not supported and will not switch.

## Links
- https://m3.material.io/styles/color/system/how-the-system-works#0207ef40-7f0d-4da8-9280-f062aa6b3e04

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After Default | Medium Contrast | High Contrast
:--: | :--: | :--: | :--:
<img src="https://github.com/user-attachments/assets/e7c52f9a-05f9-4adf-bd6c-a5bf355b2411" width="300" /> | <img src="https://github.com/user-attachments/assets/9de9cf7a-b5ba-4d53-a026-670649f1eb74" width="300" /> | <img src="https://github.com/user-attachments/assets/c33208d5-aa16-412f-b9cd-60da555abe00" width="300" /> | <img src="https://github.com/user-attachments/assets/fa640163-14f1-4b06-9fb8-9a37b68fec86" width="300" />


The color of FAB and Outlined that use ColorScheme will change depending on the device's contrast settings.


## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
