### PR TITLE
Timetable text appearance alignments

### DIFF
--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/TimetableItemCard.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/TimetableItemCard.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
@@ -82,10 +81,11 @@ fun TimetableItemCard(
                         .padding(top = 8.dp),
                 )
                 if (timetableItem.speakers.isNotEmpty()) {
-                    Spacer(Modifier.height(6.dp))
+                    Spacer(Modifier.height(4.dp))
 
                     timetableItem.speakers.forEach { speaker ->
                         Row(
+                            modifier = Modifier.padding(top = 4.dp),
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                         ) {

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/TimetableItemCard.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/TimetableItemCard.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -26,7 +27,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -34,6 +34,7 @@ import conference_app_2024.core.ui.generated.resources.bookmarked
 import conference_app_2024.core.ui.generated.resources.image
 import conference_app_2024.core.ui.generated.resources.not_bookmarked
 import io.github.droidkaigi.confsched.designsystem.theme.ProvideRoomTheme
+import io.github.droidkaigi.confsched.designsystem.theme.primaryFixed
 import io.github.droidkaigi.confsched.model.TimetableItem
 import io.github.droidkaigi.confsched.model.TimetableItem.Session
 import io.github.droidkaigi.confsched.ui.UiRes
@@ -54,71 +55,85 @@ fun TimetableItemCard(
     onTimetableItemClick: (TimetableItem) -> Unit,
 ) {
     ProvideRoomTheme(timetableItem.room.getThemeKey()) {
-        Column(
+        Row(
             modifier = modifier
                 .testTag(TimetableItemCardTestTag)
                 .border(
-                    border = BorderStroke(width = 1.dp, color = MaterialTheme.colorScheme.outlineVariant),
-                    shape = RoundedCornerShape(5.dp),
+                    border = BorderStroke(
+                        width = 1.dp,
+                        color = MaterialTheme.colorScheme.outlineVariant,
+                    ),
+                    shape = RoundedCornerShape(4.dp),
                 )
-                .clickable { onTimetableItemClick(timetableItem) }
-                .padding(15.dp),
+                .clickable { onTimetableItemClick(timetableItem) },
         ) {
-            Box {
+            val contentPadding = 12.dp
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(top = contentPadding, start = contentPadding, bottom = contentPadding),
+            ) {
                 Row(content = tags)
-                TextButton(
-                    onClick = { onBookmarkClick(timetableItem, true) },
+                Text(
+                    text = timetableItem.title.currentLangTitle,
+                    style = MaterialTheme.typography.titleMedium,
                     modifier = Modifier
-                        .testTag(TimetableItemCardBookmarkButtonTestTag)
-                        .align(Alignment.TopEnd),
-                ) {
-                    if (isBookmarked) {
-                        Icon(
-                            Icons.Filled.Favorite,
-                            contentDescription = stringResource(UiRes.string.bookmarked),
-                            tint = Color.Green,
-                            modifier = Modifier
-                                .testTag(TimetableItemCardBookmarkedIconTestTag),
-                        )
-                    } else {
-                        Icon(
-                            Icons.Outlined.FavoriteBorder,
-                            contentDescription = stringResource(UiRes.string.not_bookmarked),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
+                        .testTag(TimetableItemCardTestTag)
+                        .padding(top = 8.dp),
+                )
+                if (timetableItem.speakers.isNotEmpty()) {
+                    Spacer(Modifier.height(6.dp))
+
+                    timetableItem.speakers.forEach { speaker ->
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            // TODO: Fixed image loading again but its still slow. Maybe we need smaller images?
+                            val painter = rememberAsyncImagePainter(speaker.iconUrl)
+                            Image(
+                                painter = painter,
+                                modifier = Modifier
+                                    .width(32.dp)
+                                    .height(32.dp)
+                                    .clip(CircleShape)
+                                    .border(
+                                        BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+                                        CircleShape,
+                                    ),
+                                contentDescription = stringResource(UiRes.string.image),
+                            )
+                            Text(
+                                text = speaker.name,
+                                style = MaterialTheme.typography.titleSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier
+                                    .testTag(TimetableItemCardTestTag)
+                                    .align(Alignment.CenterVertically),
+                            )
+                            // TODO: Message goes here (missing from object we can access here?)
+                        }
                     }
                 }
             }
-
-            Text(
-                text = timetableItem.title.currentLangTitle,
-                fontSize = 24.sp,
-                modifier = Modifier
-                    .testTag(TimetableItemCardTestTag)
-                    .padding(bottom = 5.dp),
-            )
-            timetableItem.speakers.forEach { speaker ->
-                Row {
-                    // TODO: Fixed image loading again but its still slow. Maybe we need smaller images?
-                    val painter = rememberAsyncImagePainter(speaker.iconUrl)
-                    Image(
-                        painter = painter,
+            TextButton(
+                onClick = { onBookmarkClick(timetableItem, true) },
+                modifier = Modifier.testTag(TimetableItemCardBookmarkButtonTestTag),
+            ) {
+                if (isBookmarked) {
+                    Icon(
+                        Icons.Filled.Favorite,
+                        contentDescription = stringResource(UiRes.string.bookmarked),
+                        tint = MaterialTheme.colorScheme.primaryFixed,
                         modifier = Modifier
-                            .width(32.dp)
-                            .height(32.dp)
-                            .clip(CircleShape),
-                        contentDescription = stringResource(UiRes.string.image),
+                            .testTag(TimetableItemCardBookmarkedIconTestTag),
                     )
-                    Text(
-                        text = speaker.name,
-                        fontSize = 24.sp,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier
-                            .testTag(TimetableItemCardTestTag)
-                            .padding(5.dp)
-                            .align(Alignment.CenterVertically),
+                } else {
+                    Icon(
+                        Icons.Outlined.FavoriteBorder,
+                        contentDescription = stringResource(UiRes.string.not_bookmarked),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
-                    // TODO: Message goes here (missing from object we can access here?)
                 }
             }
             if (timetableItem is Session) {

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/TimetableItemCard.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/TimetableItemCard.kt
@@ -115,6 +115,25 @@ fun TimetableItemCard(
                         }
                     }
                 }
+                if (timetableItem is Session) {
+                    timetableItem.message?.let {
+                        Row(
+                            modifier = Modifier.padding(top = 8.dp),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            Icon(
+                                Icons.Filled.Info,
+                                contentDescription = stringResource(UiRes.string.image),
+                                tint = MaterialTheme.colorScheme.error,
+                            )
+                            Text(
+                                text = it.currentLangTitle,
+                                fontSize = 16.sp,
+                                color = MaterialTheme.colorScheme.error,
+                            )
+                        }
+                    }
+                }
             }
             TextButton(
                 onClick = { onBookmarkClick(timetableItem, true) },
@@ -134,24 +153,6 @@ fun TimetableItemCard(
                         contentDescription = stringResource(UiRes.string.not_bookmarked),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
-                }
-            }
-            if (timetableItem is Session) {
-                timetableItem.message?.let {
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    ) {
-                        Icon(
-                            Icons.Filled.Info,
-                            contentDescription = stringResource(UiRes.string.image),
-                            tint = MaterialTheme.colorScheme.error,
-                        )
-                        Text(
-                            text = it.currentLangTitle,
-                            fontSize = 16.sp,
-                            color = MaterialTheme.colorScheme.error,
-                        )
-                    }
                 }
             }
         }

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/TimetableItemTag.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/TimetableItemTag.kt
@@ -2,17 +2,20 @@ package io.github.droidkaigi.confsched.ui.component
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -24,18 +27,31 @@ fun TimetableItemTag(
 ) {
     Row(
         modifier = modifier
-            .border(border = BorderStroke(width = 1.dp, color = tagColor))
-            .clip(RoundedCornerShape(15.dp))
-            .padding(5.dp),
+            .border(
+                border = BorderStroke(width = 1.dp, color = tagColor),
+                shape = RoundedCornerShape(2.dp),
+            )
+            .padding(
+                horizontal = 6.dp,
+                vertical = 4.dp,
+            ),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         icon?.let { ico ->
-            Icon(ico, "", tint = tagColor)
+            Icon(
+                modifier = Modifier.size(12.dp),
+                imageVector = ico,
+                contentDescription = "",
+                tint = tagColor,
+            )
         }
-        Spacer(modifier = Modifier.padding(3.dp))
         Text(
             color = tagColor,
             text = tagText,
-            modifier = Modifier.padding(end = 5.dp),
+            style = MaterialTheme.typography.labelMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
     }
 }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridHours.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridHours.kt
@@ -45,7 +45,8 @@ fun HoursItem(
         text = hour,
         modifier = modifier,
         textAlign = TextAlign.Center,
-        style = MaterialTheme.typography.titleMedium,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
     )
 }
 

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -56,7 +57,6 @@ import io.github.droidkaigi.confsched.model.TimetableSpeaker
 import io.github.droidkaigi.confsched.model.fake
 import io.github.droidkaigi.confsched.sessions.SessionsRes
 import io.github.droidkaigi.confsched.sessions.section.TimetableSizes
-import io.github.droidkaigi.confsched.ui.icon
 import io.github.droidkaigi.confsched.ui.previewOverride
 import io.github.droidkaigi.confsched.ui.rememberAsyncImagePainter
 import kotlinx.collections.immutable.PersistentList
@@ -123,35 +123,35 @@ fun TimetableGridItem(
                 modifier = Modifier.weight(3f),
                 verticalArrangement = Arrangement.Top,
             ) {
-                Row(
+                Text(
                     modifier = Modifier.weight(1f, fill = false),
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    text = timetableItem.title.currentLangTitle,
+                    style = titleTextStyle,
+                    overflow = TextOverflow.Ellipsis,
+                )
+
+                Row(
+                    modifier = Modifier
+                        .weight(1f, fill = false)
+                        .padding(top = TimetableGridItemSizes.titleToSchedulePadding),
                 ) {
                     Icon(
                         modifier = Modifier.height(TimetableGridItemSizes.scheduleHeight),
-                        imageVector = timetableItem.room.icon,
-                        tint = LocalRoomTheme.current.primaryColor,
+                        imageVector = Icons.Default.Schedule,
                         contentDescription = stringResource(SessionsRes.string.content_description_schedule_icon),
                     )
-                    var scheduleTextStyle = MaterialTheme.typography.labelSmall
+                    Spacer(modifier = Modifier.width(4.dp))
+                    var scheduleTextStyle = MaterialTheme.typography.bodySmall
                     if (titleTextStyle.fontSize < scheduleTextStyle.fontSize) {
                         scheduleTextStyle =
                             scheduleTextStyle.copy(fontSize = titleTextStyle.fontSize)
                     }
                     Text(
-                        text = "${timetableItem.startsTimeString}~${timetableItem.endsTimeString}",
+                        text = "${timetableItem.startsTimeString} - ${timetableItem.endsTimeString}",
                         style = scheduleTextStyle,
                         color = LocalRoomTheme.current.primaryColor,
                     )
                 }
-
-                Text(
-                    modifier = Modifier.weight(1f, fill = false)
-                        .padding(top = TimetableGridItemSizes.titleToSchedulePadding),
-                    text = timetableItem.title.currentLangTitle,
-                    style = titleTextStyle,
-                    overflow = TextOverflow.Ellipsis,
-                )
             }
 
             val shouldShowError = timetableItem is Session && timetableItem.message != null

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -57,6 +56,7 @@ import io.github.droidkaigi.confsched.model.TimetableSpeaker
 import io.github.droidkaigi.confsched.model.fake
 import io.github.droidkaigi.confsched.sessions.SessionsRes
 import io.github.droidkaigi.confsched.sessions.section.TimetableSizes
+import io.github.droidkaigi.confsched.ui.icon
 import io.github.droidkaigi.confsched.ui.previewOverride
 import io.github.droidkaigi.confsched.ui.rememberAsyncImagePainter
 import kotlinx.collections.immutable.PersistentList
@@ -99,12 +99,18 @@ fun TimetableGridItem(
             )
             it.copy(fontSize = titleFontSize, lineHeight = titleLineHeight, color = LocalRoomTheme.current.primaryColor)
         }
+        val cardShape = RoundedCornerShape(4.dp)
         Column(
             modifier = modifier
                 .testTag(TimetableGridItemTestTag)
                 .background(
                     color = LocalRoomTheme.current.containerColor,
-                    shape = RoundedCornerShape(4.dp),
+                    shape = cardShape,
+                )
+                .border(
+                    width = 1.dp,
+                    color = LocalRoomTheme.current.primaryColor,
+                    shape = cardShape,
                 )
                 .width(TimetableGridItemSizes.width)
                 .height(height)
@@ -117,35 +123,35 @@ fun TimetableGridItem(
                 modifier = Modifier.weight(3f),
                 verticalArrangement = Arrangement.Top,
             ) {
-                Text(
-                    modifier = Modifier.weight(1f, fill = false),
-                    text = timetableItem.title.currentLangTitle,
-                    style = titleTextStyle,
-                    overflow = TextOverflow.Ellipsis,
-                )
-
                 Row(
-                    modifier = Modifier
-                        .weight(1f, fill = false)
-                        .padding(top = TimetableGridItemSizes.titleToSchedulePadding),
+                    modifier = Modifier.weight(1f, fill = false),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
                 ) {
                     Icon(
                         modifier = Modifier.height(TimetableGridItemSizes.scheduleHeight),
-                        imageVector = Icons.Default.Schedule,
+                        imageVector = timetableItem.room.icon,
+                        tint = LocalRoomTheme.current.primaryColor,
                         contentDescription = stringResource(SessionsRes.string.content_description_schedule_icon),
                     )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    var scheduleTextStyle = MaterialTheme.typography.bodySmall
+                    var scheduleTextStyle = MaterialTheme.typography.labelSmall
                     if (titleTextStyle.fontSize < scheduleTextStyle.fontSize) {
                         scheduleTextStyle =
                             scheduleTextStyle.copy(fontSize = titleTextStyle.fontSize)
                     }
                     Text(
-                        text = "${timetableItem.startsTimeString} - ${timetableItem.endsTimeString}",
+                        text = "${timetableItem.startsTimeString}~${timetableItem.endsTimeString}",
                         style = scheduleTextStyle,
                         color = LocalRoomTheme.current.primaryColor,
                     )
                 }
+
+                Text(
+                    modifier = Modifier.weight(1f, fill = false)
+                        .padding(top = TimetableGridItemSizes.titleToSchedulePadding),
+                    text = timetableItem.title.currentLangTitle,
+                    style = titleTextStyle,
+                    overflow = TextOverflow.Ellipsis,
+                )
             }
 
             val shouldShowError = timetableItem is Session && timetableItem.message != null

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridRooms.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridRooms.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
+import io.github.droidkaigi.confsched.designsystem.theme.LocalRoomTheme
+import io.github.droidkaigi.confsched.designsystem.theme.ProvideRoomTheme
 import io.github.droidkaigi.confsched.model.TimetableRoom
 import io.github.droidkaigi.confsched.model.TimetableRooms
 import io.github.droidkaigi.confsched.sessions.section.ScreenScrollState
@@ -37,13 +39,17 @@ fun RoomItem(
     room: TimetableRoom,
     modifier: Modifier = Modifier,
 ) {
-    Box(
-        modifier = modifier,
-        contentAlignment = Alignment.Center,
-    ) {
-        Text(
-            text = room.name.currentLangTitle,
-        )
+    ProvideRoomTheme(room.getThemeKey()) {
+        Box(
+            modifier = modifier,
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = room.name.currentLangTitle,
+                style = MaterialTheme.typography.titleMedium,
+                color = LocalRoomTheme.current.primaryColor,
+            )
+        }
     }
 }
 

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableGrid.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableGrid.kt
@@ -292,7 +292,7 @@ fun TimetableGrid(
                     },
                 )
             },
-        itemProvider = itemProvider,
+        itemProvider = { itemProvider },
     ) { constraint ->
 
         data class ItemData(val placeable: Placeable, val timetableItem: TimetableItemLayout)

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableGrid.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableGrid.kt
@@ -152,6 +152,7 @@ fun TimetableGrid(
                 ),
             ) { timetableItem, itemHeightPx ->
                 TimetableGridItem(
+                    modifier = Modifier.padding(horizontal = 2.dp),
                     timetableItem = timetableItem,
                     onTimetableItemClick = onTimetableItemClick,
                     gridItemHeightPx = itemHeightPx,


### PR DESCRIPTION
## Issue
- close #333

## Overview (Required)
- Update several components of the `TimetableList` screen to use the correct text styles and appearance
- Update several components of the `TimetableGrid` screen to use the correct text styles and appearance

## Links
- Expected design is based on [Figma](https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=54795-26746&t=agwbDcGBmYwrCwd5-0)

## Screenshot (Optional if screenshot test is present or unrelated to UI)

![after](https://github.com/user-attachments/assets/059acd8f-7819-4473-8fbd-32472ffd0a67)
