### PR TITLE
Add message for EventMapEvent

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/eventmap/EventMapApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/eventmap/EventMapApiClient.kt
@@ -4,6 +4,7 @@ import de.jensklingenberg.ktorfit.Ktorfit
 import de.jensklingenberg.ktorfit.http.GET
 import io.github.droidkaigi.confsched.data.NetworkService
 import io.github.droidkaigi.confsched.data.eventmap.response.EventMapResponse
+import io.github.droidkaigi.confsched.data.eventmap.response.MessageResponse
 import io.github.droidkaigi.confsched.model.EventMapEvent
 import io.github.droidkaigi.confsched.model.MultiLangText
 import io.github.droidkaigi.confsched.model.RoomIcon
@@ -55,6 +56,7 @@ public fun EventMapResponse.toEventMapList(): PersistentList<EventMapEvent> {
                         enTitle = event.i18nDesc.en,
                     ),
                     moreDetailsUrl = event.moreDetailsUrl,
+                    message = event.message.toMultiLangText(),
                 )
             }
         }
@@ -69,3 +71,6 @@ private fun String.toRoomIcon(): RoomIcon = when (this) {
     "Jellyfish" -> RoomIcon.Triangle
     else -> RoomIcon.None
 }
+
+private fun MessageResponse.toMultiLangText() =
+    if (ja != null && en != null) MultiLangText(jaTitle = ja, enTitle = en) else null

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/EventMapEvent.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/EventMapEvent.kt
@@ -15,6 +15,7 @@ public data class EventMapEvent(
     val roomIcon: RoomIcon,
     val description: MultiLangText,
     val moreDetailsUrl: String?,
+    val message: MultiLangText?,
 ) {
     public companion object
 }
@@ -33,6 +34,10 @@ public fun EventMapEvent.Companion.fakes(): PersistentList<EventMapEvent> = Room
         } else {
             null
         },
+        message = MultiLangText(
+            "※こちらのイベントは時間が変更されました。",
+            "※This event has been rescheduled.",
+        ),
     )
 }.toPersistentList()
 

--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/component/EventMapItem.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/component/EventMapItem.kt
@@ -71,6 +71,14 @@ fun EventMapItem(
                 style = MaterialTheme.typography.bodyLarge,
                 color = Color.White.copy(alpha = 0.7F),
             )
+            eventMapEvent.message?.let {
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = it.currentLangTitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.tertiary,
+                )
+            }
             eventMapEvent.moreDetailsUrl?.let {
                 Spacer(Modifier.height(height = 8.dp))
                 OutlinedButton(


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2024/issues/403

## Overview (Required)
- Added message property to EventMapEvent class
- Added the mapping for MessageResponse to EventMapEvent#message.
- Added logic to display EventMapEvent#message when it is non-null.

## Links
- none

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before or when EentMapEvent#message is null | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/4df24b13-2bfb-4e4a-99e9-70e500fe29d3" width="300" /> | <img src="https://github.com/user-attachments/assets/4d702030-aa7a-4e12-8d00-d32afc1e1080" width="300" />


