### PR TITLE
[feature/#334] Remove useless param of EventMapScreen in iOS

### DIFF
--- a/feature/eventmap/src/iosMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapViewController.kt
+++ b/feature/eventmap/src/iosMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapViewController.kt
@@ -14,7 +14,6 @@ fun eventMapViewController(
 ): UIViewController = composeViewController(repositories) {
     EventMapScreen(
         isTopAppBarHidden = true,
-        onNavigationIconClick = { /* no action for iOS side */ },
         onEventMapItemClick = onEventMapItemClick,
     )
 }


### PR DESCRIPTION
## Issue
- close #334

## Overview (Required)
- Bug occurred because of undefined param in eventMapViewController, so remove it.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
