### PR TITLE
Prevent refreshing BottomNavBar selected item

### DIFF
--- a/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeBottomNavigation.kt
+++ b/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeBottomNavigation.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -62,7 +63,7 @@ fun GlassLikeBottomNavigation(
     onTabSelected: (MainScreenTab) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var selectedTabIndex by remember { mutableIntStateOf(0) }
+    var selectedTabIndex by rememberSaveable { mutableIntStateOf(0) }
     Box(
         modifier = modifier
             .padding(vertical = 24.dp, horizontal = 48.dp)


### PR DESCRIPTION
## Issue
- close #316 

## Overview (Required)
- When come back from sub screen (e.g. Contributor screen on About tab), selected item of bottom nav bar will be refreshed.
- Enable to keep selected it.

## Links
- #316 

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/5579e5b0-804a-4760-96b8-31078843f8ec" width="300" > | <video src="https://github.com/user-attachments/assets/5d7ab955-65aa-421e-8d52-8b5380d4ab94" width="300" >


