### PR TITLE
Navigate from session detail to favorite list by snackbar action

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched/KaigiApp.kt
@@ -119,7 +119,7 @@ private fun KaigiNavHost(
                     onLinkClick = externalNavController::navigate,
                     onCalendarRegistrationClick = externalNavController::navigateToCalendarRegistration,
                     onShareClick = externalNavController::onShareClick,
-                    onFavoriteListClick = { navController.navigate(favoritesScreenRoute) }
+                    onFavoriteListClick = { navController.navigate(favoritesScreenRoute) },
                 )
 
                 contributorsScreens(

--- a/app-android/src/main/java/io/github/droidkaigi/confsched/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched/KaigiApp.kt
@@ -12,6 +12,7 @@ import androidx.annotation.RequiresApi
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -118,6 +119,7 @@ private fun KaigiNavHost(
                     onLinkClick = externalNavController::navigate,
                     onCalendarRegistrationClick = externalNavController::navigateToCalendarRegistration,
                     onShareClick = externalNavController::onShareClick,
+                    onFavoriteListClick = { navController.navigate(favoritesScreenRoute) }
                 )
 
                 contributorsScreens(
@@ -133,6 +135,11 @@ private fun KaigiNavHost(
                 sponsorsScreens(
                     onNavigationIconClick = navController::popBackStack,
                     onSponsorsItemClick = externalNavController::navigate,
+                )
+
+                favoritesScreens(
+                    onTimetableItemClick = navController::navigateToTimetableItemDetailScreen,
+                    contentPadding = PaddingValues(),
                 )
             }
         }

--- a/app-ios-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/shared/IosComposeKaigiApp.kt
+++ b/app-ios-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/shared/IosComposeKaigiApp.kt
@@ -88,6 +88,7 @@ private fun KaigiNavHost(
             onShareClick = {
                 navController.navigate(contributorsScreenRoute)
             },
+            onFavoriteListClick = {} // { navController.navigate(favoritesScreenRoute) }
         )
 
         // For KMP, we are not using navigation abstraction for contributors screen

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/TimetableItemDetailScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/TimetableItemDetailScreenRobot.kt
@@ -47,6 +47,7 @@ class TimetableItemDetailScreenRobot @Inject constructor(
                     onLinkClick = { },
                     onCalendarRegistrationClick = { },
                     onShareClick = { },
+                    onFavoriteListClick = { }
                 )
             }
         }

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/TimetableItemDetailScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/TimetableItemDetailScreenRobot.kt
@@ -47,7 +47,7 @@ class TimetableItemDetailScreenRobot @Inject constructor(
                     onLinkClick = { },
                     onCalendarRegistrationClick = { },
                     onShareClick = { },
-                    onFavoriteListClick = { }
+                    onFavoriteListClick = { },
                 )
             }
         }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailPresenter.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailPresenter.kt
@@ -34,7 +34,6 @@ sealed interface TimetableItemDetailEvent {
 @Composable
 fun timetableItemDetailPresenter(
     events: SharedFlow<TimetableItemDetailEvent>,
-    onFavoriteListClick: () -> Unit,
     sessionsRepository: SessionsRepository = localSessionsRepository(),
     timetableItemIdArg: String = rememberNavigationArgument(
         key = timetableItemDetailScreenRouteItemIdParameterName,
@@ -47,6 +46,7 @@ fun timetableItemDetailPresenter(
             .timetableItemWithBookmark(timetableItemId),
     )
     var selectedDescriptionLanguage by remember { mutableStateOf<Lang?>(null) }
+    var shouldGoToFavoriteList by remember { mutableStateOf(false) }
     val bookmarkedSuccessfullyString = stringResource(SessionsRes.string.bookmarked_successfully)
     val viewBookmarkListString = stringResource(SessionsRes.string.view_bookmark_list)
 
@@ -66,7 +66,7 @@ fun timetableItemDetailPresenter(
                             duration = Short,
                         )
                         if (result == ActionPerformed) {
-                            onFavoriteListClick()
+                            shouldGoToFavoriteList = true
                         }
                     }
                 }
@@ -95,5 +95,6 @@ fun timetableItemDetailPresenter(
         roomThemeKey = timetableItem.room.getThemeKey(),
         timetableItemId = timetableItemId,
         userMessageStateHolder = userMessageStateHolder,
+        shouldGoToFavoriteList = shouldGoToFavoriteList,
     )
 }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailPresenter.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailPresenter.kt
