### PR TITLE
Impl bottom floating material glassed tabbar in iOS

### DIFF
--- a/app-ios/Sources/AboutFeature/AboutView.swift
+++ b/app-ios/Sources/AboutFeature/AboutView.swift
@@ -206,6 +206,8 @@ public struct AboutView: View {
                     .padding(.bottom, 16)
             }
             .padding(.horizontal, 16)
+            // bottom floating tabbar padding
+            Color.clear.padding(.bottom, 60)
         }
         .background(AssetColors.Surface.surface.swiftUIColor)
     }

--- a/app-ios/Sources/App/RootReducer.swift
+++ b/app-ios/Sources/App/RootReducer.swift
@@ -66,7 +66,6 @@ public struct RootReducer {
         case timetable(TimetableReducer.Action)
         case favorite(FavoriteReducer.Action)
         case about(AboutReducer.Action)
-        case view(View)
         case paths(Paths)
 
         @CasePathable
@@ -74,10 +73,6 @@ public struct RootReducer {
             case timetable(StackActionOf<RootReducer.Path.Timetable>)
             case favorite(StackActionOf<RootReducer.Path.Favorite>)
             case about(StackActionOf<RootReducer.Path.About>)
-        }
-        
-        public enum View {
-            case sameTabTapped(DroidKaigiAppTab)
         }
     }
 
@@ -142,17 +137,6 @@ public struct RootReducer {
                     )
                     return .none
                 }
-                
-            case let .view(.sameTabTapped(tab)):
-                switch tab {
-                case .timetable: state.paths.timetable.removeAll()
-                case .favorite: state.paths.favorite.removeAll()
-                case .about: state.paths.about.removeAll()
-                case .map: break
-                case .idCard: break
-                }
-                
-                return .none
                 
             default:
                 return .none

--- a/app-ios/Sources/EventMapFeature/EventMapView.swift
+++ b/app-ios/Sources/EventMapFeature/EventMapView.swift
@@ -37,6 +37,8 @@ public struct EventMapView: View {
                     EventItem(event: event)
                 }
             }
+            // bottom floating tabbar padding
+            Color.clear.padding(.bottom, 60)
         }
         .background(AssetColors.Surface.surface.swiftUIColor)
         .navigationBarTitleDisplayMode(.large)

--- a/app-ios/Sources/FavoriteFeature/FavoriteView.swift
+++ b/app-ios/Sources/FavoriteFeature/FavoriteView.swift
@@ -37,6 +37,8 @@ public struct FavoriteView: View {
                             }
                         }
                         .padding(.horizontal, 16)
+                        // bottom floating tabbar padding
+                        Color.clear.padding(.bottom, 60)
                     }
                 }
             }

--- a/app-ios/Sources/StaffFeature/StaffView.swift
+++ b/app-ios/Sources/StaffFeature/StaffView.swift
@@ -24,6 +24,8 @@ public struct StaffView: View {
                 }
             }
             .padding(16)
+            // bottom floating tabbar padding
+            Color.clear.padding(.bottom, 60)
         }
         .background(AssetColors.Surface.surface.swiftUIColor)
         .onAppear {

--- a/app-ios/Sources/StaffFeature/StaffView.swift
+++ b/app-ios/Sources/StaffFeature/StaffView.swift
@@ -24,8 +24,6 @@ public struct StaffView: View {
                 }
             }
             .padding(16)
-            // bottom floating tabbar padding
-            Color.clear.padding(.bottom, 60)
         }
         .background(AssetColors.Surface.surface.swiftUIColor)
         .onAppear {

--- a/app-ios/Sources/TimetableFeature/TimetableListView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableListView.swift
@@ -103,6 +103,8 @@ struct TimetableListView: View {
             .onAppear {
                 store.send(.view(.onAppear))
             }.background(AssetColors.Surface.surface.swiftUIColor)
+            // bottom floating tabbar padding
+            Color.clear.padding(.bottom, 60)
         }
     }
 }


### PR DESCRIPTION
## Issue
- close #428

## Overview (Required)
- Replace native tabbar to custom floating tabbar
    - Background is clipped by iOS systemMaterial glass.
- I'm not sure how far we could go with the design in iOS, so I addressed the UI first.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Android | Before | After
:--: | :--: | :--:
![image](https://github.com/user-attachments/assets/ae9096f5-c586-4627-94a5-6fd06f4b8fe3) | <img width="368" alt="356984404-716d909e-f906-4673-ad1d-7b10ef19c38a" src="https://github.com/user-attachments/assets/1f758aba-8b96-4b3f-bccb-35f33e319756"> | ![Simulator Screenshot - iPhone 15 Pro - 2024-08-15 at 20 37 41](https://github.com/user-attachments/assets/44d05744-780c-4ad0-a38a-cef237219250)


## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >

https://github.com/user-attachments/assets/167039eb-c0b5-418b-a228-2f621fbb7ea4




