### PR TITLE
Add time display to the left side of the timetable

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
@@ -206,11 +206,11 @@ fun PreviewTimetableScreenDark() {
                     contentUiState = TimetableSheetUiState.ListTimetable(
                         mapOf(
                             DroidKaigi2024Day.Workday to TimetableListUiState(
-                                mapOf<String, List<TimetableItem>>().toPersistentMap(),
+                                mapOf<Pair<String, String>, List<TimetableItem>>().toPersistentMap(),
                                 Timetable(),
                             ),
                             DroidKaigi2024Day.ConferenceDay1 to TimetableListUiState(
-                                mapOf<String, List<TimetableItem>>().toPersistentMap(),
+                                mapOf<Pair<String, String>, List<TimetableItem>>().toPersistentMap(),
                                 Timetable(),
                             ),
                         ),

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenPresenter.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenPresenter.kt
@@ -85,7 +85,7 @@ fun timetableSheet(
                         days = listOf(day),
                     ),
                 ).timetableItems.groupBy {
-                    it.startsTimeString + it.endsTimeString
+                    it.startsTimeString to it.endsTimeString
                 }.mapValues { entries ->
                     entries.value.sortedWith(
                         compareBy({ it.day?.name.orEmpty() }, { it.startsTimeString }),

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableTime.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableTime.kt
@@ -1,0 +1,46 @@
+package io.github.droidkaigi.confsched.sessions.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun TimetableTime(
+    startTime: String,
+    endTime: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            text = startTime,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier,
+        )
+        Box(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.outline)
+                .width(2.dp)
+                .height(8.dp),
+        )
+        Text(
+            text = endTime,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier,
+        )
+    }
+}

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
@@ -86,7 +86,7 @@ fun TimetableList(
                                 timetableItem.language.labels.forEach { label ->
                                     TimetableItemTag(
                                         tagText = label,
-                                        tagColor = MaterialTheme.colorScheme.onSurfaceVariant
+                                        tagColor = MaterialTheme.colorScheme.onSurfaceVariant,
                                     )
                                     Spacer(modifier = Modifier.padding(3.dp))
                                 }


### PR DESCRIPTION
## Issue
- #201 

## Overview (Required)
- The times are displayed on the left side of the existing timetable list.
  - To make time data easier to consume, I changed this type to `Pair<String, String>`.
  - I Added `@Composable fun TimetableTime()` to display timetables.
  - Since many columns and rows are overlapping, I modified all but the topmost `LazyColumn` to `Column` of `TimetableList`.
- There was no design issue, So I just slightly modified the spacing between some of the views in compliance with Figma(except for Font).

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
