### PR TITLE
Added fixed colors

### DIFF
--- a/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/theme/FixedAccentColors.kt
+++ b/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/theme/FixedAccentColors.kt
@@ -1,0 +1,88 @@
+package io.github.droidkaigi.confsched.designsystem.theme
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+data class FixedAccentColors(
+    val primaryFixed: Color,
+    val onPrimaryFixed: Color,
+    val secondaryFixed: Color,
+    val onSecondaryFixed: Color,
+    val tertiaryFixed: Color,
+    val onTertiaryFixed: Color,
+    val primaryFixedDim: Color,
+    val secondaryFixedDim: Color,
+    val tertiaryFixedDim: Color,
+)
+
+@Suppress("CompositionLocalAllowlist")
+internal val LocalFixedAccentColors = compositionLocalOf {
+    FixedAccentColors(
+        primaryFixed = darkScheme.primaryContainer,
+        onPrimaryFixed = darkScheme.onPrimaryContainer,
+        secondaryFixed = darkScheme.secondaryContainer,
+        onSecondaryFixed = darkScheme.onSecondaryContainer,
+        tertiaryFixed = darkScheme.tertiaryContainer,
+        onTertiaryFixed = darkScheme.onTertiaryContainer,
+        primaryFixedDim = darkScheme.primary,
+        secondaryFixedDim = darkScheme.secondary,
+        tertiaryFixedDim = darkScheme.tertiary,
+    )
+}
+
+@Suppress("UnusedReceiverParameter")
+val ColorScheme.primaryFixed: Color
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalFixedAccentColors.current.primaryFixed
+
+@Suppress("UnusedReceiverParameter")
+val ColorScheme.onPrimaryFixed: Color
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalFixedAccentColors.current.onPrimaryFixed
+
+@Suppress("UnusedReceiverParameter")
+val ColorScheme.secondaryFixed: Color
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalFixedAccentColors.current.secondaryFixed
+
+@Suppress("UnusedReceiverParameter")
+val ColorScheme.onSecondaryFixed: Color
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalFixedAccentColors.current.onSecondaryFixed
+
+@Suppress("UnusedReceiverParameter")
+val ColorScheme.tertiaryFixed: Color
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalFixedAccentColors.current.tertiaryFixed
+
+@Suppress("UnusedReceiverParameter")
+val ColorScheme.onTertiaryFixed: Color
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalFixedAccentColors.current.onTertiaryFixed
+
+@Suppress("UnusedReceiverParameter")
+val ColorScheme.primaryFixedDim: Color
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalFixedAccentColors.current.primaryFixedDim
+
+@Suppress("UnusedReceiverParameter")
+val ColorScheme.secondaryFixedDim: Color
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalFixedAccentColors.current.secondaryFixedDim
+
+@Suppress("UnusedReceiverParameter")
+val ColorScheme.tertiaryFixedDim: Color
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalFixedAccentColors.current.tertiaryFixedDim

--- a/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/theme/Theme.kt
@@ -6,6 +6,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.graphics.Color
 
 private val lightScheme = lightColorScheme(
     primary = primaryLight,
@@ -45,7 +47,7 @@ private val lightScheme = lightColorScheme(
     surfaceContainerHighest = surfaceContainerHighestLight,
 )
 
-private val darkScheme = darkColorScheme(
+internal val darkScheme = darkColorScheme(
     primary = primaryDark,
     onPrimary = onPrimaryDark,
     primaryContainer = primaryContainerDark,
@@ -235,16 +237,32 @@ private val highContrastDarkColorScheme = darkColorScheme(
     surfaceContainerHighest = surfaceContainerHighestDarkHighContrast,
 )
 
+private val fixedAccentColors = FixedAccentColors(
+    primaryFixed = Color(0xFF67FF8D),
+    onPrimaryFixed = Color(0xFF002109),
+    secondaryFixed = Color(0xFFA3F5AD),
+    onSecondaryFixed = Color(0xFF002109),
+    tertiaryFixed = Color(0xFFFFD7F0),
+    onTertiaryFixed = Color(0xFF3A0032),
+    primaryFixedDim = Color(0xFF1CE46B),
+    secondaryFixedDim = Color(0xFF88D893),
+    tertiaryFixedDim = Color(0xFFFFACE7),
+)
+
 @Composable
 fun KaigiTheme(
-    content:
-    @Composable () -> Unit,
+    content: @Composable () -> Unit,
 ) {
     val colorScheme = darkScheme
 
     MaterialTheme(
         colorScheme = colorScheme,
         typography = appTypography(),
-        content = content,
+        content = {
+            CompositionLocalProvider(
+                value = LocalFixedAccentColors provides fixedAccentColors,
+                content = content,
+            )
+        },
     )
 }


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Added fixed colors.
  - Not applied to each screen.
  - This is required before #227 .

## Links
- https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=53699-35660&t=gQTFzGMHPcAZemBX-4
- sample: https://github.com/androidx/androidx/blob/88a2d443f349b046617d750457d438dd8637cc4e/compose/material3/material3/samples/src/main/java/androidx/compose/material3/samples/ColorSchemeSamples.kt#L34

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
