### PR TITLE
Refactor compose.resources declaration in build logic & enable Compose strong skipping mode

### DIFF
--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/AndroidComposePlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/AndroidComposePlugin.kt
@@ -9,10 +9,13 @@ class AndroidComposePlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             with(pluginManager) {
-                apply(libs.plugin("composeCompiler").pluginId)
+                apply("org.jetbrains.kotlin.plugin.compose")
             }
             android {
                 buildFeatures.compose = true
+            }
+            composeCompiler {
+                enableStrongSkippingMode.set(true)
             }
             dependencies {
                 implementation(platform(libs.library("composeBom")))

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/ComposeGradleDsl.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/ComposeGradleDsl.kt
@@ -1,0 +1,19 @@
+package io.github.droidkaigi.confsched.primitive
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.get
+import org.jetbrains.compose.ComposeExtension
+import org.jetbrains.compose.resources.ResourcesExtension
+import org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradlePluginExtension
+
+fun Project.composeCompiler(block: ComposeCompilerGradlePluginExtension.() -> Unit) {
+    extensions.configure<ComposeCompilerGradlePluginExtension>(block)
+}
+
+val Project.compose: ComposeExtension
+    get() = extensions["compose"] as ComposeExtension
+
+fun ComposeExtension.resources(block: ResourcesExtension.() -> Unit) {
+    extensions.configure<ResourcesExtension>(block)
+}

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpComposePlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpComposePlugin.kt
@@ -3,10 +3,7 @@ package io.github.droidkaigi.confsched.primitive
 import io.github.droidkaigi.confsched.convention.buildComposeMetricsParameters
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.withType
-import org.jetbrains.compose.resources.ResourcesExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 @Suppress("unused")
@@ -15,16 +12,18 @@ class KmpComposePlugin : Plugin<Project> {
         with(target) {
             with(pluginManager) {
                 apply("org.jetbrains.compose")
-                apply(libs.plugin("composeCompiler").pluginId)
+                apply("org.jetbrains.kotlin.plugin.compose")
             }
             if (plugins.hasPlugin("com.android.library")) {
                 android {
                     buildFeatures.compose = true
                 }
             }
-            val compose = extensions.get("compose") as org.jetbrains.compose.ComposeExtension
-            compose.extensions.configure<ResourcesExtension> {
+            compose.resources {
                 publicResClass = true
+            }
+            composeCompiler {
+                enableStrongSkippingMode.set(true)
             }
             kotlin {
                 with(sourceSets) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,7 +52,7 @@ peekaboo = "0.5.2"
 androidGradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
 kotlinGradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 composeJbGradlePlugin = { group = "org.jetbrains.compose", name = "compose-gradle-plugin", version.ref = "composeMultiplatform" }
-composeCompiler = { group = "org.jetbrains.kotlin", name = "kotlin-compiler-embeddable", version.ref = "kotlin" }
+composeCompilerGradlePlugin = { group = "org.jetbrains.kotlin", name = "compose-compiler-gradle-plugin", version.ref = "kotlin" }
 hiltGradlePlugin = { group = "com.google.dagger", name = "hilt-android-gradle-plugin", version.ref = "dagger" }
 roborazziGradlePlugin = { group = "io.github.takahirom.roborazzi", name = "roborazzi-gradle-plugin", version.ref = "roborazzi" }
 kspGradlePlugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
@@ -196,7 +196,7 @@ ossLicensesPlugin = { id = "com.google.android.gms.oss-licenses-plugin", version
 plugins = [
     "androidGradlePlugin",
     "kotlinGradlePlugin",
-    "composeCompiler",
+    "composeCompilerGradlePlugin",
     "hiltGradlePlugin",
     "composeJbGradlePlugin",
     "roborazziGradlePlugin",


### PR DESCRIPTION
## Issue
- close #406

## Overview (Required)
- Tidy up the composeCompiler plugin declaration in `build-logic`
- Apply `enableStrongSkippingMode` to both the Android Compose & KMP Compose plugins
- Clean up the existing declaration of compose resources with a DSL (similar to other `XxxGradleDsl.kt` files)

## Links
- More info on strong skipping mode for Compose: https://developer.android.com/develop/ui/compose/performance/stability/strongskipping
