### PR TITLE
Reverse title and time in timetable grid

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
@@ -118,7 +118,7 @@ fun TimetableGridItem(
             it.copy(
                 fontSize = titleFontSize,
                 lineHeight = titleLineHeight,
-                color = LocalRoomTheme.current.primaryColor
+                color = LocalRoomTheme.current.primaryColor,
             )
         }
         val cardShape = RoundedCornerShape(4.dp)
@@ -153,7 +153,7 @@ fun TimetableGridItem(
                 verticalArrangement = Arrangement.spacedBy(
                     space = TimetableGridItemSizes.scheduleToTitleSpace,
                     alignment = if (isShowingAllContent) Alignment.Top else Alignment.CenterVertically,
-                )
+                ),
             ) {
                 if (isShowingAllContent) {
                     Row(

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
@@ -121,15 +121,11 @@ fun TimetableGridItem(
         ) {
             Column(
                 modifier = Modifier.weight(3f),
-                verticalArrangement = Arrangement.Top,
+                verticalArrangement = Arrangement.spacedBy(
+                    space = 6.dp,
+                    alignment = Alignment.Top,
+                ),
             ) {
-                Text(
-                    modifier = Modifier.weight(1f, fill = false),
-                    text = timetableItem.title.currentLangTitle,
-                    style = titleTextStyle,
-                    overflow = TextOverflow.Ellipsis,
-                )
-
                 Row(
                     modifier = Modifier
                         .weight(1f, fill = false)
@@ -152,6 +148,13 @@ fun TimetableGridItem(
                         color = LocalRoomTheme.current.primaryColor,
                     )
                 }
+
+                Text(
+                    modifier = Modifier.weight(1f, fill = false),
+                    text = timetableItem.title.currentLangTitle,
+                    style = titleTextStyle,
+                    overflow = TextOverflow.Ellipsis,
+                )
             }
 
             val shouldShowError = timetableItem is Session && timetableItem.message != null

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
@@ -122,14 +122,13 @@ fun TimetableGridItem(
             Column(
                 modifier = Modifier.weight(3f),
                 verticalArrangement = Arrangement.spacedBy(
-                    space = 6.dp,
+                    space = TimetableGridItemSizes.scheduleToTitleSpace,
                     alignment = Alignment.Top,
                 ),
             ) {
                 Row(
                     modifier = Modifier
-                        .weight(1f, fill = false)
-                        .padding(top = TimetableGridItemSizes.titleToSchedulePadding),
+                        .weight(1f, fill = false),
                 ) {
                     Icon(
                         modifier = Modifier.height(TimetableGridItemSizes.scheduleHeight),
@@ -281,8 +280,8 @@ private fun calculateFontSizeAndLineHeight(
     titleLength: Int,
 ): Pair<TextUnit, TextUnit> {
     // The height of the title that should be displayed.
-    val titleToScheduleSpaceHeightPx = with(localDensity) {
-        TimetableGridItemSizes.titleToSchedulePadding.toPx()
+    val scheduleToTitleSpaceHeightPx = with(localDensity) {
+        TimetableGridItemSizes.scheduleToTitleSpace.toPx()
     }
     val scheduleHeightPx = with(localDensity) {
         TimetableGridItemSizes.scheduleHeight.toPx()
@@ -291,7 +290,7 @@ private fun calculateFontSizeAndLineHeight(
         (TimetableGridItemSizes.padding * 2).toPx()
     }
     var displayTitleHeight =
-        gridItemHeightPx - titleToScheduleSpaceHeightPx - scheduleHeightPx - horizontalPaddingPx
+        gridItemHeightPx - scheduleToTitleSpaceHeightPx - scheduleHeightPx - horizontalPaddingPx
     displayTitleHeight -= if (speaker != null) {
         with(localDensity) { TimetableGridItemSizes.speakerHeight.toPx() }
     } else {
@@ -388,7 +387,7 @@ private fun calculateTitleHeight(
 object TimetableGridItemSizes {
     val width = 192.dp
     val padding = 12.dp
-    val titleToSchedulePadding = 4.dp
+    val scheduleToTitleSpace = 6.dp
     val scheduleHeight = 16.dp
     val errorHeight = 16.dp
     val speakerHeight = 32.dp

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
@@ -150,7 +150,10 @@ fun TimetableGridItem(
         ) {
             Column(
                 modifier = Modifier.weight(3f),
-                verticalArrangement = if (isShowingAllContent) Arrangement.Top else Arrangement.Center,
+                verticalArrangement = Arrangement.spacedBy(
+                    space = TimetableGridItemSizes.scheduleToTitleSpace,
+                    alignment = if (isShowingAllContent) Alignment.Top else Alignment.CenterVertically,
+                )
             ) {
                 if (isShowingAllContent) {
                     Row(


### PR DESCRIPTION
## Issue
- close #225

## Overview (Required)
- Reverse title and time in timetable grid
  - also fixed the spacing with the title
- Side note
  - When I look at Figma, there is no space to only the left of the tilde, is this the correct design?
  - <img width="303" alt="image" src="https://github.com/user-attachments/assets/7928dce9-494b-44a8-b725-8a54454805ab">

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src=https://github.com/user-attachments/assets/001066a4-5ff6-4b69-911c-25dfb131f2ba  width=300>|<img src=https://github.com/user-attachments/assets/612c4274-b6d7-4df4-95a7-be3f5b318826  width=300>

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
