### PR TITLE
add a background by using surface for TimetablePreview

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableGrid.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableGrid.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.layout.LazyLayout
 import androidx.compose.foundation.lazy.layout.LazyLayoutItemProvider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
@@ -62,6 +63,7 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.model.DroidKaigi2024Day
 import io.github.droidkaigi.confsched.model.Timetable
 import io.github.droidkaigi.confsched.model.TimetableItem
@@ -364,51 +366,67 @@ fun TimetableGrid(
 @Preview
 @Composable
 fun TimetablePreview() {
-    TimetableGrid(
-        timetable = Timetable.fake(),
-        timetableState = rememberTimetableGridState(),
-        onTimetableItemClick = {},
-        modifier = Modifier.fillMaxSize(),
-    )
+    KaigiTheme {
+        Surface {
+            TimetableGrid(
+                timetable = Timetable.fake(),
+                timetableState = rememberTimetableGridState(),
+                onTimetableItemClick = {},
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
 }
 
 @Preview
 @Composable
 fun TimetableVerticalScale20PercentPreview() {
-    TimetableGrid(
-        timetable = Timetable.fake(),
-        timetableState = rememberTimetableGridState(
-            screenScaleState = ScreenScaleState(0.2f, 0.2f),
-        ),
-        onTimetableItemClick = {},
-        modifier = Modifier.fillMaxSize(),
-    )
+    KaigiTheme {
+        Surface {
+            TimetableGrid(
+                timetable = Timetable.fake(),
+                timetableState = rememberTimetableGridState(
+                    screenScaleState = ScreenScaleState(0.2f, 0.2f),
+                ),
+                onTimetableItemClick = {},
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
 }
 
 @Preview
 @Composable
 fun TimetableVerticalScale40PercentPreview() {
-    TimetableGrid(
-        timetable = Timetable.fake(),
-        timetableState = rememberTimetableGridState(
-            screenScaleState = ScreenScaleState(0.4f, 0.4f),
-        ),
-        onTimetableItemClick = {},
-        modifier = Modifier.fillMaxSize(),
-    )
+    KaigiTheme {
+        Surface {
+            TimetableGrid(
+                timetable = Timetable.fake(),
+                timetableState = rememberTimetableGridState(
+                    screenScaleState = ScreenScaleState(0.4f, 0.4f),
+                ),
+                onTimetableItemClick = {},
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
 }
 
 @Preview
 @Composable
 fun TimetableVerticalScale60PercentPreview() {
-    TimetableGrid(
-        timetable = Timetable.fake(),
-        timetableState = rememberTimetableGridState(
-            screenScaleState = ScreenScaleState(0.6f, 0.6f),
-        ),
-        onTimetableItemClick = {},
-        modifier = Modifier.fillMaxSize(),
-    )
+    KaigiTheme {
+        Surface {
+            TimetableGrid(
+                timetable = Timetable.fake(),
+                timetableState = rememberTimetableGridState(
+                    screenScaleState = ScreenScaleState(0.6f, 0.6f),
+                ),
+                onTimetableItemClick = {},
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
 }
 
 @OptIn(ExperimentalFoundationApi::class)


### PR DESCRIPTION
## Issue
- close #242

## Overview (Required)
- The background of the TimeTablePreview was transparent, so it was changed to black by using theme and surface

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/d58fc4d5-38e4-40bf-b3e1-560c7034ecf0" width="300" /> | <img src="https://github.com/user-attachments/assets/b1d02dd6-e3f1-480d-bbca-d34ff36e9d42" width="300" />


## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
