### PR TITLE
Update GlassLikeBottomNavigation design to align with Figma design

### DIFF
--- a/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeBottomNavigation.kt
+++ b/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeBottomNavigation.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -33,6 +34,7 @@ import androidx.compose.ui.unit.sp
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeChild
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
+import io.github.droidkaigi.confsched.designsystem.theme.primaryFixed
 import io.github.droidkaigi.confsched.main.MainScreenTab
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -101,9 +103,9 @@ fun BottomBarTabs(
                     Icon(
                         imageVector = tab.icon.imageVector,
                         tint = if (selectedTab == MainScreenTab.indexOf(tab)) {
-                            Color(0xFF67FF8D)
+                            MaterialTheme.colorScheme.primaryFixed
                         } else {
-                            Color(0xFFC1C8C9)
+                            MaterialTheme.colorScheme.onSurfaceVariant
                         },
                         contentDescription = "tab ${stringResource(tab.contentDescription)}",
                     )

--- a/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeBottomNavigation.kt
+++ b/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeBottomNavigation.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.HazeStyle
 import dev.chrisbanes.haze.hazeChild
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.main.MainScreenTab
@@ -50,11 +49,7 @@ fun GlassLikeBottomNavigation(
             .padding(horizontal = 48.dp)
             .fillMaxWidth()
             .height(64.dp)
-            .hazeChild(
-                state = hazeState,
-                shape = CircleShape,
-                style = HazeStyle(tint = Color.Black.copy(alpha = .4f), blurRadius = 30.dp),
-            )
+            .hazeChild(state = hazeState, shape = CircleShape)
             .border(
                 width = 1.dp,
                 color = Color.White.copy(alpha = .3f),

--- a/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeBottomNavigation.kt
+++ b/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeBottomNavigation.kt
@@ -1,10 +1,5 @@
 package io.github.droidkaigi.confsched.main.section
 
-import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.spring
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -30,31 +25,16 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.BlurredEdgeTreatment
-import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.blur
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.scale
-import androidx.compose.ui.geometry.CornerRadius
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.RoundRect
-import androidx.compose.ui.geometry.toRect
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.PathEffect
-import androidx.compose.ui.graphics.PathMeasure
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.HazeStyle
 import dev.chrisbanes.haze.hazeChild
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.main.MainScreenTab
-import io.github.droidkaigi.confsched.model.isBlurSupported
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -70,19 +50,17 @@ fun GlassLikeBottomNavigation(
             .padding(horizontal = 48.dp)
             .fillMaxWidth()
             .height(64.dp)
-            .hazeChild(state = hazeState, shape = CircleShape)
-            .border(
-                width = Dp.Hairline,
-                brush =
-                Brush.verticalGradient(
-                    colors =
-                    listOf(
-                        Color.White.copy(alpha = .8f),
-                        Color.White.copy(alpha = .2f),
-                    ),
-                ),
+            .hazeChild(
+                state = hazeState,
                 shape = CircleShape,
-            ),
+                style = HazeStyle(tint = Color.Black.copy(alpha = .4f), blurRadius = 30.dp),
+            )
+            .border(
+                width = 1.dp,
+                color = Color.White.copy(alpha = .3f),
+                shape = CircleShape,
+            )
+            .padding(horizontal = 12.dp),
     ) {
         BottomBarTabs(
             selectedTab = selectedTabIndex,
@@ -91,89 +69,6 @@ fun GlassLikeBottomNavigation(
                 onTabSelected(it)
             },
         )
-
-        val animatedSelectedTabIndex by animateFloatAsState(
-            targetValue = selectedTabIndex.toFloat(),
-            label = "animatedSelectedTabIndex",
-            animationSpec =
-            spring(
-                stiffness = Spring.StiffnessLow,
-                dampingRatio = Spring.DampingRatioLowBouncy,
-            ),
-        )
-
-        val animatedColor by animateColorAsState(
-            // FIXME: apply theme
-            targetValue = Color(0xFF67FF8D),
-            label = "animatedColor",
-            animationSpec =
-            spring(
-                stiffness = Spring.StiffnessLow,
-            ),
-        )
-
-        Canvas(
-            modifier =
-            Modifier
-                .fillMaxSize()
-                .clip(CircleShape)
-                .run {
-                    if (isBlurSupported()) {
-                        blur(50.dp, edgeTreatment = BlurredEdgeTreatment.Unbounded)
-                    } else {
-                        this
-                    }
-                },
-        ) {
-            val tabWidth = size.width / MainScreenTab.size
-            drawCircle(
-                color = animatedColor.copy(alpha = .6f),
-                radius = size.height / 2,
-                center =
-                Offset(
-                    (tabWidth * animatedSelectedTabIndex) + tabWidth / 2,
-                    size.height / 2,
-                ),
-            )
-        }
-
-        Canvas(
-            modifier =
-            Modifier
-                .fillMaxSize()
-                .clip(CircleShape),
-        ) {
-            val path =
-                Path().apply {
-                    addRoundRect(RoundRect(size.toRect(), CornerRadius(size.height)))
-                }
-            val length = PathMeasure().apply { setPath(path, false) }.length
-
-            val tabWidth = size.width / MainScreenTab.size
-            drawPath(
-                path,
-                brush =
-                Brush.horizontalGradient(
-                    colors =
-                    listOf(
-                        animatedColor.copy(alpha = 0f),
-                        animatedColor.copy(alpha = 1f),
-                        animatedColor.copy(alpha = 1f),
-                        animatedColor.copy(alpha = 0f),
-                    ),
-                    startX = tabWidth * animatedSelectedTabIndex,
-                    endX = tabWidth * (animatedSelectedTabIndex + 1),
-                ),
-                style =
-                Stroke(
-                    width = 6f,
-                    pathEffect =
-                    PathEffect.dashPathEffect(
-                        intervals = floatArrayOf(length / 2, length),
-                    ),
-                ),
-            )
-        }
     }
 }
 
@@ -195,25 +90,9 @@ fun BottomBarTabs(
             modifier = modifier.fillMaxSize(),
         ) {
             for (tab in MainScreenTab.values()) {
-                val alpha by animateFloatAsState(
-                    targetValue = if (selectedTab == MainScreenTab.indexOf(tab)) 1f else .35f,
-                    label = "alpha",
-                )
-                val scale by animateFloatAsState(
-                    targetValue = if (selectedTab == MainScreenTab.indexOf(tab)) 1f else .98f,
-                    visibilityThreshold = .000001f,
-                    animationSpec =
-                    spring(
-                        stiffness = Spring.StiffnessLow,
-                        dampingRatio = Spring.DampingRatioMediumBouncy,
-                    ),
-                    label = "scale",
-                )
                 Column(
                     modifier =
                     Modifier
-                        .scale(scale)
-                        .alpha(alpha)
                         .fillMaxHeight()
                         .weight(1f)
                         .pointerInput(Unit) {
@@ -226,6 +105,11 @@ fun BottomBarTabs(
                 ) {
                     Icon(
                         imageVector = tab.icon.imageVector,
+                        tint = if (selectedTab == MainScreenTab.indexOf(tab)) {
+                            Color(0xFF67FF8D)
+                        } else {
+                            Color(0xFFC1C8C9)
+                        },
                         contentDescription = "tab ${stringResource(tab.contentDescription)}",
                     )
                 }


### PR DESCRIPTION
## Issue
- (PR only)

## Overview (Required)
- This PR updates the `GlassLikeBottomNavigation` component to align with the latest Figma design specifications.

## Links
- https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=54876-40072&t=RcizvBd20gHKJqwT-4

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/af188a61-0ffe-4ce9-ba6e-a6e6c8d09e31" width="300" /> | <img src="https://github.com/user-attachments/assets/f6e93bd8-c56a-4d23-bec2-4b02709888a0" width="300" />
<img src="https://github.com/user-attachments/assets/70272c17-9007-4197-a805-05f45f96a2cf" width="300" /> | <img src="https://github.com/user-attachments/assets/fc3df9b7-073f-4d7d-b61a-62e3a858bd37" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
