### PR TITLE
Change the bottom margin of bottom navigation based on WindowInsets

### DIFF
--- a/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/MainScreen.kt
+++ b/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/MainScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CalendarMonth
 import androidx.compose.material.icons.outlined.Favorite
@@ -212,6 +213,7 @@ fun MainScreen(
                     onTabSelected = {
                         onTabSelected(mainNestedNavController, it)
                     },
+                    modifier = Modifier.safeDrawingPadding(),
                 )
             },
         ) { padding ->

--- a/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeBottomNavigation.kt
+++ b/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeBottomNavigation.kt
@@ -66,7 +66,7 @@ fun GlassLikeBottomNavigation(
     var selectedTabIndex by rememberSaveable { mutableIntStateOf(0) }
     Box(
         modifier = modifier
-            .padding(vertical = 24.dp, horizontal = 48.dp)
+            .padding(horizontal = 48.dp)
             .fillMaxWidth()
             .height(64.dp)
             .hazeChild(state = hazeState, shape = CircleShape)


### PR DESCRIPTION
## Issue

## Overview (Required)
- When using 3-button navigation, the bottom navigation and navigation bar interfered with each other. Margins now scale based on WindowInsets.

## Links

## Screenshot (Optional if screenshot test is present or unrelated to UI)

### 3-button navigation
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/121f6a3f-4167-43a4-b1c9-628e6b4dd3ab" width="300" /> | <img src="https://github.com/user-attachments/assets/1a30f40a-b339-49ff-a952-e9a860863f90" width="300" />

### gesture navigation
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/7d3145bf-a561-4214-8e27-39827d8c652a" width="300" /> | <img src="https://github.com/user-attachments/assets/5a61b9b9-62bb-4a60-b116-27c6bf33e219" width="300" />
