### PR TITLE
Changed the shape of speaker icons in the timeline grid from rounded rectangle to circles

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
@@ -244,7 +244,7 @@ private fun SpeakerIcon(
             .clip(CircleShape)
             .border(
                 BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
-                RoundedCornerShape(8.dp),
+                CircleShape,
             ),
     )
 }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Error
@@ -240,7 +241,7 @@ private fun SpeakerIcon(
         contentDescription = stringResource(SessionsRes.string.content_description_user_icon),
         modifier = modifier
             .size(TimetableGridItemSizes.speakerHeight)
-            .clip(RoundedCornerShape(8.dp))
+            .clip(CircleShape)
             .border(
                 BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
                 RoundedCornerShape(8.dp),


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2024/issues/224

## Overview (Required)
- Changed the shape of speaker icons in the timeline grid from rounded rectangle to circles.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/7cf12c67-07f4-4d37-81dd-c1b118463254" width="300" /> | <img src="https://github.com/user-attachments/assets/7799ef7f-b8f3-4017-8920-062c90af3a80" width="300" />


## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
