### PR TITLE
save profilecard to datastore

### DIFF
--- a/core/data/src/androidMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/ProfileCardDataStoreModule.kt
+++ b/core/data/src/androidMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/ProfileCardDataStoreModule.kt
@@ -1,0 +1,23 @@
+package io.github.droidkaigi.confsched.data.profilecard
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import io.github.droidkaigi.confsched.data.user.ProfileCardDataStoreQualifier
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal class ProfileCardDataStoreModule {
+    @Singleton
+    @Provides
+    fun provideProfileCardDataStore(
+        @ProfileCardDataStoreQualifier
+        dataStore: DataStore<Preferences>,
+    ): ProfileCardDataStore {
+        return ProfileCardDataStore(dataStore)
+    }
+}

--- a/core/data/src/androidMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/ProfileCardRepositoryModule.kt
+++ b/core/data/src/androidMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/ProfileCardRepositoryModule.kt
@@ -1,0 +1,32 @@
+package io.github.droidkaigi.confsched.data.profilecard
+
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.ClassKey
+import dagger.multibindings.IntoMap
+import io.github.droidkaigi.confsched.data.di.RepositoryQualifier
+import io.github.droidkaigi.confsched.model.ProfileCardRepository
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class ProfileCardRepositoryModule {
+    @Binds
+    @RepositoryQualifier
+    @IntoMap
+    @ClassKey(ProfileCardRepository::class)
+    abstract fun bindProfileCardRepository(profileCardRepository: ProfileCardRepository): Any
+
+    companion object {
+        @Singleton
+        @Provides
+        fun provideProfileCardRepository(
+            profileCardDataStore: ProfileCardDataStore,
+        ): ProfileCardRepository {
+            return DefaultProfileCardRepository(profileCardDataStore)
+        }
+    }
+}

--- a/core/data/src/androidMain/kotlin/io/github/droidkaigi/confsched/data/user/DataStoreModule.kt
+++ b/core/data/src/androidMain/kotlin/io/github/droidkaigi/confsched/data/user/DataStoreModule.kt
@@ -21,6 +21,9 @@ public annotation class UserDataStoreQualifier
 @Qualifier
 public annotation class SessionCacheDataStoreQualifier
 
+@Qualifier
+public annotation class ProfileCardDataStoreQualifier
+
 @InstallIn(SingletonComponent::class)
 @Module
 public class DataStoreModule {
@@ -45,9 +48,21 @@ public class DataStoreModule {
         producePath = { context.cacheDir.resolve(DATA_STORE_CACHE_PREFERENCE_FILE_NAME).path },
     )
 
+    @ProfileCardDataStoreQualifier
+    @Provides
+    @Singleton
+    public fun provideProfileCardDataStore(
+        @ApplicationContext context: Context,
+    ): DataStore<Preferences> = createDataStore(
+        coroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+        producePath = { context.cacheDir.resolve(DATA_STORE_PROFILE_CARD_PREFERENCE_FILE_NAME).path },
+    )
+
     public companion object {
         private const val DATA_STORE_PREFERENCE_FILE_NAME = "confsched2024.preferences_pb"
         private const val DATA_STORE_CACHE_PREFERENCE_FILE_NAME =
             "confsched2024.cache.preferences_pb"
+        private const val DATA_STORE_PROFILE_CARD_PREFERENCE_FILE_NAME =
+            "confsched2024.profilecard.preferences_pb"
     }
 }

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/DefaultProfileCardRepository.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/DefaultProfileCardRepository.kt
@@ -1,0 +1,25 @@
+package io.github.droidkaigi.confsched.data.profilecard
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import io.github.droidkaigi.confsched.compose.safeCollectAsRetainedState
+import io.github.droidkaigi.confsched.model.ProfileCard
+import io.github.droidkaigi.confsched.model.ProfileCardRepository
+
+internal class DefaultProfileCardRepository(
+    private val profileCardDataStore: ProfileCardDataStore,
+) : ProfileCardRepository {
+    @Composable
+    override fun profileCard(): ProfileCard? {
+        val profileCard by remember {
+            profileCardDataStore.get()
+        }.safeCollectAsRetainedState(null)
+
+        return profileCard
+    }
+
+    override suspend fun save(profileCard: ProfileCard) {
+        profileCardDataStore.save(profileCard)
+    }
+}

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/ProfileCardDataStore.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/ProfileCardDataStore.kt
@@ -1,0 +1,34 @@
+package io.github.droidkaigi.confsched.data.profilecard
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import io.github.droidkaigi.confsched.model.ProfileCard
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+public class ProfileCardDataStore(
+    private val dataStore: DataStore<Preferences>,
+) {
+    public suspend fun save(profileCard: ProfileCard) {
+        dataStore.edit { preferences ->
+            preferences[KEY_PROFILE_CARD] = Json.encodeToString(profileCard.toJson())
+        }
+    }
+
+    public fun get(): Flow<ProfileCard?> {
+        return dataStore.data.map { preferences ->
+            val cache = preferences[KEY_PROFILE_CARD] ?: return@map null
+            Json.decodeFromString<ProfileCardJson>(cache)
+        }.map {
+            it?.toModel()
+        }
+    }
+
+    private companion object {
+        private val KEY_PROFILE_CARD = stringPreferencesKey("KEY_PROFILE_CARD")
+    }
+}

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/ProfileCardJson.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/ProfileCardJson.kt
@@ -1,0 +1,32 @@
+package io.github.droidkaigi.confsched.data.profilecard
+
+import io.github.droidkaigi.confsched.model.ProfileCard
+import io.github.droidkaigi.confsched.model.ProfileCardTheme
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class ProfileCardJson(
+    val nickname: String,
+    val occupation: String?,
+    val link: String?,
+    val image: String?,
+    val theme: String,
+)
+
+internal fun ProfileCardJson.toModel() = ProfileCard(
+    nickname = nickname,
+    occupation = occupation,
+    link = link,
+    image = image,
+    theme = theme.toProfileCardTheme(),
+)
+
+internal fun String.toProfileCardTheme() = ProfileCardTheme.valueOf(this)
+
+internal fun ProfileCard.toJson() = ProfileCardJson(
+    nickname = nickname,
+    occupation = occupation,
+    link = link,
+    image = image,
+    theme = theme.name,
+)

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/ProfileCard.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/ProfileCard.kt
@@ -4,6 +4,14 @@ data class ProfileCard(
     val nickname: String,
     val occupation: String?,
     val link: String?,
-    val imageUri: String?,
+    val image: String?,
     val theme: ProfileCardTheme,
 )
