### PR TITLE
Fix appearance of time in TimetableGridItem

### DIFF
--- a/feature/sessions/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/sessions/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="content_description_schedule_icon">スケジュール</string>
     <string name="content_description_user_icon">ユーザー</string>
     <string name="content_description_error_icon">エラー</string>
     <string name="bookmarked_successfully">ブックマークに追加されました</string>

--- a/feature/sessions/src/commonMain/composeResources/values/strings.xml
+++ b/feature/sessions/src/commonMain/composeResources/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="content_description_schedule_icon">Schedule</string>
     <string name="content_description_user_icon">User</string>
     <string name="content_description_error_icon">Error</string>
     <string name="bookmarked_successfully">Bookmarked successfully.</string>

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -42,7 +41,6 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import conference_app_2024.feature.sessions.generated.resources.content_description_error_icon
-import conference_app_2024.feature.sessions.generated.resources.content_description_schedule_icon
 import conference_app_2024.feature.sessions.generated.resources.content_description_user_icon
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.designsystem.theme.LocalRoomTheme
@@ -61,6 +59,7 @@ import io.github.droidkaigi.confsched.model.TimetableSpeaker
 import io.github.droidkaigi.confsched.model.fake
 import io.github.droidkaigi.confsched.sessions.SessionsRes
 import io.github.droidkaigi.confsched.sessions.section.TimetableSizes
+import io.github.droidkaigi.confsched.ui.icon
 import io.github.droidkaigi.confsched.ui.previewOverride
 import io.github.droidkaigi.confsched.ui.rememberAsyncImagePainter
 import kotlinx.collections.immutable.PersistentList
@@ -163,17 +162,18 @@ fun TimetableGridItem(
                     ) {
                         Icon(
                             modifier = Modifier.height(TimetableGridItemSizes.scheduleHeight),
-                            imageVector = Icons.Default.Schedule,
-                            contentDescription = stringResource(SessionsRes.string.content_description_schedule_icon),
+                            imageVector = timetableItem.room.icon,
+                            contentDescription = timetableItem.room.name.currentLangTitle,
+                            tint = LocalRoomTheme.current.primaryColor,
                         )
                         Spacer(modifier = Modifier.width(4.dp))
-                        var scheduleTextStyle = MaterialTheme.typography.bodySmall
+                        var scheduleTextStyle = MaterialTheme.typography.labelSmall
                         if (titleTextStyle.fontSize < scheduleTextStyle.fontSize) {
                             scheduleTextStyle =
                                 scheduleTextStyle.copy(fontSize = titleTextStyle.fontSize)
                         }
                         Text(
-                            text = "${timetableItem.startsTimeString} - ${timetableItem.endsTimeString}",
+                            text = "${timetableItem.startsTimeString}~${timetableItem.endsTimeString}",
                             style = scheduleTextStyle,
                             color = LocalRoomTheme.current.primaryColor,
                         )


### PR DESCRIPTION
## Issue
- no issue

## Overview (Required)
- Typography use labelSmall instead bodySmall
- Icon use session room instead of schedule
  - Similarly contentDescription was fixed
- `-` to `~`
  - `~` There appears to be a space in the after, but it is not actually there. Not adjusted this time
  - https://github.com/DroidKaigi/conference-app-2024/pull/376#issuecomment-2286502405

## Links
- https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=55495-40872&t=5C229MEc5Q7tFuTf-4

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src=https://github.com/user-attachments/assets/3266bbee-fa98-4785-91cd-2c235079a697  width=300>|<img src=https://github.com/user-attachments/assets/ad01c862-a35b-4417-b95b-4a91ac5d9e48  width=300>


## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
