### PR TITLE
🧹 Use Enum.entries

### DIFF
--- a/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/MainScreen.kt
+++ b/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/MainScreen.kt
@@ -189,9 +189,9 @@ enum class MainScreenTab(
     ;
 
     companion object {
-        val size: Int get() = values().size
-        fun indexOf(tab: MainScreenTab): Int = values().indexOf(tab)
-        fun fromIndex(index: Int): MainScreenTab = values()[index]
+        val size: Int get() = entries.size
+        fun indexOf(tab: MainScreenTab): Int = entries.indexOf(tab)
+        fun fromIndex(index: Int): MainScreenTab = entries[index]
     }
 }
 
@@ -218,7 +218,7 @@ fun MainScreen(
         AnimatedVisibility(visible = navigationType == NavigationRail) {
             Column {
                 Text(text = "nav rail")
-                MainScreenTab.values().forEach { tab ->
+                MainScreenTab.entries.forEach { tab ->
                     Button(onClick = { onTabSelected(mainNestedNavController, tab) }) {
                         Text(text = stringResource(tab.label) + " " + (currentTab == tab))
                     }

--- a/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeBottomNavigation.kt
+++ b/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeBottomNavigation.kt
@@ -195,7 +195,7 @@ fun BottomBarTabs(
         Row(
             modifier = modifier.fillMaxSize(),
         ) {
-            for (tab in MainScreenTab.values()) {
+            for (tab in MainScreenTab.entries) {
                 val alpha by animateFloatAsState(
                     targetValue = if (selectedTab == MainScreenTab.indexOf(tab)) 1f else .35f,
                     label = "alpha",


### PR DESCRIPTION
## Issue
- no issue

## Overview (Required)
- Use 'Enum.entries' available since Kotlin 1.9.
- Lint recommends 'Enum.entries' instead of 'Enum.values()'

## Links
- https://youtrack.jetbrains.com/issue/KT-48872