### PR TITLE
Align the UI of the Favorite/Empty screen with the Figma design proposal.

### DIFF
--- a/feature/favorites/src/commonMain/composeResources/values-ja/favorites_strings.xml
+++ b/feature/favorites/src/commonMain/composeResources/values-ja/favorites_strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="favorite">お気に入り</string>
-    <string name="empty_description">登録されたセッションがありません</string>
+    <string name="empty_description">登録されたセッションが\nありません</string>
     <string name="empty_guide">気になるセッションをお気に入り登録しましょう</string>
     <string name="filter_all">すべて</string>
     <string name="content_description_back">戻る</string>

--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/component/FavoriteFilters.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/component/FavoriteFilters.kt
@@ -2,6 +2,7 @@ package io.github.droidkaigi.confsched.favorites.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.FilterChip
@@ -30,8 +31,8 @@ fun FavoriteFilters(
     modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier.padding(start = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         FavoriteFilterChip(
             selected = allFilterSelected,


### PR DESCRIPTION
## Issue
- close #456 

## Overview (Required)
- Updated the UI of the Favorite/Empty screen with the following changes:

1.	Adjusted the padding of the buttons at the top of the screen to match the Figma design.
2.	Corrected the line break in the text according to the Figma design.

## Links
- https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=55518-43653&t=pGcYDGfI9eDBOFFN-4

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
![before](https://github.com/user-attachments/assets/6b2b98a9-3525-4f7b-9a66-1b8b7328c047) | ![after](https://github.com/user-attachments/assets/882a500a-4be3-46a4-bd3d-e33c748d44f3)

