### PR TITLE
Make EventResponse#message field nullable

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/eventmap/EventMapApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/eventmap/EventMapApiClient.kt
@@ -56,7 +56,7 @@ public fun EventMapResponse.toEventMapList(): PersistentList<EventMapEvent> {
                         enTitle = event.i18nDesc.en,
                     ),
                     moreDetailsUrl = event.moreDetailsUrl,
-                    message = event.message.toMultiLangText(),
+                    message = event.message?.toMultiLangText(),
                 )
             }
         }

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/eventmap/response/EventResponse.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/eventmap/response/EventResponse.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 public data class EventResponse(
     val i18nDesc: I18nDescResponse,
     val id: String,
-    val message: MessageResponse,
+    val message: MessageResponse?,
     val moreDetailsUrl: String?,
     val noShow: Boolean,
     val roomId: Int,

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/EventMapEvent.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/EventMapEvent.kt
@@ -34,10 +34,14 @@ public fun EventMapEvent.Companion.fakes(): PersistentList<EventMapEvent> = Room
         } else {
             null
         },
-        message = MultiLangText(
-            "※こちらのイベントは時間が変更されました。",
-            "※This event has been rescheduled.",
-        ),
+        message = if (it.ordinal % 3 == 0) {
+            MultiLangText(
+                "※こちらのイベントは時間が変更されました。",
+                "※This event has been rescheduled.",
+            )
+        } else {
+            null
+        },
     )
 }.toPersistentList()
 


### PR DESCRIPTION
## Issue
- close #465

## Overview (Required)
- Turn `EventResponse#message` from `MessageResponse` into `MessageResponse?`
- The UI layer already handles this being absent, so no changes needed
- We can now provide a `null` value from the API for this field
- Added some variation to `EventMapEvent` fake data so that we can see the absent message in the app

## Links
- -/-

## Screenshot (Optional if screenshot test is present or unrelated to UI)

![PixelPro_1723711587](https://github.com/user-attachments/assets/5559f9d2-1e36-455a-b3ba-dc5b9b09f65e)
