### PR TITLE
[WIP] Adjust content padding (EventMap, Sponsor screen)

### DIFF
--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched.eventmap
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -132,8 +133,8 @@ private fun EventMap(
 ) {
     LazyColumn(
         modifier = modifier
-            .padding(horizontal = 16.dp)
             .testTag(EventMapLazyColumnTestTag),
+        contentPadding = PaddingValues(16.dp),
     ) {
         item {
             EventMapTab()

--- a/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/section/SponsorsList.kt
+++ b/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/section/SponsorsList.kt
@@ -49,7 +49,6 @@ fun SponsorsList(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         modifier = modifier
             .padding(padding)
-            .padding(horizontal = 12.dp)
             .let {
                 if (scrollBehavior != null) {
                     it.nestedScroll(scrollBehavior.nestedScrollConnection)
@@ -57,6 +56,7 @@ fun SponsorsList(
                     it
                 }
             },
+        contentPadding = PaddingValues(12.dp),
     ) {
         item(span = { GridItemSpan(maxLineSpan) }) {
             SponsorHeader(


### PR DESCRIPTION
## Issue
- close #381 

## Overview (Required)
- On older android devices, ripple area on EventMap and Sponsor screen are shorter than expected
![Screenshot from 2024-08-14 02-54-08](https://github.com/user-attachments/assets/570b7e25-9e9f-4b52-bb39-b39314704464)

## Links
- #381 

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/de4430ee-f6f6-4d10-b905-5fe48679c159" width="300" > | <video src="https://github.com/user-attachments/assets/5ffb1af8-22d1-4d64-8f74-843c7b78aceb" width="300" >
<video src="https://github.com/user-attachments/assets/25bbc0ce-b0be-4383-9642-f88f05a8d1f0" width="300" > | <video src="https://github.com/user-attachments/assets/cc50c416-08e3-475f-9879-d8a9cb823b0a" width="300" >



