### PR TITLE
Add tests to verify DroidKaigi2024Day and the initially displayed timetable tab

### DIFF
--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -25,6 +25,11 @@ kotlin {
                 implementation(libs.androidxAppCompat)
             }
         }
+        commonTest {
+            dependencies {
+                implementation(libs.kotlinTest)
+            }
+        }
     }
 }
 

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/DroidKaigi2024Day.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/DroidKaigi2024Day.kt
@@ -2,62 +2,44 @@ package io.github.droidkaigi.confsched.model
 
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
-import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.atTime
 import kotlinx.datetime.toInstant
 
 public enum class DroidKaigi2024Day(
-    public val dayIndex: Int,
-    public val visibleForUsers: Boolean,
-    public val dayOfMonth: Int,
-    public val start: Instant,
-    public val end: Instant,
+    private val visibleForUsers: Boolean,
+    private val date: LocalDate,
 ) {
     // We are not using Workday sessions in the app
     Workday(
-        dayIndex = 0,
         visibleForUsers = false,
-        dayOfMonth = 11,
-        start = LocalDateTime
-            .parse("2024-09-11T00:00:00")
-            .toInstant(TimeZone.of("UTC+9")),
-        end = LocalDateTime
-            .parse("2024-09-11T23:59:59")
-            .toInstant(TimeZone.of("UTC+9")),
+        date = LocalDate(2024, 9, 11),
     ),
     ConferenceDay1(
-        dayIndex = 1,
         visibleForUsers = true,
-        dayOfMonth = 12,
-        start = LocalDateTime
-            .parse("2024-09-12T00:00:00")
-            .toInstant(TimeZone.of("UTC+9")),
-        end = LocalDateTime
-            .parse("2024-09-12T23:59:59")
-            .toInstant(TimeZone.of("UTC+9")),
+        date = LocalDate(2024, 9, 12),
     ),
     ConferenceDay2(
-        dayIndex = 2,
         visibleForUsers = true,
-        dayOfMonth = 13,
-        start = LocalDateTime
-            .parse("2024-09-13T00:00:00")
-            .toInstant(TimeZone.of("UTC+9")),
-        end = LocalDateTime
-            .parse("2024-09-13T23:59:59")
-            .toInstant(TimeZone.of("UTC+9")),
+        date = LocalDate(2024, 9, 13),
     ),
     ;
 
+    public val dayOfMonth: Int = date.dayOfMonth
+    public val start: Instant = date.atStartOfDayIn(tz)
+    public val end: Instant = date.atTime(23, 59, 59, 999_999_999).toInstant(tz)
+
     fun tabIndex(): Int {
         return entries
-            .sortedBy { it.dayIndex }
+            .sortedBy { it.ordinal }
             .filter { it.visibleForUsers }
             .indexOf(this)
     }
 
     fun monthAndDay(): String {
-        return "9/$dayOfMonth"
+        return "${date.monthNumber}/${date.dayOfMonth}"
     }
 
     public companion object {
@@ -75,7 +57,7 @@ public enum class DroidKaigi2024Day(
          * @return appropriate initial day for now
          */
         fun initialSelectedTabDay(clock: Clock): DroidKaigi2024Day {
-            val reversedEntries = visibleDays().sortedByDescending { it.dayIndex }
+            val reversedEntries = visibleDays().sortedByDescending { it.ordinal }
             var selectedDay = reversedEntries.last()
             for (entry in reversedEntries) {
                 if (clock.now() <= entry.end) selectedDay = entry
@@ -84,3 +66,5 @@ public enum class DroidKaigi2024Day(
         }
     }
 }
+
+private val tz = TimeZone.of("UTC+9")

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/Timetable.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/Timetable.kt
@@ -30,7 +30,7 @@ public data class Timetable(
     }
 
     val days: List<DroidKaigi2024Day> by lazy {
-        timetableItems.mapNotNull { it.day }.toSet().sortedBy { it.dayIndex }
+        timetableItems.mapNotNull { it.day }.toSet().sortedBy { it.ordinal }
     }
 
     val categories: List<TimetableCategory> by lazy {

--- a/core/model/src/commonTest/kotlin/io/github/droidkaigi/confsched/model/DroidKaigi2024DayTest.kt
+++ b/core/model/src/commonTest/kotlin/io/github/droidkaigi/confsched/model/DroidKaigi2024DayTest.kt
@@ -1,0 +1,129 @@
+package io.github.droidkaigi.confsched.model
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.atTime
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DroidKaigi2024DayOfOrNullTest {
+    @Test
+    fun `returns Workday on September 11 2024`() {
+        val workday = LocalDate(2024, 9, 11)
+
+        runTest(
+            expected = DroidKaigi2024Day.Workday,
+            workday.atStartOfDay(),
+            workday.at3pm(),
+            workday.atEndOfDay(),
+        )
+    }
+
+    @Test
+    fun `returns Day1 on September 12 2024`() {
+        val day1 = LocalDate(2024, 9, 12)
+
+        runTest(
+            expected = DroidKaigi2024Day.ConferenceDay1,
+            day1.atStartOfDay(),
+            day1.at3pm(),
+            day1.atEndOfDay(),
+        )
+    }
+
+    @Test
+    fun `returns Day2 on September 13 2024`() {
+        val day2 = LocalDate(2024, 9, 13)
+
+        runTest(
+            expected = DroidKaigi2024Day.ConferenceDay2,
+            day2.atStartOfDay(),
+            day2.at3pm(),
+            day2.atEndOfDay(),
+        )
+    }
+
+    @Test
+    fun `returns null outside the conference`() {
+        runTest(
+            expected = null,
+            LocalDate(2024, 8, 1).at3pm(),
+            LocalDate(2024, 9, 10).atEndOfDay(),
+            LocalDate(2024, 9, 14).atStartOfDay(),
+            LocalDate(2024, 12, 31).atEndOfDay(),
+        )
+    }
+
+    private fun runTest(expected: DroidKaigi2024Day?, vararg instants: Instant) {
+        instants.forEachIndexed { index, instant ->
+            val actual = DroidKaigi2024Day.ofOrNull(instant)
+
+            assertTimestamp(instant, expected, actual)
+        }
+    }
+}
+
+class DroidKaigi2024DayTestInitialSelectedTabDayTest {
+    @Test
+    fun `initialSelectedTabDay returns Day1 on any date except for the second conference day`() {
+        runTest(
+            expected = DroidKaigi2024Day.ConferenceDay1,
+            // Before the conference
+            LocalDate(2024, 8, 1).atStartOfDay(),
+            // Workday
+            LocalDate(2024, 9, 11).atStartOfDay(),
+            LocalDate(2024, 9, 11).atEndOfDay(),
+            // Day1
+            LocalDate(2024, 9, 12).atStartOfDay(),
+            LocalDate(2024, 9, 12).at3pm(),
+            LocalDate(2024, 9, 12).atEndOfDay(),
+            // After the conference
+            LocalDate(2024, 9, 14).atStartOfDay(),
+            LocalDate(2024, 9, 14).at3pm(),
+            LocalDate(2024, 9, 14).atEndOfDay(),
+            LocalDate(2024, 12, 31).atStartOfDay(),
+        )
+    }
+
+    @Test
+    fun `initialSelectedTabDay returns Day2 on the second conference day`() {
+        runTest(
+            expected = DroidKaigi2024Day.ConferenceDay2,
+            LocalDate(2024, 9, 13).atStartOfDay(),
+            LocalDate(2024, 9, 13).at3pm(),
+            LocalDate(2024, 9, 13).atEndOfDay(),
+        )
+    }
+
+    private fun runTest(expected: DroidKaigi2024Day, vararg instants: Instant) {
+        instants.forEachIndexed { index, instant ->
+            val clock = TestClock(instant)
+            val actual = DroidKaigi2024Day.initialSelectedTabDay(clock)
+
+            assertTimestamp(instant, expected, actual)
+        }
+    }
+
+    private class TestClock(private val instant: Instant) : Clock {
+        override fun now() = instant
+    }
+}
+
+private val tz = TimeZone.of("UTC+9")
+
+private fun LocalDate.atStartOfDay() = this.atStartOfDayIn(tz)
+private fun LocalDate.at3pm() = this.atTime(15, 0).toInstant(tz)
+private fun LocalDate.atEndOfDay() = this.atTime(23, 59, 59, 999_999_999).toInstant(tz)
+
+private fun assertTimestamp(instant: Instant, expected: Any?, actual: Any?) {
+    assertEquals(
+        expected = expected,
+        actual = actual,
+        message = "Expected $expected, but was $actual for timestamp: ${instant.toLocalDateTime(tz)}",
+    )
+}

--- a/core/model/src/commonTest/kotlin/io/github/droidkaigi/confsched/model/DroidKaigi2024DayTest.kt
+++ b/core/model/src/commonTest/kotlin/io/github/droidkaigi/confsched/model/DroidKaigi2024DayTest.kt
@@ -14,37 +14,37 @@ import kotlin.test.assertEquals
 class DroidKaigi2024DayOfOrNullTest {
     @Test
     fun `returns Workday on September 11 2024`() {
-        val workday = LocalDate(2024, 9, 11)
+        val date = LocalDate(2024, 9, 11)
 
         runTest(
             expected = DroidKaigi2024Day.Workday,
-            workday.atStartOfDay(),
-            workday.at3pm(),
-            workday.atEndOfDay(),
+            date.atStartOfDay(),
+            date.at3pm(),
+            date.atEndOfDay(),
         )
     }
 
     @Test
     fun `returns Day1 on September 12 2024`() {
-        val day1 = LocalDate(2024, 9, 12)
+        val date = LocalDate(2024, 9, 12)
 
         runTest(
             expected = DroidKaigi2024Day.ConferenceDay1,
-            day1.atStartOfDay(),
-            day1.at3pm(),
-            day1.atEndOfDay(),
+            date.atStartOfDay(),
+            date.at3pm(),
+            date.atEndOfDay(),
         )
     }
 
     @Test
     fun `returns Day2 on September 13 2024`() {
-        val day2 = LocalDate(2024, 9, 13)
+        val date = LocalDate(2024, 9, 13)
 
         runTest(
             expected = DroidKaigi2024Day.ConferenceDay2,
-            day2.atStartOfDay(),
-            day2.at3pm(),
-            day2.atEndOfDay(),
+            date.atStartOfDay(),
+            date.at3pm(),
+            date.atEndOfDay(),
         )
     }
 
@@ -68,7 +68,7 @@ class DroidKaigi2024DayOfOrNullTest {
     }
 }
 
-class DroidKaigi2024DayTestInitialSelectedTabDayTest {
+class DroidKaigi2024DayInitialSelectedTabDayTest {
     @Test
     fun `initialSelectedTabDay returns Day1 on any date except for the second conference day`() {
         runTest(

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/TimetableScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/TimetableScreenRobot.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isDisplayed
@@ -17,6 +18,7 @@ import com.github.takahirom.roborazzi.Dump
 import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.captureRoboImage
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
+import io.github.droidkaigi.confsched.model.DroidKaigi2024Day
 import io.github.droidkaigi.confsched.model.TimetableItem
 import io.github.droidkaigi.confsched.sessions.TimetableScreen
 import io.github.droidkaigi.confsched.sessions.TimetableScreenTestTag
@@ -30,6 +32,9 @@ import io.github.droidkaigi.confsched.ui.component.TimetableItemCardBookmarkedIc
 import io.github.droidkaigi.confsched.ui.component.TimetableItemCardTestTag
 import io.github.droidkaigi.confsched.ui.compositionlocal.FakeClock
 import io.github.droidkaigi.confsched.ui.compositionlocal.LocalClock
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
 import javax.inject.Inject
 
 class TimetableScreenRobot @Inject constructor(
@@ -39,9 +44,15 @@ class TimetableScreenRobot @Inject constructor(
     TimetableServerRobot by timetableServerRobot {
     val clickedItems = mutableSetOf<TimetableItem>()
 
-    fun setupTimetableScreenContent() {
+    fun setupTimetableScreenContent(customTime: LocalDateTime? = null) {
+        val fakeClock = if (customTime != null) {
+            FakeClock(customTime.toInstant(TimeZone.of("UTC+9")))
+        } else {
+            FakeClock
+        }
+
         robotTestRule.setContent {
-            CompositionLocalProvider(LocalClock provides FakeClock) {
+            CompositionLocalProvider(LocalClock provides fakeClock) {
                 KaigiTheme {
                     TimetableScreen(
                         onTimetableItemClick = {
@@ -106,6 +117,12 @@ class TimetableScreenRobot @Inject constructor(
         composeTestRule
             .onNode(hasTestTag(TimetableListTestTag))
             .assertIsDisplayed()
+    }
+
+    fun checkTimetableTabSelected(day: DroidKaigi2024Day) {
+        composeTestRule
+            .onNode(hasTestTag(TimetableTabTestTag.plus(day.ordinal)))
+            .assertIsSelected()
     }
 
     fun checkTimetableListItemsDisplayed() {

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/compositionlocal/LocalClock.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/compositionlocal/LocalClock.kt
@@ -9,6 +9,11 @@ val LocalClock = staticCompositionLocalOf<Clock> {
     Clock.System
 }
 
-object FakeClock : Clock {
-    override fun now(): Instant = Instant.parse("2023-09-14T10:00:00.000Z")
+val FakeClock: Clock = FakeClockImpl(Instant.parse("2023-09-14T10:00:00.000Z"))
+
+@Suppress("FunctionName")
+fun FakeClock(instant: Instant): Clock = FakeClockImpl(instant)
+
+private class FakeClockImpl(private val instant: Instant) : Clock {
+    override fun now(): Instant = instant
 }

--- a/feature/sessions/build.gradle.kts
+++ b/feature/sessions/build.gradle.kts
@@ -27,6 +27,7 @@ kotlin {
         }
         androidUnitTest {
             dependencies {
+                implementation(projects.core.model)
                 implementation(projects.core.testing)
             }
         }

--- a/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
+++ b/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
@@ -2,6 +2,7 @@ package io.github.droidkaigi.confsched.sessions
 
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
+import io.github.droidkaigi.confsched.model.DroidKaigi2024Day
 import io.github.droidkaigi.confsched.testing.DescribedBehavior
 import io.github.droidkaigi.confsched.testing.describeBehaviors
 import io.github.droidkaigi.confsched.testing.execute
@@ -9,6 +10,7 @@ import io.github.droidkaigi.confsched.testing.robot.TimetableScreenRobot
 import io.github.droidkaigi.confsched.testing.robot.TimetableServerRobot.ServerStatus
 import io.github.droidkaigi.confsched.testing.robot.runRobot
 import io.github.droidkaigi.confsched.testing.rules.RobotTestRule
+import kotlinx.datetime.LocalDateTime
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -46,6 +48,7 @@ class TimetableScreenTest(private val testCase: DescribedBehavior<TimetableScree
                         captureScreenWithChecks(checks = {
                             checkTimetableListDisplayed()
                             checkTimetableListItemsDisplayed()
+                            checkTimetableTabSelected(DroidKaigi2024Day.ConferenceDay1)
                         })
                     }
                     describe("click first session bookmark") {
@@ -116,6 +119,19 @@ class TimetableScreenTest(private val testCase: DescribedBehavior<TimetableScree
                                 })
                             }
                         }
+                    }
+                }
+                describe("when the current date is the second conference day") {
+                    run {
+                        setupTimetableServer(ServerStatus.Operational)
+                        setupTimetableScreenContent(LocalDateTime(2024, 9, 13, 10, 0))
+                    }
+                    itShould("show timetable items") {
+                        captureScreenWithChecks(checks = {
+                            checkTimetableListDisplayed()
+                            checkTimetableListItemsDisplayed()
+                            checkTimetableTabSelected(DroidKaigi2024Day.ConferenceDay2)
+                        })
                     }
                 }
                 describe("when server is down") {

--- a/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
+++ b/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
@@ -142,7 +142,7 @@ class TimetableScreenTest(private val testCase: DescribedBehavior<TimetableScree
                             setupTimetableServer(ServerStatus.Operational)
                             setupTimetableScreenContent(case.date.atTime(10, 0))
                         }
-                        itShould("show timetable items for ${case.expectedInitialTab.monthAndDay()}") {
+                        itShould("show timetable items for ${case.expectedInitialTab.name}") {
                             captureScreenWithChecks(checks = {
                                 checkTimetableListDisplayed()
                                 checkTimetableListItemsDisplayed()

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridTab.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridTab.kt
@@ -54,7 +54,7 @@ fun TimetableDayTab(
                 DroidKaigi2024Day.visibleDays().forEach { conferenceDay ->
                     Tab(
                         modifier = Modifier
-                            .testTag(TimetableTabTestTag.plus(conferenceDay.dayIndex))
+                            .testTag(TimetableTabTestTag.plus(conferenceDay.ordinal))
                             .height(64.dp),
                         selected = false,
                         onClick = {

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridTab.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridTab.kt
@@ -56,7 +56,7 @@ fun TimetableDayTab(
                         modifier = Modifier
                             .testTag(TimetableTabTestTag.plus(conferenceDay.ordinal))
                             .height(64.dp),
-                        selected = false,
+                        selected = conferenceDay == selectedDay,
                         onClick = {
                             onDaySelected(conferenceDay)
                         },

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableSheet.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableSheet.kt
@@ -119,9 +119,7 @@ fun Timetable(
 
 @Composable
 private fun rememberListTimetableScrollStates(): Map<DroidKaigi2024Day, LazyListState> {
-    val scrollStateMap = DroidKaigi2024Day.entries.filter {
-        it.visibleForUsers
-    }.associateWith {
+    val scrollStateMap = DroidKaigi2024Day.visibleDays().associateWith {
         rememberLazyListState()
     }
     return remember { scrollStateMap }
@@ -129,9 +127,7 @@ private fun rememberListTimetableScrollStates(): Map<DroidKaigi2024Day, LazyList
 
 @Composable
 private fun rememberGridTimetableStates(): Map<DroidKaigi2024Day, TimetableState> {
-    val timetableStateMap = DroidKaigi2024Day.entries.filter {
-        it.visibleForUsers
-    }.associateWith {
+    val timetableStateMap = DroidKaigi2024Day.visibleDays().associateWith {
         rememberTimetableGridState()
     }
     return remember { timetableStateMap }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -169,6 +169,7 @@ ossLicenses = { module = "com.google.android.gms:play-services-oss-licenses", ve
 junit = { module = "junit:junit", version.ref = "junit" }
 androidxTestExtJunit = { module = "androidx.test.ext:junit", version.ref = "androidxTestExt" }
 androidxTestEspressoEspressoCore = { module = "androidx.test.espresso:espresso-core", version.ref = "androidxTestEspresso" }
+kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 robolectric = { module = "org.robolectric:robolectric", version = "4.13" }
 roborazzi = { module = "io.github.takahirom.roborazzi:roborazzi", version.ref = "roborazzi" }
 roborazziCompose = { module = "io.github.takahirom.roborazzi:roborazzi-compose", version.ref = "roborazzi" }


### PR DESCRIPTION
## Issue
- close #463 

## Overview (Required)
- Add unit tests for DroidKaigi2024Day:
  Introduce `kotlin-test` to allow for multiplatform unit tests of logic that doesn't require any UI components
- Simplify DroidKaigi2024Day enum and fix end-of-day logic:
  The current declaration makes the day "end" at 23:59:59, but in the last second the behavior would've been undefined. 
 Declare the end time explicitly with 999_999_999 nanoseconds to cover the entirety of each day
- Extend fake clock capabilities & add robot test for the second day, too:
  This required a change in how the tabs store their selection state (not sure why it was hardcoded at `selected = false` before...)

## Links
- -/-

## Screenshot (Optional if screenshot test is present or unrelated to UI)

<img width="500" alt="Screenshot 2024-08-15 at 20 31 55" src="https://github.com/user-attachments/assets/055980c2-948d-42d5-8be0-0d3bf8f03387">
