### PR TITLE
:recycle: Improve first launch UX when profilecard already saved

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/DefaultProfileCardRepository.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/DefaultProfileCardRepository.kt
@@ -11,15 +11,15 @@ internal class DefaultProfileCardRepository(
     private val profileCardDataStore: ProfileCardDataStore,
 ) : ProfileCardRepository {
     @Composable
-    override fun profileCard(): ProfileCard? {
+    override fun profileCard(): ProfileCard {
         val profileCard by remember {
             profileCardDataStore.get()
-        }.safeCollectAsRetainedState(null)
+        }.safeCollectAsRetainedState(ProfileCard.Loading)
 
         return profileCard
     }
 
-    override suspend fun save(profileCard: ProfileCard) {
+    override suspend fun save(profileCard: ProfileCard.Exists) {
         profileCardDataStore.save(profileCard)
     }
 }

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/ProfileCardDataStore.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/ProfileCardDataStore.kt
@@ -13,18 +13,18 @@ import kotlinx.serialization.json.Json
 public class ProfileCardDataStore(
     private val dataStore: DataStore<Preferences>,
 ) {
-    public suspend fun save(profileCard: ProfileCard) {
+    public suspend fun save(profileCard: ProfileCard.Exists) {
         dataStore.edit { preferences ->
             preferences[KEY_PROFILE_CARD] = Json.encodeToString(profileCard.toJson())
         }
     }
 
-    public fun get(): Flow<ProfileCard?> {
+    public fun get(): Flow<ProfileCard> {
         return dataStore.data.map { preferences ->
             val cache = preferences[KEY_PROFILE_CARD] ?: return@map null
             Json.decodeFromString<ProfileCardJson>(cache)
         }.map {
-            it?.toModel()
+            it?.toModel() ?: ProfileCard.DoesNotExists
         }
     }
 

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/ProfileCardJson.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/ProfileCardJson.kt
@@ -13,7 +13,7 @@ internal data class ProfileCardJson(
     val theme: String,
 )
 
-internal fun ProfileCardJson.toModel() = ProfileCard(
+internal fun ProfileCardJson.toModel() = ProfileCard.Exists(
     nickname = nickname,
     occupation = occupation,
     link = link,
@@ -23,7 +23,7 @@ internal fun ProfileCardJson.toModel() = ProfileCard(
 
 internal fun String.toProfileCardTheme() = ProfileCardTheme.valueOf(this)
 
-internal fun ProfileCard.toJson() = ProfileCardJson(
+internal fun ProfileCard.Exists.toJson() = ProfileCardJson(
     nickname = nickname,
     occupation = occupation,
     link = link,

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/ProfileCard.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/ProfileCard.kt
@@ -1,12 +1,18 @@
 package io.github.droidkaigi.confsched.model
 
-data class ProfileCard(
-    val nickname: String,
-    val occupation: String?,
-    val link: String?,
-    val image: String?,
-    val theme: ProfileCardTheme,
-)
+sealed interface ProfileCard {
+    data object Loading : ProfileCard
+
+    data object DoesNotExists : ProfileCard
+
+    data class Exists(
+        val nickname: String,
+        val occupation: String?,
+        val link: String?,
+        val image: String?,
+        val theme: ProfileCardTheme,
+    ) : ProfileCard
+}
 
 enum class ProfileCardTheme {
     Iguana,

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/ProfileCardRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/ProfileCardRepository.kt
@@ -5,8 +5,8 @@ import io.github.droidkaigi.confsched.model.compositionlocal.LocalRepositories
 
 interface ProfileCardRepository {
     @Composable
-    fun profileCard(): ProfileCard?
-    suspend fun save(profileCard: ProfileCard)
+    fun profileCard(): ProfileCard
+    suspend fun save(profileCard: ProfileCard.Exists)
 }
 
 @Composable

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/MiniRobots.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/MiniRobots.kt
@@ -248,13 +248,13 @@ class DefaultSponsorsServerRobot @Inject constructor(sponsorsApiClient: Sponsors
 }
 
 interface ProfileCardRepositoryRobot {
-    suspend fun saveProfileCard(profileCard: ProfileCard)
+    suspend fun saveProfileCard(profileCard: ProfileCard.Exists)
 }
 
 class DefaultProfileCardRepositoryRobot @Inject constructor(
     private val profileCardRepository: ProfileCardRepository,
 ) : ProfileCardRepositoryRobot {
-    override suspend fun saveProfileCard(profileCard: ProfileCard) {
+    override suspend fun saveProfileCard(profileCard: ProfileCard.Exists) {
         profileCardRepository.save(profileCard)
     }
 }

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -79,6 +79,7 @@ internal sealed interface ProfileCardUiState {
 }
 
 internal enum class ProfileCardUiType {
+    Loading,
     Edit,
     Card,
 }
@@ -129,6 +130,14 @@ internal fun ProfileCardScreen(
         ),
     ) { padding ->
         when (uiState.uiType) {
+            ProfileCardUiType.Loading -> {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier.padding(padding).fillMaxSize(),
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
             ProfileCardUiType.Edit -> {
                 EditScreen(
                     uiState = uiState.editUiState,
@@ -164,7 +173,7 @@ internal fun ProfileCardScreen(
 @Composable
 internal fun EditScreen(
     uiState: ProfileCardUiState.Edit,
-    onClickCreate: (ProfileCard) -> Unit,
+    onClickCreate: (ProfileCard.Exists) -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
 ) {
@@ -206,7 +215,7 @@ internal fun EditScreen(
         Button(
             onClick = {
                 onClickCreate(
-                    ProfileCard(
+                    ProfileCard.Exists(
                         nickname = nickname,
                         occupation = occupation,
                         link = link,

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
@@ -68,7 +68,7 @@ internal fun profileCardScreenPresenter(
     )
     var uiType: ProfileCardUiType by remember { mutableStateOf(ProfileCardUiType.Loading) }
 
-    // at first launch, if you have a profile card, show the appropriate UI
+    // at first launch, if you have a profile card, show card ui
     SafeLaunchedEffect(profileCard) {
         uiType = when (profileCard) {
             is ProfileCard.Exists -> ProfileCardUiType.Card

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
@@ -59,13 +59,7 @@ internal fun profileCardScreenPresenter(
     val profileCard: ProfileCard by rememberUpdatedState(repository.profileCard())
     var isLoading: Boolean by remember { mutableStateOf(false) }
     val editUiState: ProfileCardUiState.Edit by rememberUpdatedState(profileCard.toEditUiState())
-    val cardUiState: ProfileCardUiState.Card? by rememberUpdatedState(
-        if (profileCard is ProfileCard.Exists) {
-            profileCard.toCardUiState()
-        } else {
-            null
-        },
-    )
+    val cardUiState: ProfileCardUiState.Card? by rememberUpdatedState(profileCard.toCardUiState())
     var uiType: ProfileCardUiType by remember { mutableStateOf(ProfileCardUiType.Loading) }
 
     // at first launch, if you have a profile card, show card ui

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
@@ -64,7 +64,7 @@ internal fun profileCardScreenPresenter(
             profileCard.toCardUiState()
         } else {
             null
-        }
+        },
     )
     var uiType: ProfileCardUiType by remember { mutableStateOf(ProfileCardUiType.Loading) }
 

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
@@ -58,7 +58,7 @@ internal fun profileCardScreenPresenter(
 ): ProfileCardScreenState = providePresenterDefaults { userMessageStateHolder ->
     val profileCard: ProfileCard by rememberUpdatedState(repository.profileCard())
     var isLoading: Boolean by remember { mutableStateOf(false) }
-    val ediUiState: ProfileCardUiState.Edit by rememberUpdatedState(profileCard.toEditUiState())
+    val editUiState: ProfileCardUiState.Edit by rememberUpdatedState(profileCard.toEditUiState())
     val cardUiState: ProfileCardUiState.Card? by rememberUpdatedState(
         if (profileCard is ProfileCard.Exists) {
             profileCard.toCardUiState()
@@ -106,7 +106,7 @@ internal fun profileCardScreenPresenter(
 
     ProfileCardScreenState(
         isLoading = isLoading,
-        editUiState = ediUiState,
+        editUiState = editUiState,
         cardUiState = cardUiState,
         uiType = uiType,
         userMessageStateHolder = userMessageStateHolder,


### PR DESCRIPTION
## Issue
- close #371

## Overview (Required)
1. Converted ProfileCard to a sealed interface to represent the states of loading, no data, and data exists.
2. Modified the Data layer processing to handle the data structure of ProfileCard after the conversion.
3. Enabled the UI to display a loading indicator based on the data structure of ProfileCard after the conversion.

## Movie (Optional)
Before | After
:--: | :--:
 <video src="https://github.com/user-attachments/assets/823bb4b3-4ec9-423b-a0b3-7b0e77d439a3" width="300" >  |<video src="https://github.com/user-attachments/assets/bb4fd43d-7b97-42a9-93a0-5271122cca93" width="300" >