@@ -17,6 +17,7 @@ import io.github.droidkaigi.confsched.model.TimetableItemId
 import io.github.droidkaigi.confsched.model.TimetableSessionType.NORMAL
 import io.github.droidkaigi.confsched.model.localSessionsRepository
 import io.github.droidkaigi.confsched.sessions.TimetableItemDetailEvent.Bookmark
+import io.github.droidkaigi.confsched.sessions.TimetableItemDetailEvent.FavoriteListNavigated
 import io.github.droidkaigi.confsched.sessions.TimetableItemDetailEvent.SelectDescriptionLanguage
 import io.github.droidkaigi.confsched.sessions.TimetableItemDetailScreenUiState.Loaded
 import io.github.droidkaigi.confsched.sessions.TimetableItemDetailScreenUiState.Loading
@@ -29,6 +30,7 @@ import org.jetbrains.compose.resources.stringResource
 sealed interface TimetableItemDetailEvent {
     data class Bookmark(val timetableItem: TimetableItem) : TimetableItemDetailEvent
     data class SelectDescriptionLanguage(val language: Lang) : TimetableItemDetailEvent
+    data object FavoriteListNavigated : TimetableItemDetailEvent
 }
 
 @Composable
@@ -73,6 +75,10 @@ fun timetableItemDetailPresenter(
 
                 is SelectDescriptionLanguage -> {
                     selectedDescriptionLanguage = event.language
+                }
+
+                is FavoriteListNavigated -> {
+                    shouldGoToFavoriteList = false
                 }
             }
         }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailPresenter.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailPresenter.kt
@@ -18,9 +18,9 @@ import io.github.droidkaigi.confsched.model.TimetableSessionType.NORMAL
 import io.github.droidkaigi.confsched.model.localSessionsRepository
 import io.github.droidkaigi.confsched.sessions.TimetableItemDetailEvent.Bookmark
 import io.github.droidkaigi.confsched.sessions.TimetableItemDetailEvent.SelectDescriptionLanguage
-import io.github.droidkaigi.confsched.sessions.TimetableItemDetailEvent.ViewBookmarkListRequestCompleted
 import io.github.droidkaigi.confsched.sessions.TimetableItemDetailScreenUiState.Loaded
 import io.github.droidkaigi.confsched.sessions.TimetableItemDetailScreenUiState.Loading
+import io.github.droidkaigi.confsched.ui.UserMessageResult.ActionPerformed
 import io.github.droidkaigi.confsched.ui.providePresenterDefaults
 import io.github.droidkaigi.confsched.ui.rememberNavigationArgument
 import kotlinx.coroutines.flow.SharedFlow
