### PR TITLE
Feature/397 AboutDroidkaigi section design

### DIFF
--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutDroidKaigiDetailSummaryCard.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutDroidKaigiDetailSummaryCard.kt
@@ -12,9 +12,12 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.unit.dp
 import conference_app_2024.feature.about.generated.resources.date_description
 import conference_app_2024.feature.about.generated.resources.date_title
@@ -31,14 +34,26 @@ fun AboutDroidKaigiDetailSummaryCard(
     modifier: Modifier = Modifier,
     onViewMapClick: () -> Unit,
 ) {
+    val borderColor = MaterialTheme.colorScheme.onSurfaceVariant
+
     Card(
-        shape = RoundedCornerShape(12.dp),
-        modifier = modifier,
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(
-                1.dp,
-            ),
-        ),
+        shape = RoundedCornerShape(4.dp),
+        colors = CardDefaults.cardColors(MaterialTheme.colorScheme.surfaceContainerLow),
+        modifier = modifier
+            .drawBehind {
+                val strokeWidth = 1.dp.toPx()
+                val dashSize = 2.dp.toPx()
+                val pathEffect = PathEffect.dashPathEffect(floatArrayOf(dashSize, dashSize))
+
+                drawRoundRect(
+                    color = borderColor,
+                    style = Stroke(
+                        width = strokeWidth,
+                        pathEffect = pathEffect,
+                    ),
+                    cornerRadius = CornerRadius(4.dp.toPx()),
+                )
+            },
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutDroidKaigiDetailSummaryCard.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutDroidKaigiDetailSummaryCard.kt
@@ -56,10 +56,10 @@ fun AboutDroidKaigiDetailSummaryCard(
             },
     ) {
         Column(
-            verticalArrangement = Arrangement.spacedBy(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 24.dp),
+                .padding(horizontal = 16.dp, vertical = 20.dp),
         ) {
             AboutDroidKaigiDetailSummaryCardRow(
                 leadingIcon = Outlined.Schedule,

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutDroidKaigiDetailSummaryCardRow.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutDroidKaigiDetailSummaryCardRow.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import conference_app_2024.feature.about.generated.resources.place_link

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutDroidKaigiDetailSummaryCardRow.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutDroidKaigiDetailSummaryCardRow.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import conference_app_2024.feature.about.generated.resources.place_link
 import io.github.droidkaigi.confsched.about.AboutRes
@@ -46,12 +45,11 @@ fun AboutDroidKaigiDetailSummaryCardRow(
         Spacer(modifier = Modifier.width(8.dp))
         Text(
             text = label,
-            fontWeight = FontWeight.Bold,
-            style = MaterialTheme.typography.labelLarge,
+            style = MaterialTheme.typography.titleSmall,
         )
         Spacer(modifier = Modifier.width(12.dp))
         ClickableLinkText(
-            style = MaterialTheme.typography.bodyMedium,
+            style = MaterialTheme.typography.titleSmall,
             content = content,
             onLinkClick = onLinkClick,
             regex = stringResource(AboutRes.string.place_link).toRegex(),

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutDroidKaigiDetailSummaryCardRow.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutDroidKaigiDetailSummaryCardRow.kt
@@ -40,9 +40,9 @@ fun AboutDroidKaigiDetailSummaryCardRow(
             imageVector = leadingIcon,
             contentDescription = leadingIconContentDescription,
             modifier = Modifier.size(16.dp),
-            tint = Color.Green,
+            tint = MaterialTheme.colorScheme.onSurface,
         )
-        Spacer(modifier = Modifier.width(8.dp))
+        Spacer(modifier = Modifier.width(4.dp))
         Text(
             text = label,
             style = MaterialTheme.typography.titleSmall,

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/section/AboutDroidKaigiDetail.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/section/AboutDroidKaigiDetail.kt
@@ -46,7 +46,7 @@ fun AboutDroidKaigiDetail(
         )
         Text(
             text = stringResource(AboutRes.string.description),
-            style = MaterialTheme.typography.bodyLarge,
+            style = MaterialTheme.typography.titleMedium,
             textAlign = TextAlign.Center,
             modifier = Modifier
                 .padding(


### PR DESCRIPTION
## Issue
- close #397 

## Overview (Required)
- Update the AboutDroidkaigi section design to match the Figma design.

## Links
- https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=54985-75928&t=N5b6Q2AZf7PVvvKD-4 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/9643a9cf-f255-4496-ada6-69f51ef7ba99" width="300" /> | <img src="https://github.com/user-attachments/assets/8cd2b9fe-785b-4109-96c4-784ea512a11a" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
