### PR TITLE
Fixed tab on timetable. (This design may change soon)

### DIFF
--- a/app-ios/Sources/TimetableFeature/SampleData.swift
+++ b/app-ios/Sources/TimetableFeature/SampleData.swift
@@ -4,9 +4,9 @@ import shared
 public enum DayTab: String, CaseIterable, Identifiable, Sendable {
     public var id : RawValue { rawValue }
     
-    case workshopDay = "WorkshopDay"
-    case day1 = "Day 1"
-    case day2 = "Day 2"
+    case all = "All"
+    case day1 = "9/12"
+    case day2 = "9/13"
 }
 
 public enum TimetableMode {

--- a/app-ios/Sources/TimetableFeature/SampleData.swift
+++ b/app-ios/Sources/TimetableFeature/SampleData.swift
@@ -4,7 +4,6 @@ import shared
 public enum DayTab: String, CaseIterable, Identifiable, Sendable {
     public var id : RawValue { rawValue }
     
-    case all = "All"
     case day1 = "9/12"
     case day2 = "9/13"
 }

--- a/app-ios/Sources/TimetableFeature/TimetableListView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableListView.swift
@@ -25,11 +25,27 @@ public struct TimetableView: View {
                     }, label: {
                         //TODO: Only selected button should be green and underlined
                         if selectedTab == tabItem {
-                            Text(tabItem.rawValue).foregroundStyle(
-                                AssetColors.Custom.iguana.swiftUIColor)
-                            .underline()
+                            HStack(spacing: 6) {
+                                Text(tabItem.rawValue)
+                                    .textStyle(.labelMedium)
+                            }
+                            .foregroundStyle(AssetColors.Custom.iguana.swiftUIColor)
+                            .padding(6)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 4)
+                                    .stroke(AssetColors.Custom.iguana.swiftUIColor, lineWidth: 1)
+                            )
                         } else {
-                            Text(tabItem.rawValue)
+                            HStack(spacing: 6) {
+                                Text(tabItem.rawValue)
+                                    .textStyle(.labelMedium)
+                            }
+                            .foregroundStyle(AssetColors.Surface.onSurface.swiftUIColor)
+                            .padding(6)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 4)
+                                    .stroke(AssetColors.Surface.onSurface.swiftUIColor, lineWidth: 1)
+                            )
                         }
                     })
                 }

--- a/app-ios/Sources/TimetableFeature/TimetableListView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableListView.swift
@@ -13,6 +13,7 @@ public struct TimetableView: View {
     
     @State var timetableMode = TimetableMode.list
     @State var switchModeIcon: String = "square.grid.2x2"
+    @State var selectedTab: DayTab = DayTab.day1
     
     public var body: some View {
         VStack {
@@ -20,11 +21,16 @@ public struct TimetableView: View {
                 ForEach(DayTab.allCases) { tabItem in
                     Button(action: {
                         store.send(.view(.selectDay(tabItem)))
+                        selectedTab = tabItem
                     }, label: {
                         //TODO: Only selected button should be green and underlined
-                        Text(tabItem.rawValue).foregroundStyle(
-                            AssetColors.Custom.flamingo.swiftUIColor)
+                        if selectedTab == tabItem {
+                            Text(tabItem.rawValue).foregroundStyle(
+                                AssetColors.Custom.iguana.swiftUIColor)
                             .underline()
+                        } else {
+                            Text(tabItem.rawValue)
+                        }
                     })
                 }
                 Spacer()

--- a/app-ios/Sources/TimetableFeature/TimetableListView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableListView.swift
@@ -28,13 +28,10 @@ public struct TimetableView: View {
                             HStack(spacing: 6) {
                                 Text(tabItem.rawValue)
                                     .textStyle(.labelMedium)
+                                    .underline()
                             }
                             .foregroundStyle(AssetColors.Custom.iguana.swiftUIColor)
                             .padding(6)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 4)
-                                    .stroke(AssetColors.Custom.iguana.swiftUIColor, lineWidth: 1)
-                            )
                         } else {
                             HStack(spacing: 6) {
                                 Text(tabItem.rawValue)
@@ -42,10 +39,6 @@ public struct TimetableView: View {
                             }
                             .foregroundStyle(AssetColors.Surface.onSurface.swiftUIColor)
                             .padding(6)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 4)
-                                    .stroke(AssetColors.Surface.onSurface.swiftUIColor, lineWidth: 1)
-                            )
                         }
                     })
                 }

--- a/app-ios/Sources/TimetableFeature/TimetableListView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableListView.swift
@@ -24,22 +24,13 @@ public struct TimetableView: View {
                         selectedTab = tabItem
                     }, label: {
                         //TODO: Only selected button should be green and underlined
-                        if selectedTab == tabItem {
-                            HStack(spacing: 6) {
+                        HStack(spacing: 6) {
                                 Text(tabItem.rawValue)
                                     .textStyle(.labelMedium)
-                                    .underline()
+                                    .underline(selectedTab == tabItem)
                             }
-                            .foregroundStyle(AssetColors.Custom.iguana.swiftUIColor)
+                            .foregroundStyle(selectedTab == tabItem ? AssetColors.Custom.iguana.swiftUIColor : AssetColors.Surface.onSurface.swiftUIColor)
                             .padding(6)
-                        } else {
-                            HStack(spacing: 6) {
-                                Text(tabItem.rawValue)
-                                    .textStyle(.labelMedium)
-                            }
-                            .foregroundStyle(AssetColors.Surface.onSurface.swiftUIColor)
-                            .padding(6)
-                        }
                     })
                 }
                 Spacer()

