### PR TITLE
Change transition area to cover entire card

### DIFF
--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/TimetableItemCard.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/TimetableItemCard.kt
@@ -52,6 +52,7 @@ fun TimetableItemCard(
     ProvideRoomTheme(timetableItem.room.getThemeKey()) {
         Column(
             modifier = modifier
+                .testTag(TimetableItemCardTestTag)
                 .border(
                     border = BorderStroke(width = 1.dp, color = MaterialTheme.colorScheme.outlineVariant),
                     shape = RoundedCornerShape(5.dp),

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/TimetableItemCard.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/TimetableItemCard.kt
@@ -56,6 +56,7 @@ fun TimetableItemCard(
                     border = BorderStroke(width = 1.dp, color = MaterialTheme.colorScheme.outlineVariant),
                     shape = RoundedCornerShape(5.dp),
                 )
+                .clickable { onTimetableItemClick(timetableItem) }
                 .padding(15.dp),
         ) {
             Box {
@@ -87,8 +88,7 @@ fun TimetableItemCard(
                 fontSize = 24.sp,
                 modifier = Modifier
                     .testTag(TimetableItemCardTestTag)
-                    .padding(bottom = 5.dp)
-                    .clickable { onTimetableItemClick(timetableItem) },
+                    .padding(bottom = 5.dp),
             )
             timetableItem.speakers.forEach { speaker ->
                 Row {


### PR DESCRIPTION
## Issue
- close #214

## Overview (Required)
- Change transition area cover entire card.

## Links
- nothing

## Screenshot (Optional if screenshot test is present or unrelated to UI)
nothing

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/5b487648-7ced-425e-a322-3b115d18b9a6" width="300" > | <video src="https://github.com/user-attachments/assets/7715c201-020c-4694-9c27-32ff7703e56e" width="300" >
