### PR TITLE
fixed link between timetable and timetable detail

### DIFF
--- a/app-ios/Sources/App/RootReducer.swift
+++ b/app-ios/Sources/App/RootReducer.swift
@@ -111,12 +111,13 @@ public struct RootReducer {
                 state.paths.about.append(.acknowledgements)
                 return .none
                 
-            case .timetable(.view(.timetableItemTapped)):
+            case .timetable(.view(.timetableItemTapped(let item))):
                 state.paths.timetable.append(.timetableDetail(
                     TimetableDetailReducer.State(
-                        timetableItem: shared.TimetableItem.Session.companion.fake()
+                        timetableItem: item.timetableItem,
+                        isBookmarked: item.isFavorited)
                     )
-                ))
+                )
                 return .none
 
             case .timetable(.view(.searchTapped)):

--- a/app-ios/Sources/TimetableFeature/TimetableListView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableListView.swift
@@ -91,10 +91,10 @@ struct TimetableListView: View {
             LazyVStack {
                 ForEach(store.timetableItems, id: \.self) { item in
                     Button {
-                        store.send(.view(.timetableItemTapped))
+                        //store.send(.view(.timetableItemTapped))
                     } label: {
                         TimeGroupMiniList(contents: item, onItemTap: { item in
-                            store.send(.view(.timetableItemTapped))
+                            store.send(.view(.timetableItemTapped(item)))
                         })
                     }
                 }

--- a/app-ios/Sources/TimetableFeature/TimetableListView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableListView.swift
@@ -90,19 +90,15 @@ struct TimetableListView: View {
         ScrollView{
             LazyVStack {
                 ForEach(store.timetableItems, id: \.self) { item in
-                    Button {
-                        //store.send(.view(.timetableItemTapped))
-                    } label: {
-                        TimeGroupMiniList(contents: item, onItemTap: { item in
-                            store.send(.view(.timetableItemTapped(item)))
-                        })
-                    }
+                    
+                    TimeGroupMiniList(contents: item, onItemTap: { item in
+                        store.send(.view(.timetableItemTapped(item)))
+                    })
                 }
             }.scrollContentBackground(.hidden)
-            
-                .onAppear {
-                    store.send(.onAppear)
-                }.background(AssetColors.Surface.surface.swiftUIColor)
+            .onAppear {
+                store.send(.onAppear)
+            }.background(AssetColors.Surface.surface.swiftUIColor)
         }
     }
 }

--- a/app-ios/Sources/TimetableFeature/TimetableReducer.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableReducer.swift
@@ -28,7 +28,7 @@ public struct TimetableReducer : Sendable{
         
         public enum View : Sendable {
             case selectDay(DayTab)
-            case timetableItemTapped
+            case timetableItemTapped(TimetableItemWithFavorite)
             case searchTapped
         }
     }


### PR DESCRIPTION
## Issue
- close #286

## Overview (Required)
- Added in a way to send the selected item to the timetable detail screen

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/41b6fece-c252-498c-bef4-e485f1c08ffc" width="300"  alt="before" title="Before">  |  <video src="https://github.com/user-attachments/assets/c5f5fd2e-38a4-43ba-aa54-6f1d964abdcb" width="300"  alt="after" title="After">





