### PR TITLE
issue-302 Remove intent filter of HiltTestActivity

### DIFF
--- a/core/testing-manifest/src/main/AndroidManifest.xml
+++ b/core/testing-manifest/src/main/AndroidManifest.xml
@@ -7,11 +7,6 @@
             android:name="io.github.droidkaigi.confsched.testing.HiltTestActivity"
             android:theme="@style/Theme.AppCompat.NoActionBar"
             android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
     </application>
 </manifest>


### PR DESCRIPTION
## Issue

- close #302

## Result

The launcher app shows one app icon.

<img src="https://github.com/user-attachments/assets/7c7a862d-628a-4b4b-b7af-aef227bf5380" width="300" />
