### PR TITLE
Added a 'View Map' text button to the About screen."

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched/KaigiApp.kt
@@ -148,6 +148,9 @@ private fun NavGraphBuilder.mainScreen(
                         "https://portal.droidkaigi.jp/en"
                     }
                     when (aboutItem) {
+                        AboutItem.Map -> externalNavController.navigate(
+                            url = "https://goo.gl/maps/vv9sE19JvRjYKtSP9"
+                        )
                         AboutItem.Sponsors -> navController.navigate(sponsorsScreenRoute)
                         AboutItem.CodeOfConduct -> {
                             externalNavController.navigate(

--- a/app-android/src/main/java/io/github/droidkaigi/confsched/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched/KaigiApp.kt
@@ -149,7 +149,7 @@ private fun NavGraphBuilder.mainScreen(
                     }
                     when (aboutItem) {
                         AboutItem.Map -> externalNavController.navigate(
-                            url = "https://goo.gl/maps/vv9sE19JvRjYKtSP9"
+                            url = "https://goo.gl/maps/vv9sE19JvRjYKtSP9",
                         )
                         AboutItem.Sponsors -> navController.navigate(sponsorsScreenRoute)
                         AboutItem.CodeOfConduct -> {

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/AboutItem.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/AboutItem.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched.model
 
 sealed class AboutItem {
+    data object Map : AboutItem()
     data object Sponsors : AboutItem()
     data object Contributors : AboutItem()
     data object Staff : AboutItem()

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/AboutScreen.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/AboutScreen.kt
@@ -84,7 +84,7 @@ fun AboutScreen(
                 AboutDroidKaigiDetail(
                     onViewMapClick = {
                         onAboutItemClick(AboutItem.Map)
-                    }
+                    },
                 )
             }
             aboutCredits(

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/AboutScreen.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/AboutScreen.kt
@@ -81,7 +81,11 @@ fun AboutScreen(
             contentPadding = padding,
         ) {
             item {
-                AboutDroidKaigiDetail()
+                AboutDroidKaigiDetail(
+                    onViewMapClick = {
+                        onAboutItemClick(AboutItem.Map)
+                    }
+                )
             }
             aboutCredits(
                 onSponsorsItemClick = {

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutDroidKaigiDetailSummaryCard.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutDroidKaigiDetailSummaryCard.kt
@@ -69,7 +69,6 @@ fun AboutDroidKaigiDetailSummaryCard(
                     regex = stringResource(AboutRes.string.place_link).toRegex(),
                 )
             }
-
         }
     }
 }

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutDroidKaigiDetailSummaryCard.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutDroidKaigiDetailSummaryCard.kt
@@ -2,11 +2,8 @@ package io.github.droidkaigi.confsched.about.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons.Outlined
 import androidx.compose.material.icons.outlined.Place
@@ -25,7 +22,6 @@ import conference_app_2024.feature.about.generated.resources.place_description
 import conference_app_2024.feature.about.generated.resources.place_link
 import conference_app_2024.feature.about.generated.resources.place_title
 import io.github.droidkaigi.confsched.about.AboutRes
-import io.github.droidkaigi.confsched.designsystem.component.ClickableLinkText
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -55,20 +51,14 @@ fun AboutDroidKaigiDetailSummaryCard(
                 label = stringResource(AboutRes.string.date_title),
                 content = stringResource(AboutRes.string.date_description),
             )
-            Row {
-                AboutDroidKaigiDetailSummaryCardRow(
-                    leadingIcon = Outlined.Place,
-                    label = stringResource(AboutRes.string.place_title),
-                    content = stringResource(AboutRes.string.place_description),
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                ClickableLinkText(
-                    style = MaterialTheme.typography.bodyMedium,
-                    content = stringResource(AboutRes.string.place_link),
-                    onLinkClick = { _ -> onViewMapClick() },
-                    regex = stringResource(AboutRes.string.place_link).toRegex(),
-                )
-            }
+            val placeContent = stringResource(AboutRes.string.place_description)
+                .plus(" " + stringResource(AboutRes.string.place_link))
+            AboutDroidKaigiDetailSummaryCardRow(
+                leadingIcon = Outlined.Place,
+                label = stringResource(AboutRes.string.place_title),
+                content = placeContent,
+                onLinkClick = { _ -> onViewMapClick() },
+            )
         }
     }
 }

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutDroidKaigiDetailSummaryCard.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutDroidKaigiDetailSummaryCard.kt
@@ -2,8 +2,11 @@ package io.github.droidkaigi.confsched.about.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons.Outlined
 import androidx.compose.material.icons.outlined.Place
@@ -19,8 +22,10 @@ import androidx.compose.ui.unit.dp
 import conference_app_2024.feature.about.generated.resources.date_description
 import conference_app_2024.feature.about.generated.resources.date_title
 import conference_app_2024.feature.about.generated.resources.place_description
+import conference_app_2024.feature.about.generated.resources.place_link
 import conference_app_2024.feature.about.generated.resources.place_title
 import io.github.droidkaigi.confsched.about.AboutRes
+import io.github.droidkaigi.confsched.designsystem.component.ClickableLinkText
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -28,6 +33,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 @Composable
 fun AboutDroidKaigiDetailSummaryCard(
     modifier: Modifier = Modifier,
+    onViewMapClick: () -> Unit,
 ) {
     Card(
         shape = RoundedCornerShape(12.dp),
@@ -49,11 +55,21 @@ fun AboutDroidKaigiDetailSummaryCard(
                 label = stringResource(AboutRes.string.date_title),
                 content = stringResource(AboutRes.string.date_description),
             )
-            AboutDroidKaigiDetailSummaryCardRow(
-                leadingIcon = Outlined.Place,
-                label = stringResource(AboutRes.string.place_title),
-                content = stringResource(AboutRes.string.place_description),
-            )
+            Row {
+                AboutDroidKaigiDetailSummaryCardRow(
+                    leadingIcon = Outlined.Place,
+                    label = stringResource(AboutRes.string.place_title),
+                    content = stringResource(AboutRes.string.place_description),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                ClickableLinkText(
+                    style = MaterialTheme.typography.bodyMedium,
+                    content = stringResource(AboutRes.string.place_link),
+                    onLinkClick = { _ -> onViewMapClick() },
+                    regex = stringResource(AboutRes.string.place_link).toRegex(),
+                )
+            }
+
         }
     }
 }
@@ -63,7 +79,9 @@ fun AboutDroidKaigiDetailSummaryCard(
 fun AboutDroidKaigiDetailSummaryCardPreview() {
     KaigiTheme {
         Surface {
-            AboutDroidKaigiDetailSummaryCard()
+            AboutDroidKaigiDetailSummaryCard(
+                onViewMapClick = {},
+            )
         }
     }
 }

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutDroidKaigiDetailSummaryCardRow.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutDroidKaigiDetailSummaryCardRow.kt
@@ -17,7 +17,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import conference_app_2024.feature.about.generated.resources.place_link
+import io.github.droidkaigi.confsched.about.AboutRes
+import io.github.droidkaigi.confsched.designsystem.component.ClickableLinkText
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
+import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
@@ -27,6 +31,7 @@ fun AboutDroidKaigiDetailSummaryCardRow(
     content: String,
     modifier: Modifier = Modifier,
     leadingIconContentDescription: String? = null,
+    onLinkClick: (url: String) -> Unit = {},
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -45,10 +50,11 @@ fun AboutDroidKaigiDetailSummaryCardRow(
             style = MaterialTheme.typography.labelLarge,
         )
         Spacer(modifier = Modifier.width(12.dp))
-        Text(
-            text = content,
-            fontWeight = FontWeight.Bold,
+        ClickableLinkText(
             style = MaterialTheme.typography.bodyMedium,
+            content = content,
+            onLinkClick = onLinkClick,
+            regex = stringResource(AboutRes.string.place_link).toRegex(),
         )
     }
 }

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/section/AboutDroidKaigiDetail.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/section/AboutDroidKaigiDetail.kt
@@ -31,6 +31,7 @@ object AboutDetailSectionTestTag {
 @Composable
 fun AboutDroidKaigiDetail(
     modifier: Modifier = Modifier,
+    onViewMapClick: () -> Unit,
 ) {
     Column(
         modifier = modifier.testTag(AboutDetailSectionTestTag.Section),
@@ -61,6 +62,7 @@ fun AboutDroidKaigiDetail(
                     top = 12.dp,
                     end = 16.dp,
                 ),
+            onViewMapClick = onViewMapClick,
         )
     }
 }
@@ -70,7 +72,9 @@ fun AboutDroidKaigiDetail(
 fun AboutDroidKaigiDetailPreview() {
     KaigiTheme {
         Surface {
-            AboutDroidKaigiDetail()
+            AboutDroidKaigiDetail(
+                onViewMapClick = {},
+            )
         }
     }
 }


### PR DESCRIPTION
## Issue
- close #205

## Overview (Required)
- Added a 'View Map' text button to the About screen."

## Links
- [Figma](https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=54985-75942&t=e1CZJMlo119t4tkU-4)

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/9339eb92-7f45-4868-9f44-99cbeb49c635" width="300" /> | <img src="https://github.com/user-attachments/assets/c56a299d-ab35-4f37-b82b-507ca029fbd9" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
None | <video src="https://github.com/user-attachments/assets/a0b8c1bb-73dd-4f9f-b11e-c3f3514d37e3" width="300" >