### PR TITLE
Display appropriate information for Welcome Talk and Lunch Break in Timetable detail screen

### DIFF
--- a/feature/sessions/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/sessions/src/commonMain/composeResources/values-ja/strings.xml
@@ -8,7 +8,6 @@
     <string name="bookmarked">ブックマーク済み</string>
     <string name="not_bookmarked">ブックマークされていません</string>
     <string name="image">画像</string>
-    <string name="special">特別</string>
     <string name="read_more">続きを読む</string>
     <string name="target_audience">対象者</string>
     <string name="archive">アーカイブ</string>

--- a/feature/sessions/src/commonMain/composeResources/values/strings.xml
+++ b/feature/sessions/src/commonMain/composeResources/values/strings.xml
@@ -8,7 +8,6 @@
     <string name="bookmarked">Bookmarked</string>
     <string name="not_bookmarked">Not Bookmarked</string>
     <string name="image">image</string>
-    <string name="special">Special</string>
     <string name="read_more">More</string>
     <string name="target_audience">Target Audience</string>
     <string name="archive">Archive</string>

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailContent.kt
@@ -79,7 +79,11 @@ fun TimetableItemDetailContent(
             }
 
             is Special -> {
-                Text(stringResource(SessionsRes.string.special))
+                DescriptionSection(
+                    description = timetableItem.description.currentLangTitle,
+                    onLinkClick = onLinkClick,
+                )
+                TargetAudienceSection(timetableItem = timetableItem)
             }
         }
     }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailContent.kt
@@ -84,6 +84,13 @@ fun TimetableItemDetailContent(
                     onLinkClick = onLinkClick,
                 )
                 TargetAudienceSection(timetableItem = timetableItem)
+                if (timetableItem.asset.isAvailable) {
+                    ArchiveSection(
+                        timetableItem = timetableItem,
+                        onViewSlideClick = onLinkClick,
+                        onWatchVideoClick = onLinkClick,
+                    )
+                }
             }
         }
     }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailContent.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.unit.dp
 import conference_app_2024.feature.sessions.generated.resources.archive
 import conference_app_2024.feature.sessions.generated.resources.read_more
 import conference_app_2024.feature.sessions.generated.resources.slide
-import conference_app_2024.feature.sessions.generated.resources.special
 import conference_app_2024.feature.sessions.generated.resources.target_audience
 import conference_app_2024.feature.sessions.generated.resources.video
 import io.github.droidkaigi.confsched.designsystem.component.ClickableLinkText


### PR DESCRIPTION
## Issue
- close #213 

## Overview (Required)
- Changed the details screen for special content such as Welcome Talk and Lunch Break to display the appropriate wording.

## Links
- nothing

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
![Screenshot_20240811_173130](https://github.com/user-attachments/assets/7a82c2d6-6429-4faf-8f30-73e2a66c369b) | ![Screenshot_20240811_173037](https://github.com/user-attachments/assets/376c848e-9beb-46a2-b57a-9813ce228390)

