### PR TITLE
Change time table icon by state

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
@@ -164,9 +164,9 @@ private fun TimetableScreen(
                         Crossfade(targetState = uiState.timetableUiType) { timetableUiType ->
                             Icon(
                                 imageVector = if (timetableUiType == Grid) {
-                                    Icons.Default.GridView
-                                } else {
                                     Icons.Default.ViewTimeline
+                                } else {
+                                    Icons.Default.GridView
                                 },
                                 contentDescription = null,
                                 modifier = Modifier.padding(8.dp).clickable {

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched.sessions
 
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -13,8 +14,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Grid3x3
+import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.ViewTimeline
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
@@ -45,6 +47,7 @@ import io.github.droidkaigi.confsched.model.DroidKaigi2024Day
 import io.github.droidkaigi.confsched.model.Timetable
 import io.github.droidkaigi.confsched.model.TimetableItem
 import io.github.droidkaigi.confsched.model.TimetableUiType
+import io.github.droidkaigi.confsched.model.TimetableUiType.Grid
 import io.github.droidkaigi.confsched.sessions.section.TimetableListUiState
 import io.github.droidkaigi.confsched.sessions.section.TimetableSheet
 import io.github.droidkaigi.confsched.sessions.section.TimetableSheetUiState
@@ -158,13 +161,19 @@ private fun TimetableScreen(
                             modifier = Modifier.padding(8.dp).clickable {
                             },
                         )
-                        Icon(
-                            imageVector = Icons.Default.Grid3x3,
-                            contentDescription = null,
-                            modifier = Modifier.padding(8.dp).clickable {
-                                onTimetableUiChangeClick()
-                            }.testTag(TimetableUiTypeChangeButtonTestTag),
-                        )
+                        Crossfade(targetState = uiState.timetableUiType) { timetableUiType ->
+                            Icon(
+                                imageVector = if (timetableUiType == Grid) {
+                                    Icons.Default.GridView
+                                } else {
+                                    Icons.Default.ViewTimeline
+                                },
+                                contentDescription = null,
+                                modifier = Modifier.padding(8.dp).clickable {
+                                    onTimetableUiChangeClick()
+                                }.testTag(TimetableUiTypeChangeButtonTestTag),
+                            )
+                        }
                     }
                 },
             )


### PR DESCRIPTION
## Issue
- close #207 

## Overview (Required)
- Previously, the timetable icon was fixed by the `Grid3x3` icon. 
- Now, each icon is determined by the `timetableUiType` state.
   - When displaying the timetable in grid type, the icon is shown as `Icons.Default.ViewTimeline`.
   - When displaying the timetable in list type, the icon is shown as `Icons.Default.GridView`.

## Links
- [Related Figma link](https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=54876-39860&t=2ihtMr09UnG5zVpA-4)

## Screenshot 
Before | Grid | Timeline
:--: | :--: | :--:
<img src="https://github.com/user-attachments/assets/b4939420-0428-4fb2-9d58-d5e84fb5a55d" width="300" /> | <img src="https://github.com/user-attachments/assets/1b4fe15d-4b9e-493f-a19c-8c7ae1ea494e" width="300" /> | <img src="https://github.com/user-attachments/assets/99bcf4c6-b698-4b47-a742-bc98b52e19da" width="300" />

## Movie
(To check cross fade animation.)

https://github.com/user-attachments/assets/bf748254-b963-4c19-b97d-84f0147258d6