+
+enum class ProfileCardTheme {
+    Iguana,
+    Hedgehog,
+    Giraffe,
+    Flamingo,
+    Jellyfish,
+}

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/ProfileCardRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/ProfileCardRepository.kt
@@ -1,0 +1,15 @@
+package io.github.droidkaigi.confsched.model
+
+import androidx.compose.runtime.Composable
+import io.github.droidkaigi.confsched.model.compositionlocal.LocalRepositories
+
+interface ProfileCardRepository {
+    @Composable
+    fun profileCard(): ProfileCard?
+    suspend fun save(profileCard: ProfileCard)
+}
+
+@Composable
+fun localProfileCardRepository(): ProfileCardRepository {
+    return LocalRepositories.current[ProfileCardRepository::class] as ProfileCardRepository
+}

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/ProfileCardTheme.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/ProfileCardTheme.kt
@@ -1,5 +1,0 @@
-package io.github.droidkaigi.confsched.model
-
-enum class ProfileCardTheme {
-    Default,
-}

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/data/TestDataStoreModule.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/data/TestDataStoreModule.kt
@@ -10,6 +10,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
 import io.github.droidkaigi.confsched.data.createDataStore
 import io.github.droidkaigi.confsched.data.user.DataStoreModule
+import io.github.droidkaigi.confsched.data.user.ProfileCardDataStoreQualifier
 import io.github.droidkaigi.confsched.data.user.SessionCacheDataStoreQualifier
 import io.github.droidkaigi.confsched.data.user.UserDataStoreQualifier
 import kotlinx.coroutines.CoroutineScope
@@ -47,8 +48,21 @@ class TestDataStoreModule {
         },
     )
 
