### PR TITLE
Fixed display conditions for empty view in Favorite Screen

### DIFF
--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenPresenter.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenPresenter.kt
@@ -102,7 +102,7 @@ private fun favoritesSheet(
             .filtered(Filters(days = selectedDayFilters.toList())),
     )
 
-    return if (favoriteSessions.isEmpty()) {
+    return if (filteredSessions.isEmpty()) {
         FavoritesSheetUiState.Empty(
             currentDayFilter = selectedDayFilters.toPersistentList(),
             allFilterSelected = allFilterSelected,


### PR DESCRIPTION
## Issue
- close #360

## Overview (Required)
- Empty View display condition was referring to the list before filtering, so it has been fixed to refer to the list after filtering.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />


## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/2c8a6247-04fd-42da-9084-80df8806a11e" width="300" > | <video src="https://github.com/user-attachments/assets/1ed45651-25f7-4a6c-be29-b8ebeeed31ea" width="300" >

