### PR TITLE
feature:add an argument to the AboutContentColumn

### DIFF
--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutContentColumn.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutContentColumn.kt
@@ -34,7 +34,6 @@ fun AboutContentColumn(
     testTag: String,
     onClickAction: () -> Unit,
     modifier: Modifier = Modifier,
-    textColor: Color = MaterialTheme.colorScheme.primaryFixed,
 ) {
     Column(
         modifier = modifier
@@ -69,7 +68,7 @@ fun AboutContentColumn(
                     .padding(
                         end = 16.dp,
                     ),
-                color = textColor,
+                color = MaterialTheme.colorScheme.primaryFixed,
             )
         }
         HorizontalDivider(
@@ -89,7 +88,6 @@ fun AboutContentColumnPreview() {
                 label = stringResource(AboutRes.string.staff),
                 testTag = "",
                 onClickAction = {},
-                textColor = MaterialTheme.colorScheme.onPrimary,
             )
         }
     }

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutContentColumn.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutContentColumn.kt
@@ -89,6 +89,7 @@ fun AboutContentColumnPreview() {
                 label = stringResource(AboutRes.string.staff),
                 testTag = "",
                 onClickAction = {},
+                textColor = MaterialTheme.colorScheme.onPrimary,
             )
         }
     }

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutContentColumn.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutContentColumn.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import conference_app_2024.feature.about.generated.resources.staff
 import io.github.droidkaigi.confsched.about.AboutRes
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
+import io.github.droidkaigi.confsched.designsystem.theme.primaryFixed
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -33,6 +34,7 @@ fun AboutContentColumn(
     testTag: String,
     onClickAction: () -> Unit,
     modifier: Modifier = Modifier,
+    textColor: Color = MaterialTheme.colorScheme.primaryFixed,
 ) {
     Column(
         modifier = modifier
@@ -67,6 +69,7 @@ fun AboutContentColumn(
                     .padding(
                         end = 16.dp,
                     ),
+                color = textColor,
             )
         }
         HorizontalDivider(


### PR DESCRIPTION
## Issue
- close #227 

## Overview (Required)
- Change the text color of the Credits and Other items in the AboutContentScreen
  - The default is primaryFixed, but if you want to specify a different color, you can specify it in the AboutContentColumn argument.
## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/0a45e052-aa17-4885-9293-1694f81f7be6" width="300" /> | <img src="https://github.com/user-attachments/assets/0165adb6-f6f5-4502-94b5-33d8d959e931" width="300" />