+    @ProfileCardDataStoreQualifier
+    @Provides
+    @Singleton
+    fun provideProfileCardDataStore(
+        @ApplicationContext context: Context,
+        testDispatcher: TestDispatcher,
+    ): DataStore<Preferences> = createDataStore(
+        coroutineScope = CoroutineScope(testDispatcher + Job()),
+        producePath = { context.cacheDir.resolve(TEST_DATASTORE_PROFILE_CARD_NAME).path },
+    )
+
     companion object {
         private const val TEST_DATASTORE_NAME = "test_datastore.preferences_pb"
         private const val TEST_DATASTORE_CACHE_NAME = "test_datastore_cache.preferences_pb"
+        private const val TEST_DATASTORE_PROFILE_CARD_NAME =
+            "test_datastore_profilecard.preferences_pb"
     }
 }

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/MiniRobots.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/MiniRobots.kt
@@ -13,6 +13,8 @@ import io.github.droidkaigi.confsched.data.sponsors.FakeSponsorsApiClient
 import io.github.droidkaigi.confsched.data.sponsors.SponsorsApiClient
 import io.github.droidkaigi.confsched.data.staff.FakeStaffApiClient
 import io.github.droidkaigi.confsched.data.staff.StaffApiClient
+import io.github.droidkaigi.confsched.model.ProfileCard
+import io.github.droidkaigi.confsched.model.ProfileCardRepository
 import io.github.droidkaigi.confsched.testing.coroutines.runTestWithLogging
 import io.github.droidkaigi.confsched.testing.robot.SponsorsServerRobot.ServerStatus
 import io.github.droidkaigi.confsched.testing.rules.RobotTestRule
@@ -242,5 +244,17 @@ class DefaultSponsorsServerRobot @Inject constructor(sponsorsApiClient: Sponsors
                 ServerStatus.Error -> FakeSponsorsApiClient.Status.Error
             },
         )
+    }
+}
+
+interface ProfileCardRepositoryRobot {
+    suspend fun saveProfileCard(profileCard: ProfileCard)
+}
+
+class DefaultProfileCardRepositoryRobot @Inject constructor(
+    private val profileCardRepository: ProfileCardRepository,
+) : ProfileCardRepositoryRobot {
+    override suspend fun saveProfileCard(profileCard: ProfileCard) {
+        profileCardRepository.save(profileCard)
     }
 }

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/ProfileCardScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/ProfileCardScreenRobot.kt
@@ -1,16 +1,25 @@
 package io.github.droidkaigi.confsched.testing.robot
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.profilecard.ProfileCardCardScreenTestTag
+import io.github.droidkaigi.confsched.profilecard.ProfileCardCreateButtonTestTag
+import io.github.droidkaigi.confsched.profilecard.ProfileCardEditButtonTestTag
 import io.github.droidkaigi.confsched.profilecard.ProfileCardEditScreenTestTag
