### PR TITLE
to be able show connection failed message

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/NetworkService.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/NetworkService.kt
@@ -2,6 +2,7 @@ package io.github.droidkaigi.confsched.data
 
 import io.github.droidkaigi.confsched.data.auth.AuthApi
 import io.github.droidkaigi.confsched.model.AppError
+import io.github.droidkaigi.confsched.model.knownPlatformExceptionOrNull
 import io.ktor.client.HttpClient
 import io.ktor.client.network.sockets.SocketTimeoutException
 import io.ktor.client.plugins.HttpRequestTimeoutException
@@ -23,6 +24,9 @@ public class NetworkService(public val httpClient: HttpClient, public val authAp
 }
 
 public fun Throwable.toAppError(): AppError {
+    // Platform specific exception handling
+    knownPlatformExceptionOrNull(this)?.let { return it }
+
     return when (this) {
         is AppError -> this
         is ResponseException ->

--- a/core/model/src/androidMain/kotlin/io/github/droidkaigi/confsched/model/AppError.kt
+++ b/core/model/src/androidMain/kotlin/io/github/droidkaigi/confsched/model/AppError.kt
@@ -1,0 +1,9 @@
+package io.github.droidkaigi.confsched.model
+
+public actual fun knownPlatformExceptionOrNull(e: Throwable): AppError? {
+    return if (e is java.net.UnknownHostException) {
+        AppError.InternetConnectionException(e)
+    } else {
+        null
+    }
+}

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/AppError.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/AppError.kt
@@ -18,4 +18,7 @@ public sealed class AppError : RuntimeException {
     }
 
     public class UnknownException(cause: Throwable?) : AppError(cause = cause)
+    public class InternetConnectionException(cause: Throwable?) : AppError(cause)
 }
+
+public expect fun knownPlatformExceptionOrNull(e: Throwable): AppError?

--- a/core/model/src/iosMain/kotlin/io/github/droidkaigi/confsched/model/AppError.kt
+++ b/core/model/src/iosMain/kotlin/io/github/droidkaigi/confsched/model/AppError.kt
@@ -1,0 +1,3 @@
+package io.github.droidkaigi.confsched.model
+
+public actual fun knownPlatformExceptionOrNull(e: Throwable): AppError? = null

--- a/core/ui/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-ja/strings.xml
@@ -3,4 +3,5 @@
     <string name="bookmarked">ブックマーク済み</string>
     <string name="not_bookmarked">ブックマークされていません</string>
     <string name="image">画像</string>
+    <string name="connection_failed">接続に失敗しました、ネットワーク設定を確認してください。</string>
 </resources>

--- a/core/ui/src/commonMain/composeResources/values/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="bookmarked">Bookmarked</string>
     <string name="not_bookmarked">Not Bookmarked</string>
     <string name="image">image</string>
+    <string name="connection_failed">Connection failed, Check your network settings.</string>
 </resources>

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/AppErrorMapper.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/AppErrorMapper.kt
@@ -1,5 +1,15 @@
 package io.github.droidkaigi.confsched.ui
 
-fun Throwable.toApplicationErrorMessage(): String {
+import io.github.droidkaigi.confsched.model.AppError.InternetConnectionException
+import io.github.droidkaigi.confsched.ui.ComposeResourceErrorMessageType.ConnectionFailed
+
+internal fun Throwable.toApplicationErrorMessage(
+    composeResourceErrorMessage: List<ComposeResourceErrorMessage>? = null,
+): String {
+    composeResourceErrorMessage?.forEach {
+        if (it.type == ConnectionFailed && this is InternetConnectionException) {
+            return it.message
+        }
+    }
     return message ?: ""
 }

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/AppErrorMapper.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/AppErrorMapper.kt
@@ -1,15 +1,12 @@
 package io.github.droidkaigi.confsched.ui
 
-import io.github.droidkaigi.confsched.model.AppError.InternetConnectionException
-import io.github.droidkaigi.confsched.ui.ComposeResourceErrorMessageType.ConnectionFailed
+import io.ktor.util.reflect.instanceOf
 
 internal fun Throwable.toApplicationErrorMessage(
     composeResourceErrorMessages: List<ComposeResourceErrorMessage>? = null,
 ): String {
     composeResourceErrorMessages?.forEach {
-        if (it.type == ConnectionFailed && this is InternetConnectionException) {
-            return it.message
-        }
+        if (this.instanceOf(it.appError)) return it.message
     }
     return message ?: ""
 }

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/AppErrorMapper.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/AppErrorMapper.kt
@@ -4,9 +4,9 @@ import io.github.droidkaigi.confsched.model.AppError.InternetConnectionException
 import io.github.droidkaigi.confsched.ui.ComposeResourceErrorMessageType.ConnectionFailed
 
 internal fun Throwable.toApplicationErrorMessage(
-    composeResourceErrorMessage: List<ComposeResourceErrorMessage>? = null,
+    composeResourceErrorMessages: List<ComposeResourceErrorMessage>? = null,
 ): String {
-    composeResourceErrorMessage?.forEach {
+    composeResourceErrorMessages?.forEach {
         if (it.type == ConnectionFailed && this is InternetConnectionException) {
             return it.message
         }

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/AppErrorMapper.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/AppErrorMapper.kt
@@ -1,12 +1,10 @@
 package io.github.droidkaigi.confsched.ui
 
-import io.ktor.util.reflect.instanceOf
-
 internal fun Throwable.toApplicationErrorMessage(
     composeResourceErrorMessages: List<ComposeResourceErrorMessage>? = null,
 ): String {
     composeResourceErrorMessages?.forEach {
-        if (this.instanceOf(it.appError)) return it.message
+        if (it.appErrorClass.isInstance(this)) return it.message
     }
     return message ?: ""
 }

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/ComposeResourceErrorMessage.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/ComposeResourceErrorMessage.kt
@@ -2,25 +2,23 @@ package io.github.droidkaigi.confsched.ui
 
 import androidx.compose.runtime.Composable
 import conference_app_2024.core.ui.generated.resources.connection_failed
+import io.github.droidkaigi.confsched.model.AppError
+import io.github.droidkaigi.confsched.model.AppError.InternetConnectionException
 import org.jetbrains.compose.resources.stringResource
+import kotlin.reflect.KClass
 
 /**
  * If you want to display composeResource error messages instead of error messages from the API, define them here
- * [Throwable.toApplicationErrorMessage] also needs to be defined
  */
 @Composable
-internal fun ComposeResourceErrorMessages(): List<ComposeResourceErrorMessage> = listOf(
+internal fun composeResourceErrorMessages(): List<ComposeResourceErrorMessage> = listOf(
     ComposeResourceErrorMessage(
-        ComposeResourceErrorMessageType.ConnectionFailed,
+        InternetConnectionException::class,
         stringResource(UiRes.string.connection_failed),
     ),
 )
 
-internal enum class ComposeResourceErrorMessageType {
-    ConnectionFailed,
-}
-
 internal data class ComposeResourceErrorMessage(
-    val type: ComposeResourceErrorMessageType,
+    val appError: KClass<out AppError>,
     val message: String,
 )

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/ComposeResourceErrorMessage.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/ComposeResourceErrorMessage.kt
@@ -1,0 +1,26 @@
+package io.github.droidkaigi.confsched.ui
+
+import androidx.compose.runtime.Composable
+import conference_app_2024.core.ui.generated.resources.connection_failed
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * If you want to display composeResource error messages instead of error messages from the API, define them here
+ * [Throwable.toApplicationErrorMessage] also needs to be defined
+ */
+@Composable
+internal fun ComposeResourceErrorMessages(): List<ComposeResourceErrorMessage> = listOf(
+    ComposeResourceErrorMessage(
+        ComposeResourceErrorMessageType.ConnectionFailed,
+        stringResource(UiRes.string.connection_failed),
+    ),
+)
+
+internal enum class ComposeResourceErrorMessageType {
+    ConnectionFailed,
+}
+
+internal data class ComposeResourceErrorMessage(
+    val type: ComposeResourceErrorMessageType,
+    val message: String,
+)

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/ComposeResourceErrorMessage.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/ComposeResourceErrorMessage.kt
@@ -19,6 +19,6 @@ internal fun composeResourceErrorMessages(): List<ComposeResourceErrorMessage> =
 )
 
 internal data class ComposeResourceErrorMessage(
-    val appError: KClass<out AppError>,
+    val appErrorClass: KClass<out AppError>,
     val message: String,
 )

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/PresenterDefaultsProvider.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/PresenterDefaultsProvider.kt
@@ -11,11 +11,11 @@ fun <T> providePresenterDefaults(
     userMessageStateHolder: UserMessageStateHolder = rememberUserMessageStateHolder(),
     block: @Composable (UserMessageStateHolder) -> T,
 ): T {
-    val composeResourceErrorMessage = ComposeResourceErrorMessages()
+    val composeResourceErrorMessages = ComposeResourceErrorMessages()
     val handler = remember(userMessageStateHolder) {
         object : ComposeEffectErrorHandler {
             override suspend fun emit(throwable: Throwable) {
-                val message = throwable.toApplicationErrorMessage(composeResourceErrorMessage)
+                val message = throwable.toApplicationErrorMessage(composeResourceErrorMessages)
                 userMessageStateHolder.showMessage(
                     message = message,
                     actionLabel = null,

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/PresenterDefaultsProvider.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/PresenterDefaultsProvider.kt
@@ -11,7 +11,7 @@ fun <T> providePresenterDefaults(
     userMessageStateHolder: UserMessageStateHolder = rememberUserMessageStateHolder(),
     block: @Composable (UserMessageStateHolder) -> T,
 ): T {
-    val composeResourceErrorMessages = ComposeResourceErrorMessages()
+    val composeResourceErrorMessages = composeResourceErrorMessages()
     val handler = remember(userMessageStateHolder) {
         object : ComposeEffectErrorHandler {
             override suspend fun emit(throwable: Throwable) {

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/PresenterDefaultsProvider.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/PresenterDefaultsProvider.kt
@@ -11,12 +11,13 @@ fun <T> providePresenterDefaults(
     userMessageStateHolder: UserMessageStateHolder = rememberUserMessageStateHolder(),
     block: @Composable (UserMessageStateHolder) -> T,
 ): T {
+    val composeResourceErrorMessage = ComposeResourceErrorMessages()
     val handler = remember(userMessageStateHolder) {
         object : ComposeEffectErrorHandler {
             override suspend fun emit(throwable: Throwable) {
-                val a = throwable.toApplicationErrorMessage()
+                val message = throwable.toApplicationErrorMessage(composeResourceErrorMessage)
                 userMessageStateHolder.showMessage(
-                    message = a,
+                    message = message,
                     actionLabel = null,
                 )
             }


### PR DESCRIPTION
## Issue
- close #404
  - I have not been assigned to an issue, but I thought that no one but me would show up to do it, so I created this PR.


## Overview (Required)
- Created `knownPlatformExceptionOrNull` and `InternetConnectionException` to match The following [comments](https://github.com/DroidKaigi/conference-app-2024/issues/404#issuecomment-2290206708) 

>How about adding a expect function like this?
>
>expect fun knownPlatformExceptionOrNulll(e: Exception): AppError?
>
>actual fun knownPlatformExceptionOrNulll(e: Exception): AppError? {
>if(e is UnknownHostException) {
>return AppError.InternetConnectionException(e)
>}
>return null
>}

- Composable function `ComposeResourceErrorMessages` to display network connection failure in English or Japanese
- Error wording in Japanese and English is my own wording


## Movie
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/9d10f9ff-863c-439d-8d9e-f2ee851e24bd" width="300" > | <video src="https://github.com/user-attachments/assets/92abe38f-c1f9-448b-be8a-3b7e2c2326c4" width="300" >

