### PR TITLE
Adjusted padding to increase spacing between bottom navigation items

### DIFF
--- a/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeBottomNavigation.kt
+++ b/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeBottomNavigation.kt
@@ -64,7 +64,7 @@ fun GlassLikeBottomNavigation(
     var selectedTabIndex by remember { mutableIntStateOf(0) }
     Box(
         modifier = modifier
-            .padding(vertical = 24.dp, horizontal = 64.dp)
+            .padding(vertical = 24.dp, horizontal = 48.dp)
             .fillMaxWidth()
             .height(64.dp)
             .hazeChild(state = hazeState, shape = CircleShape)


### PR DESCRIPTION
## Issue
- close #226 

## Overview (Required)
- Adjusted padding to increase spacing between bottom navigation items

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/093c0147-d157-480b-9db0-21486208e553" width="300" /> | <img src="https://github.com/user-attachments/assets/8b93b704-c32f-44e2-bbc2-c1965488eb86" width="300" />



## Other
- I'm concerned about the bottom navigation interfering with the system navigation. (Device: Pixel 7)
