### PR TITLE
Add make bootstrap for app-ios

### DIFF
--- a/app-ios/Makefile
+++ b/app-ios/Makefile
@@ -25,6 +25,12 @@ build-app-debug: build-kmp-module
 		-destination "platform=iOS Simulator,name=iPhone 15 Pro,OS=17.5" \
 		clean build | xcbeautify
 
+.PHONY: bootstrap
+bootstrap:
+	make setup && \
+	make build-kmp-module && \
+	make open
+
 # Gradle Utility
 .PHONY: gradle-clean
 gradle-clean:

--- a/app-ios/README.md
+++ b/app-ios/README.md
@@ -5,7 +5,7 @@ Official iOS App for DroidKaigi 2024.
 ## Getting started
 
 1. Setup "Requirements > Must"
-2. `make open`
+2. `make bootstrap`
 
 ## Requirements
 


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- To make the app-ios build process easier and more reliable, added `make bootstrap`. The previous `make open` command seemed insufficient for the setup.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
