### PR TITLE
Implement the app bar "About DroidKaigi" in the About list screen

### DIFF
--- a/feature/about/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/about/src/commonMain/composeResources/values-ja/strings.xml
@@ -15,6 +15,7 @@
     <string name="license">ライセンス</string>
     <string name="privacy_policy">プライバシーポリシー</string>
     <string name="app_version">アプリバージョン</string>
+    <string name="about-droidkaigi">Droidkaigiについて</string>
     <string name="content_description_youtube">YouTube</string>
     <string name="content_description_x">X</string>
     <string name="content_description_medium">Medium</string>

--- a/feature/about/src/commonMain/composeResources/values/strings.xml
+++ b/feature/about/src/commonMain/composeResources/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="license">License</string>
     <string name="privacy_policy">Privacy Policy</string>
     <string name="app_version">App Version</string>
+    <string name="about_droidkaigi">About Droidkaigi</string>
     <string name="content_description_youtube">YouTube</string>
     <string name="content_description_x">X</string>
     <string name="content_description_medium">Medium</string>

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/AboutScreen.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/AboutScreen.kt
@@ -7,6 +7,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -18,6 +20,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import conference_app_2024.feature.about.generated.resources.about_droidkaigi
 import io.github.droidkaigi.confsched.about.section.AboutDroidKaigiDetail
 import io.github.droidkaigi.confsched.about.section.AboutFooterLinks
 import io.github.droidkaigi.confsched.about.section.aboutCredits
@@ -26,6 +29,7 @@ import io.github.droidkaigi.confsched.model.AboutItem
 import io.github.droidkaigi.confsched.model.AboutItem.Medium
 import io.github.droidkaigi.confsched.model.AboutItem.X
 import io.github.droidkaigi.confsched.model.AboutItem.YouTube
+import org.jetbrains.compose.resources.stringResource
 
 const val aboutScreenRoute = "about"
 
@@ -68,6 +72,7 @@ fun AboutScreen(
 
     Scaffold(
         modifier = modifier.testTag(AboutScreenTestTag.Screen),
+        topBar = { TopAppBar(title = { Text(stringResource(AboutRes.string.about_droidkaigi)) }) },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         contentWindowInsets = WindowInsets(
             left = contentPadding.calculateLeftPadding(layoutDirection),


### PR DESCRIPTION
## Issue
- close #223 

## Overview (Required)
- Implement the app bar "About DroidKaigi" in the About list screen using `TopAppBar`

## Links
- figma https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=54982-75342&t=k4TShQboqq07iWl6-0

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After (Japanase) | After (English)
:--: | :--: | :--:
<img src="https://github.com/user-attachments/assets/661274f7-15c6-42e1-b34f-60feb6952adb" width="300" /> | <img src="https://github.com/user-attachments/assets/9ce127be-0c36-43a8-8e9f-bd2f578d5aa8" width="300" /> | <img src="https://github.com/user-attachments/assets/fa04eb3e-8d96-4617-9079-69c1a4feb719" width="300" />

# question 
According to [this figma](https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=55725-8670&t=htgSgF3wWucKlsEr-0), the `"About Droidkaigi"` text in the App Bar seems to be fixed in the center when scrolling the screen.
Should this feature be resolved in this PR? Should it be separated into a different issue?
