### PR TITLE
Fix crash when enabling minification

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -105,7 +105,7 @@ composeMaterialWindowSize = "dev.chrisbanes.material3:material3-window-size-clas
 composeMaterialIcon = { module = "androidx.compose.material:material-icons-extended" }
 composeUiTestManifest = { module = "androidx.compose.ui:ui-test-manifest" }
 composeUiTestJunit4 = { module = "androidx.compose.ui:ui-test-junit4" }
-composeNavigation = { module = "org.jetbrains.androidx.navigation:navigation-compose", version = "2.8.0-alpha02" }
+composeNavigation = { module = "org.jetbrains.androidx.navigation:navigation-compose", version = "2.8.0-alpha08" }
 coreBundle = { module = "org.jetbrains.androidx.core:core-bundle", version = "1.0.0" }
 composeHiltNavigtation = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "composeHiltNavigatiaon" }
 composeLintCheck = { module = "com.slack.lint.compose:compose-lint-checks", version = "1.3.1" }


### PR DESCRIPTION
## Issue
- close #257

## Overview (Required)
- Changed `org.jetbrains.androidx.navigation:navigation-compose` to version 2.8.0-alpha08 to avoid crashes on screen transitions in release (and debug) builds as a workaround.

## Links
- https://github.com/JetBrains/compose-multiplatform/issues/4711

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Unrelated to UI



## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/ed8ec293-5836-4199-8aa2-3ffd2a0540ad" width="300" > | <video src="https://github.com/user-attachments/assets/e93ddd2d-8f84-473e-9963-ccb9e332c259" width="300" >