### PR TITLE
Update AGP 8.5.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-androidGradlePlugin = "8.5.1"
+androidGradlePlugin = "8.5.2"
 # For updating Kotlin and Compose Compiler version, see:
 # https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compatibility-and-versioning.html#jetpack-compose-and-compose-multiplatform-release-cycles
 # https://developer.android.com/jetpack/androidx/releases/compose-kotlin?#pre-release_kotlin_compatibility


### PR DESCRIPTION
## Issue
- no issue

## Overview (Required)
- Update to the latest patched version of Android Studio.
- Since this is a patched version, there are no additional migration items

## Links
- [Android Studio Koala | 2024.1.1 Patch 2 release note](https://androidstudio.googleblog.com/2024/08/android-studio-koala-202411-patch-2-now.html)