### PR TITLE
Session detail screen: Speaker name not center-aligned next to icon

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailHeadline.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailHeadline.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
@@ -60,7 +61,9 @@ fun TimetableItemDetailHeadline(
         )
         Spacer(modifier = Modifier.height(16.dp))
         timetableItem.speakers.forEach { speaker ->
-            Row {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
                 Image(
                     painter = rememberAsyncImagePainter(speaker.iconUrl),
                     contentDescription = null,


### PR DESCRIPTION
## Issue
- close #220 

## Overview (Required)
- Centered Speaker names in session details

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/79778bb5-b5d3-4d86-8693-57d3a19739f9" width="300" /> | <img src="https://github.com/user-attachments/assets/97436d7e-c455-40bb-881c-3a1d9548048f" width="300" />
