### PR TITLE
Verify changing tab on Timetable screen

### DIFF
--- a/app-android/src/test/java/io/github/droidkaigi/confsched/KaigiAppTest.kt
+++ b/app-android/src/test/java/io/github/droidkaigi/confsched/KaigiAppTest.kt
@@ -42,7 +42,7 @@ class KaigiAppTest(private val testCase: DescribedBehavior<KaigiAppRobot>) {
                     itShould("show timetable items") {
                         captureScreenWithChecks {
                             runRobot(timetableScreenRobot) {
-                                checkTimetableItemsDisplayed()
+                                checkTimetableListItemsDisplayed()
                             }
                         }
                     }

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/TimetableScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/TimetableScreenRobot.kt
@@ -16,6 +16,7 @@ import io.github.droidkaigi.confsched.model.TimetableItem
 import io.github.droidkaigi.confsched.sessions.TimetableScreen
 import io.github.droidkaigi.confsched.sessions.TimetableScreenTestTag
 import io.github.droidkaigi.confsched.sessions.TimetableUiTypeChangeButtonTestTag
+import io.github.droidkaigi.confsched.sessions.component.TimetableGridItemTestTag
 import io.github.droidkaigi.confsched.sessions.section.TimetableTabTestTag
 import io.github.droidkaigi.confsched.ui.component.TimetableItemCardBookmarkIconTestTag
 import io.github.droidkaigi.confsched.ui.component.TimetableItemCardTestTag
@@ -92,9 +93,16 @@ class TimetableScreenRobot @Inject constructor(
         assert(clickedItems.isNotEmpty())
     }
 
-    fun checkTimetableItemsDisplayed() {
+    fun checkTimetableListItemsDisplayed() {
         composeTestRule
             .onAllNodes(hasTestTag(TimetableItemCardTestTag))
+            .onFirst()
+            .assertIsDisplayed()
+    }
+
+    fun checkTimetableGridItemsDisplayed() {
+        composeTestRule
+            .onAllNodes(hasTestTag(TimetableGridItemTestTag))
             .onFirst()
             .assertIsDisplayed()
     }

--- a/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
+++ b/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
@@ -45,7 +45,7 @@ class TimetableScreenTest(private val testCase: DescribedBehavior<TimetableScree
                     }
                     itShould("show timetable items") {
                         captureScreenWithChecks(checks = {
-                            checkTimetableItemsDisplayed()
+                            checkTimetableListItemsDisplayed()
                         })
                     }
                     describe("click first session bookmark") {
@@ -65,6 +65,16 @@ class TimetableScreenTest(private val testCase: DescribedBehavior<TimetableScree
                             checkClickedItemsExists()
                         }
                     }
+                    describe("click conference day2 tab") {
+                        run {
+                            clickTimetableTab(2)
+                        }
+                        itShould("change displayed day") {
+                            captureScreenWithChecks(checks = {
+                                checkTimetableListItemsDisplayed()
+                            })
+                        }
+                    }
                     describe("click timetable ui type change") {
                         run {
                             clickTimetableUiTypeChangeButton()
@@ -73,6 +83,16 @@ class TimetableScreenTest(private val testCase: DescribedBehavior<TimetableScree
                             captureScreenWithChecks(
                                 checks = todoChecks("This screen is roughly created. Please add some checks."),
                             )
+                        }
+                        describe("click conference day2 tab") {
+                            run {
+                                clickTimetableTab(2)
+                            }
+                            itShould("change displayed day") {
+                                captureScreenWithChecks(checks = {
+                                    checkTimetableGridItemsDisplayed()
+                                })
+                            }
                         }
                     }
                 }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Density
@@ -100,6 +101,7 @@ fun TimetableGridItem(
         }
         Column(
             modifier = modifier
+                .testTag(TimetableGridItemTestTag)
                 .background(
                     color = LocalRoomTheme.current.containerColor,
                     shape = RoundedCornerShape(4.dp),

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridTab.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridTab.kt
@@ -15,12 +15,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import conference_app_2024.feature.sessions.generated.resources.conference
 import io.github.droidkaigi.confsched.model.DroidKaigi2024Day
 import io.github.droidkaigi.confsched.sessions.SessionsRes
+import io.github.droidkaigi.confsched.sessions.section.TimetableTabTestTag
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -51,7 +53,9 @@ fun TimetableDayTab(
             tabs = {
                 DroidKaigi2024Day.visibleDays().forEach { conferenceDay ->
                     Tab(
-                        modifier = Modifier.height(64.dp),
+                        modifier = Modifier
+                            .testTag(TimetableTabTestTag.plus(conferenceDay.dayIndex))
+                            .height(64.dp),
                         selected = false,
                         onClick = {
                             onDaySelected(conferenceDay)


### PR DESCRIPTION
## Issue
- close #290 

## Overview (Required)
- Add TimetableScreenTest to verify changing event day.
- For this, I added two tests switching event day (list / grid)

## Links
- #290 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
NotExist | <img src="https://github.com/user-attachments/assets/e3df4742-c5f2-472b-b251-4008769649a4" width="300" />
NotExist | <img src="https://github.com/user-attachments/assets/8db48993-46df-4885-b281-77401a7e6a94" width="300" />
