### PR TITLE
"EventMap" text uses string resource

### DIFF
--- a/feature/eventmap/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/eventmap/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="sample">!!Please remove this resource when you add string resource!!</string>
     <string name="eventmap">イベントマップ</string>
 </resources>

--- a/feature/eventmap/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/eventmap/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="sample">!!Please remove this resource when you add string resource!!</string>
+    <string name="eventmap">イベントマップ</string>
 </resources>

--- a/feature/eventmap/src/commonMain/composeResources/values/strings.xml
+++ b/feature/eventmap/src/commonMain/composeResources/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="sample">!!Please remove this resource when you add string resource!!</string>
+    <string name="eventmap">EventMap</string>
 </resources>

--- a/feature/eventmap/src/commonMain/composeResources/values/strings.xml
+++ b/feature/eventmap/src/commonMain/composeResources/values/strings.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="sample">!!Please remove this resource when you add string resource!!</string>
     <string name="eventmap">EventMap</string>
 </resources>

--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
@@ -30,6 +30,7 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import co.touchlab.kermit.Logger
+import conference_app_2024.feature.eventmap.generated.resources.eventmap
 import io.github.droidkaigi.confsched.compose.rememberEventEmitter
 import io.github.droidkaigi.confsched.eventmap.component.EventMapItem
 import io.github.droidkaigi.confsched.eventmap.component.EventMapTab
@@ -40,6 +41,7 @@ import io.github.droidkaigi.confsched.ui.handleOnClickIfNotNavigating
 import io.github.droidkaigi.confsched.ui.rememberUserMessageStateHolder
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
+import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 const val eventMapScreenRoute = "eventMap"
@@ -130,7 +132,7 @@ fun EventMapScreen(
             if (scrollBehavior != null) {
                 LargeTopAppBar(
                     title = {
-                        Text(text = "イベントマップ")
+                        Text(text = stringResource(EventMapRes.string.eventmap))
                     },
                     navigationIcon = {
                         IconButton(


### PR DESCRIPTION
## Overview (Required)
- Fixed "イベントマップ" text to use string resource since it is hard-coded.
- Supported in Japanese and English.


## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After (Japanese) | After (English)
:--: | :--: | :--:
<img src="https://github.com/user-attachments/assets/1403c3a7-b429-45af-8d46-48d1f8410789" width="300" /> | <img src="https://github.com/user-attachments/assets/4c15f39d-8015-4545-ba60-31c4b7887681" width="300" /> | <img src="https://github.com/user-attachments/assets/f88e944c-73f9-4f25-ad36-4e893c4d4128" width="300" />

