### PR TITLE
Remove BackButton in eventmap screen

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched/KaigiApp.kt
@@ -144,7 +144,6 @@ private fun NavGraphBuilder.mainScreen(
                 contentPadding = contentPadding,
             )
             eventMapScreens(
-                onNavigationIconClick = navController::popBackStack,
                 onEventMapItemClick = externalNavController::navigate,
             )
             favoritesScreens(

--- a/feature/eventmap/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreenTest.kt
+++ b/feature/eventmap/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreenTest.kt
@@ -74,7 +74,6 @@ class EventMapScreenRobot @Inject constructor(
     fun setupScreenContent() {
         robotTestRule.setContent {
             EventMapScreen(
-                onNavigationIconClick = { },
                 onEventMapItemClick = { },
             )
         }

--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -33,7 +32,6 @@ import io.github.droidkaigi.confsched.eventmap.component.EventMapTab
 import io.github.droidkaigi.confsched.model.EventMapEvent
 import io.github.droidkaigi.confsched.ui.SnackbarMessageEffect
 import io.github.droidkaigi.confsched.ui.UserMessageStateHolder
-import io.github.droidkaigi.confsched.ui.handleOnClickIfNotNavigating
 import io.github.droidkaigi.confsched.ui.rememberUserMessageStateHolder
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
@@ -44,18 +42,10 @@ const val eventMapScreenRoute = "eventMap"
 const val EventMapScreenTestTag = "EventMapScreenTestTag"
 
 fun NavGraphBuilder.eventMapScreens(
-    onNavigationIconClick: () -> Unit,
     onEventMapItemClick: (url: String) -> Unit,
 ) {
     composable(eventMapScreenRoute) {
-        val lifecycleOwner = LocalLifecycleOwner.current
         EventMapScreen(
-            onNavigationIconClick = {
-                handleOnClickIfNotNavigating(
-                    lifecycleOwner,
-                    onNavigationIconClick,
-                )
-            },
             onEventMapItemClick = onEventMapItemClick,
         )
     }
@@ -78,7 +68,6 @@ data class EventMapUiState(
 
 @Composable
 fun EventMapScreen(
-    onNavigationIconClick: () -> Unit,
     onEventMapItemClick: (url: String) -> Unit,
     modifier: Modifier = Modifier,
     isTopAppBarHidden: Boolean = false,
@@ -98,7 +87,6 @@ fun EventMapScreen(
         uiState = uiState,
         isTopAppBarHidden = isTopAppBarHidden,
         snackbarHostState = snackbarHostState,
-        onBackClick = onNavigationIconClick,
         onEventMapItemClick = onEventMapItemClick,
         modifier = modifier,
     )
@@ -109,7 +97,6 @@ fun EventMapScreen(
 fun EventMapScreen(
     uiState: EventMapUiState,
     snackbarHostState: SnackbarHostState,
-    onBackClick: () -> Unit,
     onEventMapItemClick: (url: String) -> Unit,
     isTopAppBarHidden: Boolean,
     modifier: Modifier = Modifier,
@@ -185,7 +172,6 @@ fun PreviewEventMapScreen() {
         uiState = EventMapUiState(persistentListOf(), rememberUserMessageStateHolder()),
         snackbarHostState = SnackbarHostState(),
         isTopAppBarHidden = false,
-        onBackClick = {},
         onEventMapItemClick = {},
     )
 }

--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
@@ -7,11 +7,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material.icons.Icons.AutoMirrored.Filled
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -133,16 +129,6 @@ fun EventMapScreen(
                 LargeTopAppBar(
                     title = {
                         Text(text = stringResource(EventMapRes.string.eventmap))
-                    },
-                    navigationIcon = {
-                        IconButton(
-                            onClick = onBackClick,
-                        ) {
-                            Icon(
-                                imageVector = Filled.ArrowBack,
-                                contentDescription = "Back",
-                            )
-                        }
                     },
                     scrollBehavior = scrollBehavior,
                 )


### PR DESCRIPTION
## Issue
- close #303 

## Overview (Required)
- Remove the BackButton on the EventMap screen as it is not needed.

## Links
- https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI

## Screenshot (Optional if screenshot test is present or unrelated to UI)
#### FV
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/f0c00472-1203-4547-92c1-9ee88a2f078a" width="300" /> | <img src="https://github.com/user-attachments/assets/204c4811-4e65-4643-8441-55145c266bb5" width="300" />

#### Scroll
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/989334cb-4e11-4c5e-b6c5-f6fa41a22e75" width="300" /> | <img src="https://github.com/user-attachments/assets/114f3e80-f4c2-4b64-a5da-58aec0aa9d04" width="300" />

