### PR TITLE
Not to share scroll state between conference date tabs

### DIFF
--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/TimetableScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/TimetableScreenRobot.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched.testing.robot
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isDisplayed
@@ -91,7 +92,7 @@ class TimetableScreenRobot @Inject constructor(
             .performTouchInput {
                 swipeUp(
                     startY = visibleSize.height * 4F / 5,
-                    endY = visibleSize.height / 2F,
+                    endY = visibleSize.height / 5F,
                 )
             }
     }
@@ -113,6 +114,13 @@ class TimetableScreenRobot @Inject constructor(
             .assertIsDisplayed()
     }
 
+    fun checkTimetableListFirstItemNotDisplayed() {
+        composeTestRule
+            .onAllNodes(hasTestTag(TimetableItemCardTestTag))
+            .onFirst()
+            .assertIsNotDisplayed()
+    }
+
     fun checkTimetableGridDisplayed() {
         composeTestRule
             .onNode(hasTestTag(TimetableGridTestTag))
@@ -124,6 +132,13 @@ class TimetableScreenRobot @Inject constructor(
             .onAllNodes(hasTestTag(TimetableGridItemTestTag))
             .onFirst()
             .assertIsDisplayed()
+    }
+
+    fun checkTimetableGridFirstItemNotDisplayed() {
+        composeTestRule
+            .onAllNodes(hasTestTag(TimetableGridItemTestTag))
+            .onFirst()
+            .assertIsNotDisplayed()
     }
 
     fun checkFirstSessionBookmarkedIconDisplayed() {

--- a/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
+++ b/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
@@ -66,6 +66,14 @@ class TimetableScreenTest(private val testCase: DescribedBehavior<TimetableScree
                             checkClickedItemsExists()
                         }
                     }
+                    describe("scroll timetable") {
+                        run {
+                            scrollTimetable()
+                        }
+                        itShould("first session is not displayed") {
+                            checkTimetableListFirstItemNotDisplayed()
+                        }
+                    }
                     describe("click conference day2 tab") {
                         run {
                             clickTimetableTab(2)
@@ -85,6 +93,14 @@ class TimetableScreenTest(private val testCase: DescribedBehavior<TimetableScree
                                 checkTimetableGridDisplayed()
                                 checkTimetableGridItemsDisplayed()
                             })
+                        }
+                        describe("scroll timetable") {
+                            run {
+                                scrollTimetable()
+                            }
+                            itShould("first session is not displayed") {
+                                checkTimetableGridFirstItemNotDisplayed()
+                            }
                         }
                         describe("click conference day2 tab") {
                             run {

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridHours.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridHours.kt
@@ -71,7 +71,7 @@ fun TimetableGridHours(
             verticalScale = verticalScale,
         )
     }
-    val hoursScreen = remember(hoursLayout, density) {
+    val hoursScreen = remember(hoursLayout, scrollState, density) {
         HoursScreen(
             hoursLayout,
             scrollState,

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridRooms.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridRooms.kt
@@ -69,7 +69,7 @@ fun TimetableGridRooms(
         )
     }
 
-    val roomsScreen = remember(roomsLayout, density) {
+    val roomsScreen = remember(roomsLayout, scrollState, density) {
         RoomScreen(
             roomsLayout = roomsLayout,
             scrollState = scrollState,

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableGrid.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableGrid.kt
@@ -93,6 +93,7 @@ data class TimetableGridUiState(val timetable: Timetable)
 @Composable
 fun TimetableGrid(
     uiState: TimetableGridUiState,
+    timetableState: TimetableState,
     onTimetableItemClick: (TimetableItem) -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
@@ -100,6 +101,7 @@ fun TimetableGrid(
     Column {
         TimetableGrid(
             timetable = uiState.timetable,
+            timetableState = timetableState,
             onTimetableItemClick = onTimetableItemClick,
             modifier = modifier,
             contentPadding = contentPadding,
@@ -110,11 +112,11 @@ fun TimetableGrid(
 @Composable
 fun TimetableGrid(
     timetable: Timetable,
+    timetableState: TimetableState,
     onTimetableItemClick: (TimetableItem) -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
 ) {
-    val timetableGridState = rememberTimetableGridState()
     val coroutineScope = rememberCoroutineScope()
     val layoutDirection = LocalLayoutDirection.current
     Row(
@@ -127,7 +129,7 @@ fun TimetableGrid(
             ),
     ) {
         TimetableGridHours(
-            timetableState = timetableGridState,
+            timetableState = timetableState,
             coroutineScope = coroutineScope,
         ) { hour ->
             HoursItem(hour = hour)
@@ -135,14 +137,14 @@ fun TimetableGrid(
         Column {
             TimetableGridRooms(
                 timetableRooms = TimetableRooms(timetable.rooms),
-                timetableState = timetableGridState,
+                timetableState = timetableState,
                 coroutineScope = coroutineScope,
             ) { room ->
                 RoomItem(room = room)
             }
             TimetableGrid(
                 timetable = timetable,
-                timetableState = timetableGridState,
+                timetableState = timetableState,
                 modifier = modifier,
                 contentPadding = PaddingValues(
                     top = 16.dp + contentPadding.calculateTopPadding(),
@@ -177,7 +179,7 @@ fun TimetableGrid(
         TimetableLayout(timetable = timetable, density = density, verticalScale = verticalScale)
     }
     val scrollState = timetableState.screenScrollState
-    val timetableScreen = remember(timetableLayout, density) {
+    val timetableScreen = remember(timetableLayout, scrollState, density) {
         TimetableScreen(
             timetableLayout,
             scrollState,
@@ -241,7 +243,7 @@ fun TimetableGrid(
                 timetableState.screenScrollState.componentPositionInRoot =
                     coordinates.positionInRoot()
             }
-            .pointerInput(Unit) {
+            .pointerInput(timetableState) {
                 detectDragGestures(
                     onDragStart = {
                         scrollState.resetTracking()
@@ -340,6 +342,7 @@ fun TimetableGrid(
 fun TimetablePreview() {
     TimetableGrid(
         timetable = Timetable.fake(),
+        timetableState = rememberTimetableGridState(),
         onTimetableItemClick = {},
         modifier = Modifier.fillMaxSize(),
     )

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableSheet.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableSheet.kt
@@ -66,9 +66,14 @@ fun Timetable(
             )
             when (uiState) {
                 is ListTimetable -> {
+                    val scrollStates = DroidKaigi2024Day.entries.filter {
+                        it.visibleForUsers
+                    }.associateWith {
+                        rememberLazyListState()
+                    }
                     TimetableList(
                         uiState = requireNotNull(uiState.timetableListUiStates[selectedDay]),
-                        scrollState = rememberLazyListState(),
+                        scrollState = scrollStates.getValue(selectedDay),
                         onTimetableItemClick = onTimetableItemClick,
                         onBookmarkClick = onFavoriteClick,
                         modifier = Modifier
@@ -83,8 +88,14 @@ fun Timetable(
                 }
 
                 is GridTimetable -> {
+                    val timetableStates = DroidKaigi2024Day.entries.filter {
+                        it.visibleForUsers
+                    }.associateWith {
+                        rememberTimetableGridState()
+                    }
                     TimetableGrid(
                         uiState = requireNotNull(uiState.timetableGridUiState[selectedDay]),
+                        timetableState = timetableStates.getValue(selectedDay),
                         onTimetableItemClick = onTimetableItemClick,
                         modifier = Modifier
                             .fillMaxSize()

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableSheet.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableSheet.kt
@@ -7,12 +7,14 @@ import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -66,11 +68,7 @@ fun Timetable(
             )
             when (uiState) {
                 is ListTimetable -> {
-                    val scrollStates = DroidKaigi2024Day.entries.filter {
-                        it.visibleForUsers
-                    }.associateWith {
-                        rememberLazyListState()
-                    }
+                    val scrollStates = rememberListTimetableScrollStates()
                     TimetableList(
                         uiState = requireNotNull(uiState.timetableListUiStates[selectedDay]),
                         scrollState = scrollStates.getValue(selectedDay),
@@ -88,11 +86,7 @@ fun Timetable(
                 }
 
                 is GridTimetable -> {
-                    val timetableStates = DroidKaigi2024Day.entries.filter {
-                        it.visibleForUsers
-                    }.associateWith {
-                        rememberTimetableGridState()
-                    }
+                    val timetableStates = rememberGridTimetableStates()
                     TimetableGrid(
                         uiState = requireNotNull(uiState.timetableGridUiState[selectedDay]),
                         timetableState = timetableStates.getValue(selectedDay),
@@ -121,4 +115,24 @@ fun Timetable(
             }
         }
     }
+}
+
+@Composable
+private fun rememberListTimetableScrollStates(): Map<DroidKaigi2024Day, LazyListState> {
+    val scrollStateMap = DroidKaigi2024Day.entries.filter {
+        it.visibleForUsers
+    }.associateWith {
+        rememberLazyListState()
+    }
+    return remember { scrollStateMap }
+}
+
+@Composable
+private fun rememberGridTimetableStates(): Map<DroidKaigi2024Day, TimetableState> {
+    val timetableStateMap = DroidKaigi2024Day.entries.filter {
+        it.visibleForUsers
+    }.associateWith {
+        rememberTimetableGridState()
+    }
+    return remember { timetableStateMap }
 }


### PR DESCRIPTION
## Issue
- close #340 

## Overview (Required)
- At present, each Timetable is sharing scroll state between conference date.
  - it means if you switch conference date, switched timetable displayed as scrolled.
- By separating passed scrollstate or timetablestate, trying to adjust it.

## Links
- #340 

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/de688e83-8aa6-45f5-b3ed-fa2eca1ef4c5" width="300" > | <video src="https://github.com/user-attachments/assets/d1685c4f-6939-44e5-b832-ea0ef6b4d620" width="300" >
<video src="https://github.com/user-attachments/assets/1ea66460-89f2-4b69-8308-efcc1ced93f4" width="300" > | <video src="https://github.com/user-attachments/assets/76d16c66-bbfc-43d6-a159-93993e4634fc" width="300" >


