### PR TITLE
Fix Staff API url and return actual value

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/staff/StaffApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/staff/StaffApiClient.kt
@@ -14,7 +14,7 @@ import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 
 internal interface StaffApi {
-    @GET("/events/droidkaigi2023/staff")
+    @GET("/events/droidkaigi2024/staff")
     suspend fun getStaff(): StaffsResponse
 }
 
@@ -26,11 +26,9 @@ public class DefaultStaffApiClient(
     private val staffApi = ktorfit.create<StaffApi>()
 
     public override suspend fun getStaff(): PersistentList<Staff> {
-        // FIXME: When the API is ready, remove the comments below and return the actual data.
-        return Staff.fakes()
-//        return networkService {
-//            staffApi.getStaff()
-//        }.toStaffList()
+        return networkService {
+            staffApi.getStaff()
+        }.toStaffList()
     }
 }
 

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/staff/StaffApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/staff/StaffApiClient.kt
@@ -9,7 +9,6 @@ import io.github.droidkaigi.confsched.data.NetworkService
 import io.github.droidkaigi.confsched.data.staff.response.StaffResponse
 import io.github.droidkaigi.confsched.data.staff.response.StaffsResponse
 import io.github.droidkaigi.confsched.model.Staff
-import io.github.droidkaigi.confsched.model.fakes
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/staff/StaffApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/staff/StaffApiClient.kt
@@ -14,6 +14,11 @@ import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 
 internal interface StaffApi {
+    /**
+     * Gets staff information for the DroidKaigi 2024 event.
+     *
+     * @return [StaffsResponse]
+     */
     @GET("/events/droidkaigi2024/staff")
     suspend fun getStaff(): StaffsResponse
 }


### PR DESCRIPTION
## Issue
- close #386

## Overview (Required)
- I fixed the StaffApi url in [StaffApiClient.kt](https://github.com/DroidKaigi/conference-app-2024/blob/a3d0c2a8e928b1c5c35c454086321535ded66a52/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/staff/StaffApiClient.kt#L17)
- I added comment in the API

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/b98e86fd-68aa-432d-a591-96d9b6215d66" width="300" /> | <img src="https://github.com/user-attachments/assets/4f9f903f-63a0-4a34-bac5-e9df8217d7ee" width="300" />