--- a/app-ios/Sources/TimetableFeature/TimetableListView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableListView.swift
@@ -23,11 +23,8 @@ public struct TimetableView: View {
                         store.send(.view(.selectDay(tabItem)))
                         selectedTab = tabItem
                     }, label: {
-                        //TODO: Only selected button should be green and underlined
                         HStack(spacing: 6) {
-                                Text(tabItem.rawValue)
-                                .textStyle(.titleMedium)
-                                    .underline(selectedTab == tabItem)
+                                Text(tabItem.rawValue).textStyle(.titleMedium).underline(selectedTab == tabItem)
                             }
                             .foregroundStyle(selectedTab == tabItem ? AssetColors.Custom.iguana.swiftUIColor : AssetColors.Surface.onSurface.swiftUIColor)
                             .padding(6)

--- a/app-ios/Sources/TimetableFeature/TimetableListView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableListView.swift
@@ -24,10 +24,10 @@ public struct TimetableView: View {
                         selectedTab = tabItem
                     }, label: {
                         HStack(spacing: 6) {
-                                Text(tabItem.rawValue).textStyle(.titleMedium).underline(selectedTab == tabItem)
-                            }
-                            .foregroundStyle(selectedTab == tabItem ? AssetColors.Custom.iguana.swiftUIColor : AssetColors.Surface.onSurface.swiftUIColor)
-                            .padding(6)
+                            Text(tabItem.rawValue).textStyle(.titleMedium).underline(selectedTab == tabItem)
+                        }
+                        .foregroundStyle(selectedTab == tabItem ? AssetColors.Custom.iguana.swiftUIColor : AssetColors.Surface.onSurface.swiftUIColor)
+                        .padding(6)
                     })
                 }
                 Spacer()

--- a/app-ios/Sources/TimetableFeature/TimetableListView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableListView.swift
@@ -26,7 +26,7 @@ public struct TimetableView: View {
                         //TODO: Only selected button should be green and underlined
                         HStack(spacing: 6) {
                                 Text(tabItem.rawValue)
-                                    .textStyle(.labelMedium)
+                                .textStyle(.titleMedium)
                                     .underline(selectedTab == tabItem)
                             }
                             .foregroundStyle(selectedTab == tabItem ? AssetColors.Custom.iguana.swiftUIColor : AssetColors.Surface.onSurface.swiftUIColor)
@@ -162,7 +162,6 @@ struct TagView: View {
 }
 
 struct PhotoView: View {
-    //TODO: Replace this with an actual photo render
     let photo: String
     let name: String
     

--- a/app-ios/Sources/TimetableFeature/TimetableReducer.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableReducer.swift
@@ -66,23 +66,15 @@ public struct TimetableReducer : Sendable{
                  }
             case .requestDay(.selectDay(let dayTab)):
                 return .run { send in
-                    let internalDay: DroidKaigi2024Day? = switch dayTab {
-                    case DayTab.all:
-                        nil
+                    let internalDay: DroidKaigi2024Day = switch dayTab {
                     case DayTab.day1:
                         DroidKaigi2024Day.conferenceDay1
                     case DayTab.day2:
                         DroidKaigi2024Day.conferenceDay2
                     }
                     
-                    if let selection = internalDay {
-                        for try await timetables in try timetableClient.streamTimetable() {
-                            await send(.response(.success(timetables.dayTimetable(droidKaigi2024Day: selection).contents)))
-                        }
-                    } else {
-                        for try await timetables in try timetableClient.streamTimetable() {
-                            await send(.response(.success(timetables.contents)))
-                        }
+                    for try await timetables in try timetableClient.streamTimetable() {
+                        await send(.response(.success(timetables.dayTimetable(droidKaigi2024Day: internalDay).contents)))
                     }
                 }
                 .cancellable(id: CancelID.connection)

--- a/app-ios/Sources/TimetableFeature/TimetableReducer.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableReducer.swift
@@ -66,17 +66,23 @@ public struct TimetableReducer : Sendable{
                  }
             case .requestDay(.selectDay(let dayTab)):
                 return .run { send in
-                    let internalDay = switch dayTab {
-                    case DayTab.workshopDay:
-                        DroidKaigi2024Day.workday
+                    let internalDay: DroidKaigi2024Day? = switch dayTab {
+                    case DayTab.all:
+                        nil
                     case DayTab.day1:
                         DroidKaigi2024Day.conferenceDay1
                     case DayTab.day2:
                         DroidKaigi2024Day.conferenceDay2
                     }
                     
-                    for try await timetables in try timetableClient.streamTimetable() {
-                        await send(.response(.success(timetables.dayTimetable(droidKaigi2024Day: internalDay).contents)))
+                    if let selection = internalDay {
+                        for try await timetables in try timetableClient.streamTimetable() {
+                            await send(.response(.success(timetables.dayTimetable(droidKaigi2024Day: selection).contents)))
+                        }
+                    } else {
+                        for try await timetables in try timetableClient.streamTimetable() {
+                            await send(.response(.success(timetables.contents)))
+                        }
                     }
                 }
                 .cancellable(id: CancelID.connection)


### PR DESCRIPTION
## Issue
- close #291

## Overview (Required)
- Fixed basic tab functionality for iOS

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img width="366" alt="スクリーンショット 2024-08-11 20 53 52" src="https://github.com/user-attachments/assets/5ae162a7-094b-4bab-bdb6-b3a1ab9d3af0" width="300"> | <img width="368" alt="スクリーンショット 2024-08-12 17 46 06" src="https://github.com/user-attachments/assets/716d909e-f906-4673-ad1d-7b10ef19c38a">


## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
