### PR TITLE
Fix a header background in case of the detail that the title is too short and the speakers are nothing in iOS

### DIFF
--- a/app-ios/Sources/TimetableDetailFeature/TimetableDetailView.swift
+++ b/app-ios/Sources/TimetableDetailFeature/TimetableDetailView.swift
@@ -131,6 +131,7 @@ public struct TimetableDetailView: View {
             .padding(.bottom, 20)
         }
         .padding([.top, .horizontal], 16)
+        .frame(maxWidth: .infinity)
         .background(store.timetableItem.room.roomTheme.containerColor)
     }
 

--- a/app-ios/Sources/TimetableDetailFeature/TimetableDetailView.swift
+++ b/app-ios/Sources/TimetableDetailFeature/TimetableDetailView.swift
@@ -105,6 +105,7 @@ public struct TimetableDetailView: View {
                 .textStyle(.headlineSmall)
                 .foregroundStyle(AssetColors.Surface.onSurfaceVariant.swiftUIColor)
                 .padding(.bottom, 20)
+                .frame(maxWidth: .infinity, alignment: .leading)
             
             ForEach(store.timetableItem.speakers, id: \.id) { speaker in
                 HStack(spacing: 12) {
@@ -131,7 +132,6 @@ public struct TimetableDetailView: View {
             .padding(.bottom, 20)
         }
         .padding([.top, .horizontal], 16)
-        .frame(maxWidth: .infinity)
         .background(store.timetableItem.room.roomTheme.containerColor)
     }
 


### PR DESCRIPTION

## Issue
- close #307 

## Overview (Required)
- Make `VStack` full-width in SwiftUI View.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