+import io.github.droidkaigi.confsched.profilecard.ProfileCardNicknameTextFieldTestTag
+import io.github.droidkaigi.confsched.profilecard.ProfileCardOccupationTextFieldTestTag
 import io.github.droidkaigi.confsched.profilecard.ProfileCardScreen
 import javax.inject.Inject
 
 class ProfileCardScreenRobot @Inject constructor(
     screenRobot: DefaultScreenRobot,
-) : ScreenRobot by screenRobot {
+    profileCardRepositoryRobot: DefaultProfileCardRepositoryRobot,
+) : ScreenRobot by screenRobot,
+    ProfileCardRepositoryRobot by profileCardRepositoryRobot {
     fun setupScreenContent() {
         robotTestRule.setContent {
             KaigiTheme {
@@ -26,9 +35,47 @@ class ProfileCardScreenRobot @Inject constructor(
             .assertIsDisplayed()
     }
 
+    fun inputNickName(nickName: String) {
+        composeTestRule
+            .onNode(hasTestTag(ProfileCardNicknameTextFieldTestTag))
+            .performTextInput(nickName)
+    }
+
+    fun checkNickName(nickName: String) {
+        composeTestRule
+            .onNode(hasTestTag(ProfileCardNicknameTextFieldTestTag))
+            .assertTextEquals(nickName)
+    }
+
+    fun inputOccupation(occupation: String) {
+        composeTestRule
+            .onNode(hasTestTag(ProfileCardOccupationTextFieldTestTag))
+            .performTextInput(occupation)
+    }
+
+    fun checkOccupation(occupation: String) {
+        composeTestRule
+            .onNode(hasTestTag(ProfileCardOccupationTextFieldTestTag))
+            .assertTextEquals(occupation)
+    }
+
+    fun clickCreateButton() {
+        composeTestRule
+            .onNode(hasTestTag(ProfileCardCreateButtonTestTag))
+            .performClick()
+        wait5Seconds()
+    }
+
     fun checkCardScreenDisplayed() {
         composeTestRule
             .onNode(hasTestTag(ProfileCardCardScreenTestTag))
             .assertIsDisplayed()
+    }
+
+    fun clickEditButton() {
+        composeTestRule
+            .onNode(hasTestTag(ProfileCardEditButtonTestTag))
+            .performClick()
+        wait5Seconds()
     }
 }

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/ProfileCardScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/ProfileCardScreenRobot.kt
@@ -3,8 +3,9 @@ package io.github.droidkaigi.confsched.testing.robot
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
+import io.github.droidkaigi.confsched.profilecard.ProfileCardCardScreenTestTag
+import io.github.droidkaigi.confsched.profilecard.ProfileCardEditScreenTestTag
 import io.github.droidkaigi.confsched.profilecard.ProfileCardScreen
-import io.github.droidkaigi.confsched.profilecard.ProfileCardTestTag
 import javax.inject.Inject
 
 class ProfileCardScreenRobot @Inject constructor(
@@ -21,13 +22,13 @@ class ProfileCardScreenRobot @Inject constructor(
 
     fun checkEditScreenDisplayed() {
         composeTestRule
-            .onNode(hasTestTag(ProfileCardTestTag.EditScreen.SCREEN))
+            .onNode(hasTestTag(ProfileCardEditScreenTestTag))
             .assertIsDisplayed()
     }
 
     fun checkCardScreenDisplayed() {
         composeTestRule
-            .onNode(hasTestTag(ProfileCardTestTag.CardScreen.SCREEN))
+            .onNode(hasTestTag(ProfileCardCardScreenTestTag))
             .assertIsDisplayed()
     }
 }

--- a/feature/profilecard/build.gradle.kts
+++ b/feature/profilecard/build.gradle.kts
@@ -3,7 +3,8 @@ plugins {
 }
 
 android.namespace = "io.github.droidkaigi.confsched.feature.profilecard"
-roborazzi.generateComposePreviewRobolectricTests.packages = listOf("io.github.droidkaigi.confsched.profilecard")
+roborazzi.generateComposePreviewRobolectricTests.packages =
+    listOf("io.github.droidkaigi.confsched.profilecard")
 kotlin {
     sourceSets {
         commonMain {
@@ -18,6 +19,7 @@ kotlin {
         }
         androidTarget {
             dependencies {
+                implementation(projects.core.model)
                 implementation(libs.composeMaterialWindowSize)
             }
         }

--- a/feature/profilecard/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenTest.kt
+++ b/feature/profilecard/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenTest.kt
@@ -47,7 +47,70 @@ class ProfileCardScreenTest(
                             checkEditScreenDisplayed()
                         }
                     }
+                    val nickName = "test"
+                    val occupation = "test"
+                    describe("input nickname") {
+                        run {
+                            inputNickName(nickName)
+                        }
+                        itShould("show nickname") {
+                            captureScreenWithChecks {
+                                checkEditScreenDisplayed()
+                            }
+                        }
+                        describe("input occupation") {
+                            run {
+                                inputOccupation(occupation)
+                            }
+                            itShould("show occupation") {
+                                captureScreenWithChecks {
+                                    checkEditScreenDisplayed()
+                                }
+                            }
+                            describe("click create button") {
+                                run {
+                                    clickCreateButton()
+                                }
+                                itShould("show card screen") {
+                                    captureScreenWithChecks {
+                                        checkCardScreenDisplayed()
+                                    }
+                                }
+                                describe("click edit button") {
+                                    run {
+                                        clickEditButton()
+                                    }
+                                    itShould("show edit screen") {
+                                        captureScreenWithChecks {
+                                            checkEditScreenDisplayed()
+                                            checkNickName(nickName)
+                                            checkOccupation(occupation)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
+                // FIXME: java.util.concurrent.CancellationException: The test timed out at saveProfileCard
+                // describe("when profile card is found") {
+                //     run {
+                //         val profileCard = ProfileCard(
+                //             nickname = "test",
+                //             occupation = "test",
+                //             link = null,
+                //             image = null,
+                //             theme = ProfileCardTheme.Iguana
+                //         )
+                //         saveProfileCard(profileCard)
+                //         setupScreenContent()
+                //     }
+                //     itShould("show card screen") {
+                //         captureScreenWithChecks {
+                //             checkCardScreenDisplayed()
+                //         }
+                //     }
+                // }
             }
         }
     }

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -143,7 +143,7 @@ internal fun ProfileCardScreen(
                 if (uiState.cardUiState == null) return@Scaffold
                 CardScreen(
                     uiState = uiState.cardUiState,
-                    onClickReset = {
+                    onClickEdit = {
                         eventEmitter.tryEmit(CardScreenEvent.Edit)
                     },
                     contentPadding = padding,
@@ -225,7 +225,7 @@ internal fun EditScreen(
 @Composable
 internal fun CardScreen(
     uiState: ProfileCardUiState.Card,
-    onClickReset: () -> Unit,
+    onClickEdit: () -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
 ) {
@@ -243,10 +243,10 @@ internal fun CardScreen(
             Text(uiState.link)
         }
         Button(
-            onClickReset,
+            onClickEdit,
             modifier = Modifier.testTag(ProfileCardEditButtonTestTag),
         ) {
-            Text("Reset")
+            Text("Edit")
         }
     }
 }

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -86,7 +86,7 @@ internal sealed interface ProfileCardUiState {
                 occupation = null,
                 link = null,
                 imageUri = null,
-                theme = ProfileCardTheme.Default,
+                theme = ProfileCardTheme.Iguana,
             )
         }
     }

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -35,25 +35,14 @@ import io.github.droidkaigi.confsched.ui.UserMessageStateHolder
 
 const val profileCardScreenRoute = "profilecard"
 
-object ProfileCardTestTag {
-    private const val suffix = "TestTag"
-    private const val prefix = "ProfileCard"
-
-    object EditScreen {
-        private const val editScreenPrefix = "${prefix}_EditScreen"
-        const val SCREEN = "${editScreenPrefix}_$suffix"
-        const val NICKNAME_TEXT_FIELD = "${editScreenPrefix}_NicknameTextField_$suffix"
-        const val OCCUPATION_TEXT_FIELD = "${editScreenPrefix}_OccupationTextField_$suffix"
-        const val LINK_TEXT_FIELD = "${editScreenPrefix}_LinkTextField_$suffix"
-        const val SELECT_IMAGE_BUTTON = "${editScreenPrefix}_SelectImageButton_$suffix"
-        const val CREATE_BUTTON = "${editScreenPrefix}_CreateButton_$suffix"
-    }
-
-    object CardScreen {
-        private const val cardScreenPrefix = "${prefix}_CardScreen"
-        const val SCREEN = "${cardScreenPrefix}_$suffix"
-    }
-}
+const val ProfileCardEditScreenTestTag = "ProfileCardEditScreenTestTag"
+const val ProfileCardNicknameTextFieldTestTag = "ProfileCardNicknameTextFieldTestTag"
+const val ProfileCardOccupationTextFieldTestTag = "ProfileCardOccupationTextFieldTestTag"
+const val ProfileCardLinkTextFieldTestTag = "ProfileCardLinkTextFieldTestTag"
+const val ProfileCardSelectImageButtonTestTag = "ProfileCardSelectImageButtonTestTag"
+const val ProfileCardCreateButtonTestTag = "ProfileCardCreateButtonTestTag"
+const val ProfileCardCardScreenTestTag = "ProfileCardCardScreenTestTag"
+const val ProfileCardEditButtonTestTag = "ProfileCardEditButtonTestTag"
 
 fun NavGraphBuilder.profileCardScreen(contentPadding: PaddingValues) {
     composable(profileCardScreenRoute) {
@@ -186,7 +175,7 @@ internal fun EditScreen(
 
     Column(
         modifier = modifier
-            .testTag(ProfileCardTestTag.EditScreen.SCREEN)
+            .testTag(ProfileCardEditScreenTestTag)
             .padding(contentPadding),
     ) {
         Text("ProfileCardEdit")
@@ -194,23 +183,23 @@ internal fun EditScreen(
             value = nickname,
             onValueChange = { nickname = it },
             placeholder = { Text("Nickname") },
-            modifier = Modifier.testTag(ProfileCardTestTag.EditScreen.NICKNAME_TEXT_FIELD),
+            modifier = Modifier.testTag(ProfileCardNicknameTextFieldTestTag),
         )
         TextField(
             value = occupation ?: "",
             onValueChange = { occupation = it },
             placeholder = { Text("Occupation") },
-            modifier = Modifier.testTag(ProfileCardTestTag.EditScreen.OCCUPATION_TEXT_FIELD),
+            modifier = Modifier.testTag(ProfileCardOccupationTextFieldTestTag),
         )
         TextField(
             value = link ?: "",
             onValueChange = { link = it },
             placeholder = { Text("Link") },
-            modifier = Modifier.testTag(ProfileCardTestTag.EditScreen.LINK_TEXT_FIELD),
+            modifier = Modifier.testTag(ProfileCardLinkTextFieldTestTag),
         )
         Button(
             onClick = {},
-            modifier = Modifier.testTag(ProfileCardTestTag.EditScreen.SELECT_IMAGE_BUTTON),
+            modifier = Modifier.testTag(ProfileCardSelectImageButtonTestTag),
         ) {
             Text("画像を選択")
         }
@@ -226,7 +215,7 @@ internal fun EditScreen(
                     ),
                 )
             },
-            modifier = Modifier.testTag(ProfileCardTestTag.EditScreen.CREATE_BUTTON),
+            modifier = Modifier.testTag(ProfileCardCreateButtonTestTag),
         ) {
             Text("Create")
         }
@@ -242,7 +231,7 @@ internal fun CardScreen(
 ) {
     Column(
         modifier = modifier
-            .testTag(ProfileCardTestTag.CardScreen.SCREEN)
+            .testTag(ProfileCardCardScreenTestTag)
             .padding(contentPadding),
     ) {
         Text("ProfileCard")
@@ -253,7 +242,10 @@ internal fun CardScreen(
         if (uiState.link != null) {
             Text(uiState.link)
         }
-        Button(onClickReset) {
+        Button(
+            onClickReset,
+            modifier = Modifier.testTag(ProfileCardEditButtonTestTag),
+        ) {
             Text("Reset")
         }
     }

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
@@ -73,7 +73,7 @@ internal fun profileCardScreenPresenter(
             isLoading = true
             when (it) {
                 CardScreenEvent.Edit -> {
-                    userMessageStateHolder.showMessage("Reset")
+                    userMessageStateHolder.showMessage("Edit")
                     uiType = ProfileCardUiType.Edit
                 }
 

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
@@ -4,9 +4,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import io.github.droidkaigi.confsched.compose.SafeLaunchedEffect
 import io.github.droidkaigi.confsched.model.ProfileCard
+import io.github.droidkaigi.confsched.model.ProfileCardRepository
+import io.github.droidkaigi.confsched.model.localProfileCardRepository
 import io.github.droidkaigi.confsched.ui.providePresenterDefaults
 import kotlinx.coroutines.flow.Flow
 
@@ -14,44 +17,72 @@ internal sealed interface ProfileCardScreenEvent
 
 internal sealed interface EditScreenEvent : ProfileCardScreenEvent {
     data object SelectImage : EditScreenEvent
-    data class CreateProfileCard(val profileCard: ProfileCard) : EditScreenEvent
+    data class Create(val profileCard: ProfileCard) : EditScreenEvent
 }
 
 internal sealed interface CardScreenEvent : ProfileCardScreenEvent {
-    data object ShareProfileCard : CardScreenEvent
-    data object Reset : CardScreenEvent
+    data object Share : CardScreenEvent
+    data object Edit : CardScreenEvent
+}
+
+private fun ProfileCard?.toEditUiState(): ProfileCardUiState.Edit {
+    if (this == null) {
+        return ProfileCardUiState.Edit()
+    }
+    return ProfileCardUiState.Edit(
+        nickname = nickname,
+        occupation = occupation,
+        link = link,
+        image = image,
+        theme = theme,
+    )
+}
+
+private fun ProfileCard.toCardUiState(): ProfileCardUiState.Card {
+    return ProfileCardUiState.Card(
+        nickname = nickname,
+        occupation = occupation,
+        link = link,
+        image = image,
+        theme = theme,
+    )
 }
 
 @Composable
 internal fun profileCardScreenPresenter(
     events: Flow<ProfileCardScreenEvent>,
-): ProfileCardScreenUiState = providePresenterDefaults { userMessageStateHolder ->
-    // TODO: get from repository
-    val profileCard: ProfileCard? by remember { mutableStateOf(null) }
-    var isLoading by remember { mutableStateOf(false) }
-    var contentUiState by remember {
-        mutableStateOf(
-            profileCard?.toUiState() ?: ProfileCardUiState.Edit.initial(),
-        )
+    repository: ProfileCardRepository = localProfileCardRepository(),
+): ProfileCardScreenState = providePresenterDefaults { userMessageStateHolder ->
+    val profileCard: ProfileCard? by rememberUpdatedState(repository.profileCard())
+    var isLoading: Boolean by remember { mutableStateOf(false) }
+    val ediUiState: ProfileCardUiState.Edit by rememberUpdatedState(profileCard.toEditUiState())
+    val cardUiState: ProfileCardUiState.Card? by rememberUpdatedState(profileCard?.toCardUiState())
+    var uiType: ProfileCardUiType by remember {
+        val initialUiType = if (profileCard == null) {
+            ProfileCardUiType.Edit
+        } else {
+            ProfileCardUiType.Card
+        }
+        mutableStateOf(initialUiType)
     }
 
     SafeLaunchedEffect(Unit) {
         events.collect {
             isLoading = true
             when (it) {
-                CardScreenEvent.Reset -> {
+                CardScreenEvent.Edit -> {
                     userMessageStateHolder.showMessage("Reset")
-                    contentUiState = ProfileCardUiState.Edit.initial()
+                    uiType = ProfileCardUiType.Edit
                 }
 
-                CardScreenEvent.ShareProfileCard -> {
+                CardScreenEvent.Share -> {
                     userMessageStateHolder.showMessage("Share Profile Card")
                 }
 
-                is EditScreenEvent.CreateProfileCard -> {
+                is EditScreenEvent.Create -> {
                     userMessageStateHolder.showMessage("Create Profile Card")
-                    // TODO: save model by repository
-                    contentUiState = it.profileCard.toUiState()
+                    repository.save(it.profileCard)
+                    uiType = ProfileCardUiType.Card
                 }
 
                 EditScreenEvent.SelectImage -> {
@@ -62,9 +93,11 @@ internal fun profileCardScreenPresenter(
         }
     }
 
-    ProfileCardScreenUiState(
+    ProfileCardScreenState(
         isLoading = isLoading,
-        contentUiState = contentUiState,
+        editUiState = ediUiState,
+        cardUiState = cardUiState,
+        uiType = uiType,
         userMessageStateHolder = userMessageStateHolder,
     )
 }

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
@@ -57,13 +57,15 @@ internal fun profileCardScreenPresenter(
     var isLoading: Boolean by remember { mutableStateOf(false) }
     val ediUiState: ProfileCardUiState.Edit by rememberUpdatedState(profileCard.toEditUiState())
     val cardUiState: ProfileCardUiState.Card? by rememberUpdatedState(profileCard?.toCardUiState())
-    var uiType: ProfileCardUiType by remember {
-        val initialUiType = if (profileCard == null) {
+    var uiType: ProfileCardUiType by remember { mutableStateOf(ProfileCardUiType.Edit) }
+
+    // at first launch, if you have a profile card, show card ui
+    SafeLaunchedEffect(profileCard) {
+        uiType = if (profileCard == null) {
             ProfileCardUiType.Edit
         } else {
             ProfileCardUiType.Card
         }
-        mutableStateOf(initialUiType)
     }
 
     SafeLaunchedEffect(Unit) {


### PR DESCRIPTION
## Overview (Required)
- define logic to save profilecard
  - ProfileCardJson for saving ProfileCard to DataStore
    - https://github.com/DroidKaigi/conference-app-2024/commit/0152574dc77b2a90d4081eaceef7637f9562014e
  - ProfileCardDataStore
    - https://github.com/DroidKaigi/conference-app-2024/commit/74a2b60063d48ad5f760323b2994df718ee493b6
  - ProfileCardRepository
    - https://github.com/DroidKaigi/conference-app-2024/commit/415cd749e597e8add59381ddf3ee86fb3be8933f
- integrate UI layer
  - https://github.com/DroidKaigi/conference-app-2024/commit/0241600713da6e2ec548d0fc950e639ac0354d37

- add ProfileCardTheme
  - https://github.com/DroidKaigi/conference-app-2024/commit/df9860950dde8e126659e2dfbcec84c3777004a9

- add test
  - https://github.com/DroidKaigi/conference-app-2024/pull/361/commits/cd6efbbfebb25f9cdd1413f21d8a4a7e2f167a18

## Movie (Optional)

### create profile card

https://github.com/user-attachments/assets/aa304b49-b947-49d6-a524-fcda55a89abb

### back to edit screen

https://github.com/user-attachments/assets/2ecc8868-1304-4148-ac46-e5fd33ae37e1

### when profile card found

https://github.com/user-attachments/assets/822eadba-5b9c-4340-80ed-016929f35880

