### PR TITLE
Improve flip animation

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/FlipCard.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/FlipCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -52,6 +53,7 @@ internal fun FlipCard(
             easing = FastOutSlowInEasing,
         ),
     )
+    val isBack by remember { derivedStateOf { rotation > 90f } }
     val targetRotation by animateFloatAsState(
         targetValue = 30f,
         animationSpec = tween(
@@ -88,7 +90,7 @@ internal fun FlipCard(
             colors = CardDefaults.cardColors(containerColor = LocalProfileCardScreenTheme.current.containerColor),
             elevation = CardDefaults.cardElevation(10.dp),
         ) {
-            if (isFlipped) { // Back
+            if (isBack) { // Back
                 Column(
                     modifier = Modifier
                         .fillMaxSize()

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/FlipCard.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/FlipCard.kt
@@ -45,27 +45,27 @@ internal fun FlipCard(
     var isFlipped by remember { mutableStateOf(false) }
     var isCreated by rememberSaveable { mutableStateOf(isCreated) }
     var initialRotation by remember { mutableStateOf(0f) }
-    val rotation = animateFloatAsState(
+    val rotation by animateFloatAsState(
         targetValue = if (isFlipped) 180f else initialRotation,
         animationSpec = tween(
             durationMillis = 400,
             easing = FastOutSlowInEasing,
         ),
     )
-    val targetRotation = animateFloatAsState(
+    val targetRotation by animateFloatAsState(
         targetValue = 30f,
         animationSpec = tween(
             durationMillis = 400,
             easing = FastOutSlowInEasing,
         ),
-    ).value
-    val targetRotation2 = animateFloatAsState(
+    )
+    val targetRotation2 by animateFloatAsState(
         targetValue = 0f,
         animationSpec = tween(
             durationMillis = 400,
             easing = FastOutSlowInEasing,
         ),
-    ).value
+    )
 
     LaunchedEffect(Unit) {
         if (isCreated) {
@@ -82,7 +82,7 @@ internal fun FlipCard(
                 .size(width = 300.dp, height = 380.dp)
                 .clickable { isFlipped = !isFlipped }
                 .graphicsLayer {
-                    rotationY = rotation.value
+                    rotationY = rotation
                     cameraDistance = 12f * density
                 },
             colors = CardDefaults.cardColors(containerColor = LocalProfileCardScreenTheme.current.containerColor),


### PR DESCRIPTION
## Issue
none

## Overview (Required)
It was flipping and flickering as soon as I tapped the card, so I change the setting to flip it over after rotating more than 90 degrees.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/77d02ff6-f925-47ab-b022-8922d73a657a" width="300" > | <video src="https://github.com/user-attachments/assets/44b18eba-84fd-4d33-8972-7474d171f065" width="300" >




