### PR TITLE
Use applyDefaultHierarchyTemplate

### DIFF
--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpIosPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpIosPlugin.kt
@@ -5,7 +5,6 @@ import io.github.droidkaigi.confsched.primitive.Arch.ARM
 import io.github.droidkaigi.confsched.primitive.Arch.X86
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.creating
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpIosPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpIosPlugin.kt
@@ -5,6 +5,7 @@ import io.github.droidkaigi.confsched.primitive.Arch.ARM
 import io.github.droidkaigi.confsched.primitive.Arch.X86
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.creating
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
@@ -42,21 +43,7 @@ class KmpIosPlugin : Plugin<Project> {
                         }
                     }
                 }
-                with(sourceSets) {
-                    create("iosMain") {
-                        dependsOn(getByName("commonMain"))
-                        maybeCreate("iosArm64Main").dependsOn(this)
-                        maybeCreate("iosX64Main").dependsOn(this)
-                        maybeCreate("iosSimulatorArm64Main").dependsOn(this)
-                    }
-
-                    create("iosTest") {
-                        dependsOn(getByName("commonTest"))
-                        maybeCreate("iosArm64Test").dependsOn(this)
-                        maybeCreate("iosX64Test").dependsOn(this)
-                        maybeCreate("iosSimulatorArm64Test").dependsOn(this)
-                    }
-                }
+                applyDefaultHierarchyTemplate()
 
                 targets.withType<KotlinNativeTarget> {
                     // export kdoc to header file


### PR DESCRIPTION
## Issue
- close #12 

## Overview (Required)
- Use applyDefaultHierarchyTemplate.
- Remove unnecessary definition.
- Following the above, the warning disappears when Gradle sync.

## Links
- https://kotlinlang.org/docs/multiplatform-hierarchy.html

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Nothing.

## Movie (Optional)
Nothing.
