### PR TITLE
:wrench: Change scrollBehavior in TimetableItemDetailScreen.

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
@@ -155,7 +155,7 @@ private fun TimetableItemDetailScreen(
     val sharedTransitionScope = LocalSharedTransitionScope.current
     val animatedScope = LocalAnimatedVisibilityScope.current
 
-    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     Scaffold(
         modifier = Modifier
             .fillMaxSize()


### PR DESCRIPTION
## Issue
- close #387

## Overview (Required)
- Made it so that the TopAppBar is immediately hidden when scrolling down and immediately appears when scrolling up.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/b4f368a7-7d23-4340-9642-26753e8c629e" width="300" > | <video src="https://github.com/user-attachments/assets/527e13e9-7028-47bc-85eb-f04f1f841b2b" width="300" >