### PR TITLE
Replace Pair with a new data class TimeSlot

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
@@ -215,11 +215,11 @@ fun PreviewTimetableScreenDark() {
                     contentUiState = TimetableUiState.ListTimetable(
                         mapOf(
                             DroidKaigi2024Day.Workday to TimetableListUiState(
-                                mapOf<Pair<String, String>, List<TimetableItem>>().toPersistentMap(),
+                                mapOf<TimetableListUiState.TimeSlot, List<TimetableItem>>().toPersistentMap(),
                                 Timetable(),
                             ),
                             DroidKaigi2024Day.ConferenceDay1 to TimetableListUiState(
-                                mapOf<Pair<String, String>, List<TimetableItem>>().toPersistentMap(),
+                                mapOf<TimetableListUiState.TimeSlot, List<TimetableItem>>().toPersistentMap(),
                                 Timetable(),
                             ),
                         ),

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenPresenter.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenPresenter.kt
@@ -85,7 +85,10 @@ fun timetableSheet(
                         days = listOf(day),
                     ),
                 ).timetableItems.groupBy {
-                    it.startsTimeString to it.endsTimeString
+                    TimetableListUiState.TimeSlot(
+                        startTimeString = it.startsTimeString,
+                        endTimeString = it.endsTimeString,
+                    )
                 }.mapValues { entries ->
                     entries.value.sortedWith(
                         compareBy({ it.day?.name.orEmpty() }, { it.startsTimeString }),

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
@@ -31,9 +31,16 @@ import kotlinx.collections.immutable.PersistentMap
 const val TimetableListTestTag = "TimetableList"
 
 data class TimetableListUiState(
-    val timetableItemMap: PersistentMap<Pair<String, String>, List<TimetableItem>>,
+    val timetableItemMap: PersistentMap<TimeSlot, List<TimetableItem>>,
     val timetable: Timetable,
-)
+) {
+    data class TimeSlot(
+        val startTimeString: String,
+        val endTimeString: String,
+    ) {
+        val key: String get() = "$startTimeString-$endTimeString"
+    }
+}
 
 @Composable
 fun TimetableList(
@@ -59,12 +66,12 @@ fun TimetableList(
         items(
             // TODO: Check whether the number of recompositions increases.
             items = uiState.timetableItemMap.toList(),
-            key = { it.first },
+            key = { it.first.key },
         ) { (time, timetableItems) ->
             Row {
                 TimetableTime(
-                    startTime = time.first,
-                    endTime = time.second,
+                    startTime = time.startTimeString,
+                    endTime = time.endTimeString,
                 )
                 Spacer(modifier = Modifier.width(12.dp))
                 Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {


### PR DESCRIPTION
## Issue
- close #341 

## Overview (Required)
- Replace `Pair<String, String>` with the `TimeSlot` class to make it easier to understand.

## Additional Notes
- The property `TimeSlot.key` is required to avoid the runtime error related to LazyList.
```kotlin
FATAL EXCEPTION: main
Process: io.github.droidkaigi.confsched2024.dev, PID: 15075
java.lang.IllegalArgumentException: Type of the key TimeSlot(startTimeString=10:30, endTimeString=11:00) is not supported. On Android you can only use types which can be stored inside the Bundle.
	at androidx.compose.runtime.saveable.SaveableStateHolderImpl.SaveableStateProvider(SaveableStateHolder.kt:79)
	at androidx.compose.foundation.lazy.layout.LazySaveableStateHolder.SaveableStateProvider(LazySaveableStateHolder.kt:85)
	at androidx.compose.foundation.lazy.layout.LazyLayoutItemContentFactoryKt.SkippableItem-JVlU9Rs(LazyLayoutItemContentFactory.kt:134)
	at androidx.compose.foundation.lazy.layout.LazyLayoutItemContentFactoryKt.access$SkippableItem-JVlU9Rs(LazyLayoutItemContentFactory.kt:1)
	at ...
```

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
