### PR TITLE
Use non-blurred scrim for GlassLikeBottomNavigation on devices without support for blur

### DIFF
--- a/core/model/src/androidMain/kotlin/io/github/droidkaigi/confsched/model/BlurSupport.kt
+++ b/core/model/src/androidMain/kotlin/io/github/droidkaigi/confsched/model/BlurSupport.kt
@@ -1,0 +1,6 @@
+package io.github.droidkaigi.confsched.model
+
+import android.os.Build
+
+public actual fun isBlurSupported(): Boolean =
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.S

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/BlurSupport.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/BlurSupport.kt
@@ -1,0 +1,3 @@
+package io.github.droidkaigi.confsched.model
+
+public expect fun isBlurSupported(): Boolean

--- a/core/model/src/iosMain/kotlin/io/github/droidkaigi/confsched/model/BlurSupport.kt
+++ b/core/model/src/iosMain/kotlin/io/github/droidkaigi/confsched/model/BlurSupport.kt
@@ -1,0 +1,3 @@
+package io.github.droidkaigi.confsched.model
+
+public actual fun isBlurSupported(): Boolean = true

--- a/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/MainScreen.kt
+++ b/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/MainScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Map
 import androidx.compose.material.icons.outlined.People
 import androidx.compose.material3.Button
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -51,6 +53,7 @@ import io.github.droidkaigi.confsched.compose.rememberEventEmitter
 import io.github.droidkaigi.confsched.main.NavigationType.BottomNavigation
 import io.github.droidkaigi.confsched.main.NavigationType.NavigationRail
 import io.github.droidkaigi.confsched.main.section.GlassLikeBottomNavigation
+import io.github.droidkaigi.confsched.model.isBlurSupported
 import io.github.droidkaigi.confsched.ui.SnackbarMessageEffect
 import io.github.droidkaigi.confsched.ui.UserMessageStateHolder
 import org.jetbrains.compose.resources.DrawableResource
@@ -219,7 +222,7 @@ fun MainScreen(
         ) { padding ->
             val hazeStyle =
                 HazeStyle(
-                    tint = Color.Black.copy(alpha = .2f),
+                    tint = MaterialTheme.colorScheme.hazeTint,
                     blurRadius = 30.dp,
                 )
             NavHost(
@@ -238,6 +241,13 @@ fun MainScreen(
         }
     }
 }
+
+private val ColorScheme.hazeTint: Color
+    @Composable get() = if (isBlurSupported()) {
+        scrim.copy(alpha = 0.4f)
+    } else {
+        scrim
+    }
 
 private fun materialFadeThroughIn(): EnterTransition =
     fadeIn(

--- a/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeBottomNavigation.kt
+++ b/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeBottomNavigation.kt
@@ -54,6 +54,7 @@ import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeChild
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.main.MainScreenTab
+import io.github.droidkaigi.confsched.model.isBlurSupported
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -116,7 +117,13 @@ fun GlassLikeBottomNavigation(
             Modifier
                 .fillMaxSize()
                 .clip(CircleShape)
-                .blur(50.dp, edgeTreatment = BlurredEdgeTreatment.Unbounded),
+                .run {
+                    if (isBlurSupported()) {
+                        blur(50.dp, edgeTreatment = BlurredEdgeTreatment.Unbounded)
+                    } else {
+                        this
+                    }
+                },
         ) {
             val tabWidth = size.width / MainScreenTab.size
             drawCircle(


### PR DESCRIPTION
## Issue
- close #345

## Overview (Required)
- Haze is a great library, but it doesn't work on Android 11 or below
- Introduce `isBlurSupported()` to determine if a device can or cannot utilize blur
- Change opacity of scrim to 40% for supported devices, matching Figma
- Decide which color to pass to `HazeStyle` depending on whether blur is supported

## Links
- https://chrisbanes.github.io/haze/


## Movie (Optional)
API 34 | API 27
:--: | :--:
<video src="https://github.com/user-attachments/assets/cb2d4bae-9813-43bb-89f4-28eb9d5459b6" width="300" > | <video src="https://github.com/user-attachments/assets/520f2aa5-a69f-4a03-82a9-15fdf9e4a650" width="300" >