@@ -29,12 +29,12 @@ import org.jetbrains.compose.resources.stringResource
 sealed interface TimetableItemDetailEvent {
     data class Bookmark(val timetableItem: TimetableItem) : TimetableItemDetailEvent
     data class SelectDescriptionLanguage(val language: Lang) : TimetableItemDetailEvent
-    data object ViewBookmarkListRequestCompleted : TimetableItemDetailEvent
 }
 
 @Composable
 fun timetableItemDetailPresenter(
     events: SharedFlow<TimetableItemDetailEvent>,
+    onFavoriteListClick: () -> Unit,
     sessionsRepository: SessionsRepository = localSessionsRepository(),
     timetableItemIdArg: String = rememberNavigationArgument(
         key = timetableItemDetailScreenRouteItemIdParameterName,
@@ -60,15 +60,15 @@ fun timetableItemDetailPresenter(
                     sessionsRepository.toggleBookmark(timetableItem.id)
                     val oldBookmarked = timetableItemWithBookmark.second
                     if (!oldBookmarked) {
-                        userMessageStateHolder.showMessage(
+                        val result = userMessageStateHolder.showMessage(
                             message = bookmarkedSuccessfullyString,
                             actionLabel = viewBookmarkListString,
                             duration = Short,
                         )
+                        if (result == ActionPerformed) {
+                            onFavoriteListClick()
+                        }
                     }
-                }
-
-                is ViewBookmarkListRequestCompleted -> {
                 }
 
                 is SelectDescriptionLanguage -> {

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
@@ -94,7 +94,6 @@ fun TimetableItemDetailScreen(
     eventEmitter: EventEmitter<TimetableItemDetailEvent> = rememberEventEmitter(),
     uiState: TimetableItemDetailScreenUiState = timetableItemDetailPresenter(
         events = eventEmitter,
-        onFavoriteListClick = onFavoriteListClick,
     ),
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
@@ -102,6 +101,10 @@ fun TimetableItemDetailScreen(
         snackbarHostState = snackbarHostState,
         userMessageStateHolder = uiState.userMessageStateHolder,
     )
+
+    if (uiState is Loaded && uiState.shouldGoToFavoriteList) {
+        onFavoriteListClick()
+    }
 
     TimetableItemDetailScreen(
         uiState = uiState,
@@ -132,6 +135,7 @@ sealed interface TimetableItemDetailScreenUiState {
         val isLangSelectable: Boolean,
         val currentLang: Lang?,
         val roomThemeKey: String,
+        val shouldGoToFavoriteList: Boolean,
         override val timetableItemId: TimetableItemId,
         override val userMessageStateHolder: UserMessageStateHolder,
     ) : TimetableItemDetailScreenUiState
@@ -276,6 +280,7 @@ fun TimetableItemDetailScreenPreview() {
                     roomThemeKey = "iguana",
                     timetableItemId = fakeSession.id,
                     userMessageStateHolder = UserMessageStateHolderImpl(),
+                    shouldGoToFavoriteList = false,
                 ),
                 onNavigationIconClick = {},
                 onBookmarkClick = {

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
@@ -72,7 +72,7 @@ fun NavGraphBuilder.sessionScreens(
                 onLinkClick = onLinkClick,
                 onCalendarRegistrationClick = onCalendarRegistrationClick,
                 onShareClick = onShareClick,
-                onFavoriteListClick = onFavoriteListClick
+                onFavoriteListClick = onFavoriteListClick,
             )
         }
     }
@@ -94,7 +94,7 @@ fun TimetableItemDetailScreen(
     eventEmitter: EventEmitter<TimetableItemDetailEvent> = rememberEventEmitter(),
     uiState: TimetableItemDetailScreenUiState = timetableItemDetailPresenter(
         events = eventEmitter,
-        onFavoriteListClick = onFavoriteListClick
+        onFavoriteListClick = onFavoriteListClick,
     ),
 ) {
     val snackbarHostState = remember { SnackbarHostState() }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -102,8 +103,11 @@ fun TimetableItemDetailScreen(
         userMessageStateHolder = uiState.userMessageStateHolder,
     )
 
-    if (uiState is Loaded && uiState.shouldGoToFavoriteList) {
-        onFavoriteListClick()
+    LaunchedEffect(uiState is Loaded && uiState.shouldGoToFavoriteList) {
+        if (uiState is Loaded && uiState.shouldGoToFavoriteList) {
+            eventEmitter.tryEmit(TimetableItemDetailEvent.FavoriteListNavigated)
+            onFavoriteListClick()
+        }
     }
 
     TimetableItemDetailScreen(

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
@@ -61,6 +61,7 @@ fun NavGraphBuilder.sessionScreens(
     onLinkClick: (url: String) -> Unit,
     onCalendarRegistrationClick: (TimetableItem) -> Unit,
     onShareClick: (TimetableItem) -> Unit,
+    onFavoriteListClick: () -> Unit,
 ) {
     composable<TimetableItemDetailDestination> {
         CompositionLocalProvider(
@@ -71,6 +72,7 @@ fun NavGraphBuilder.sessionScreens(
                 onLinkClick = onLinkClick,
                 onCalendarRegistrationClick = onCalendarRegistrationClick,
                 onShareClick = onShareClick,
+                onFavoriteListClick = onFavoriteListClick
             )
         }
     }
@@ -88,9 +90,11 @@ fun TimetableItemDetailScreen(
     onLinkClick: (url: String) -> Unit,
     onCalendarRegistrationClick: (TimetableItem) -> Unit,
     onShareClick: (TimetableItem) -> Unit,
+    onFavoriteListClick: () -> Unit,
     eventEmitter: EventEmitter<TimetableItemDetailEvent> = rememberEventEmitter(),
     uiState: TimetableItemDetailScreenUiState = timetableItemDetailPresenter(
         events = eventEmitter,
+        onFavoriteListClick = onFavoriteListClick
     ),
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
@@ -287,4 +291,5 @@ fun TimetableItemDetailScreenPreview() {
     }
 }
 
-internal fun timetableDetailSharedContentStateKey(timetableItemId: TimetableItemId) = "timetable-item-${timetableItemId.value}"
+internal fun timetableDetailSharedContentStateKey(timetableItemId: TimetableItemId) =
+    "timetable-item-${timetableItemId.value}"


### PR DESCRIPTION
## Issue
- nothing

## Overview (Required)
- When we tap the snack bar button that is shown when we tap a favorite button on the session details screen, this app shows the favorites list screen.

## Links
- nothing

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
<video src="https://github.com/user-attachments/assets/67bfc25a-42d8-4be5-8aa2-1dff417f8faf" width="300" >


