### PR TITLE
[feature/#352] Apply type safe compose navigation in event map screen

### DIFF
--- a/feature/eventmap/build.gradle.kts
+++ b/feature/eventmap/build.gradle.kts
@@ -12,7 +12,7 @@ kotlin {
                 implementation(projects.core.model)
                 implementation(projects.core.ui)
                 implementation(projects.core.designsystem)
-                
+
                 implementation(libs.kotlinxCoroutinesCore)
                 implementation(libs.kotlinSerializationJson)
                 implementation(libs.moleculeRuntime)

--- a/feature/eventmap/build.gradle.kts
+++ b/feature/eventmap/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("droidkaigi.convention.kmpfeature")
+    id("droidkaigi.primitive.kmp.serialization")
 }
 
 android.namespace = "io.github.droidkaigi.confsched.feature.eventmap"
@@ -10,8 +11,10 @@ kotlin {
             dependencies {
                 implementation(projects.core.model)
                 implementation(projects.core.ui)
-                implementation(libs.kotlinxCoroutinesCore)
                 implementation(projects.core.designsystem)
+                
+                implementation(libs.kotlinxCoroutinesCore)
+                implementation(libs.kotlinSerializationJson)
                 implementation(libs.moleculeRuntime)
                 implementation(compose.components.resources)
                 implementation(compose.components.uiToolingPreview)

--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
@@ -31,6 +31,7 @@ import conference_app_2024.feature.eventmap.generated.resources.eventmap
 import io.github.droidkaigi.confsched.compose.rememberEventEmitter
 import io.github.droidkaigi.confsched.eventmap.component.EventMapItem
 import io.github.droidkaigi.confsched.eventmap.component.EventMapTab
+import io.github.droidkaigi.confsched.eventmap.navigation.EventMapDestination
 import io.github.droidkaigi.confsched.model.EventMapEvent
 import io.github.droidkaigi.confsched.ui.SnackbarMessageEffect
 import io.github.droidkaigi.confsched.ui.UserMessageStateHolder
@@ -48,7 +49,7 @@ const val EventMapItemTestTag = "EventMapItemTestTag:"
 fun NavGraphBuilder.eventMapScreens(
     onEventMapItemClick: (url: String) -> Unit,
 ) {
-    composable(eventMapScreenRoute) {
+    composable<EventMapDestination> {
         EventMapScreen(
             onEventMapItemClick = onEventMapItemClick,
         )
@@ -56,7 +57,7 @@ fun NavGraphBuilder.eventMapScreens(
 }
 
 fun NavController.navigateEventMapScreen() {
-    navigate(eventMapScreenRoute) {
+    navigate(EventMapDestination) {
         popUpTo(route = checkNotNull(graph.findStartDestination().route)) {
             saveState = true
         }

--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/navigation/EventMapDestination.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/navigation/EventMapDestination.kt
@@ -1,0 +1,6 @@
+package io.github.droidkaigi.confsched.eventmap.navigation
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object EventMapDestination


### PR DESCRIPTION
## Issue
- close #352 

## Overview (Required)
- Apply type safe compose navigation in event map screen

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/c3949ec0-1866-4d90-87c6-2efc13136843" width="300" > | <video src="https://github.com/user-attachments/assets/4cdbfbb8-f190-49e7-bd9f-626f17e0b43f" width="300" >
