### PR TITLE
Session detail screen: Room and language layout slightly differs from Figma

### DIFF
--- a/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/theme/RoomTheme.kt
+++ b/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/theme/RoomTheme.kt
@@ -26,9 +26,9 @@ sealed interface RoomTheme {
     }
 
     data object Flamingo : RoomTheme {
-        override val primaryColor = Color(0xFFBB85FF)
-        override val containerColor = Color(0xFFBB85FF).copy(alpha = 0.1f)
-        override val dimColor = Color(0xFF1E1A27)
+        override val primaryColor = Color(0xFFFF53CF)
+        override val containerColor = Color(0xFFFF53CF).copy(alpha = 0.1f)
+        override val dimColor = Color(0xFF271A25)
     }
 
     data object Jellyfish : RoomTheme {

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/TimetableRoomExt.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/TimetableRoomExt.kt
@@ -1,22 +1,17 @@
 package io.github.droidkaigi.confsched.ui
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Circle
-import androidx.compose.material.icons.filled.Square
-import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.filled.Thermostat
-import androidx.compose.ui.graphics.vector.ImageVector
+import io.github.droidkaigi.confsched.model.RoomIcon
 import io.github.droidkaigi.confsched.model.TimetableRoom
+import org.jetbrains.compose.resources.DrawableResource
 
-val TimetableRoom.icon: ImageVector
+val TimetableRoom.icon: DrawableResource?
     get() {
-        // TODO: Replace with the real icons. Probably need to embed them.
         return when (name.enTitle) {
-            "Flamingo" -> Icons.Filled.Square
-            "Giraffe" -> Icons.Filled.Circle
-            "Hedgehog" -> Icons.Filled.Star
-            "Iguana" -> Icons.Filled.Thermostat
-            "Jellyfish" -> Icons.Filled.Star
-            else -> Icons.Filled.Star
+            "Flamingo" -> RoomIcon.Rhombus.toResDrawable()
+            "Giraffe" -> RoomIcon.Circle.toResDrawable()
+            "Hedgehog" -> RoomIcon.Diamond.toResDrawable()
+            "Iguana" -> RoomIcon.Square.toResDrawable()
+            "Jellyfish" -> RoomIcon.Triangle.toResDrawable()
+            else -> RoomIcon.Rhombus.toResDrawable()
         }
     }

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/TimetableItemTag.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/TimetableItemTag.kt
@@ -14,16 +14,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.vectorResource
 
 @Composable
 fun TimetableItemTag(
     tagText: String,
     tagColor: Color,
     modifier: Modifier = Modifier,
-    icon: ImageVector? = null,
+    icon: DrawableResource? = null,
 ) {
     Row(
         modifier = modifier
@@ -41,7 +42,7 @@ fun TimetableItemTag(
         icon?.let { ico ->
             Icon(
                 modifier = Modifier.size(12.dp),
-                imageVector = ico,
+                imageVector = vectorResource(ico),
                 contentDescription = "",
                 tint = tagColor,
             )


### PR DESCRIPTION
## Issue
- close #211 

## Overview (Required)
- fix design of tag icon.
- fix theme color of flamingo.

## Links
- nothing

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/06978656-81b9-41ef-82f6-8a9fb0e7f0c6" width="300" /> | <img src="https://github.com/user-attachments/assets/74e2a890-6e0a-4bb0-83f0-a1c8c7a55954" width="300" /> 
<img src="https://github.com/user-attachments/assets/2428129c-4d3c-470e-a19b-cd4e11648f37" width="300" />| <img src="https://github.com/user-attachments/assets/b6372719-0b70-437d-8a12-3338751c2891" width="300" />
