### PR TITLE
Fixed sponsor wording on About page

### DIFF
--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/section/AboutCredits.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/section/AboutCredits.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import conference_app_2024.feature.about.generated.resources.contributor
 import conference_app_2024.feature.about.generated.resources.credits_title
+import conference_app_2024.feature.about.generated.resources.sponsor
 import conference_app_2024.feature.about.generated.resources.staff
 import io.github.droidkaigi.confsched.about.AboutRes
 import io.github.droidkaigi.confsched.about.component.AboutContentColumn
@@ -75,7 +76,7 @@ fun LazyListScope.aboutCredits(
     item {
         AboutContentColumn(
             leadingIcon = Outlined.Apartment,
-            label = stringResource(AboutRes.string.staff),
+            label = stringResource(AboutRes.string.sponsor),
             testTag = SponsorsItem,
             onClickAction = onSponsorsItemClick,
             modifier = modifier


### PR DESCRIPTION
## Issue
- nothing

## Overview (Required)
- The sponsor title on the About page was written as "staff," so I have corrected it.

## Links
- nothing

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
![Screenshot_20240811_174823](https://github.com/user-attachments/assets/d7c2d619-2aca-4603-ae17-2d984e48b7be) | ![Screenshot_20240811_174914](https://github.com/user-attachments/assets/f2944be1-4f98-4d81-8338-005b7fcd3964)


## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
