### PR TITLE
Typo in the about screen title

### DIFF
--- a/feature/about/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/about/src/commonMain/composeResources/values-ja/strings.xml
@@ -15,7 +15,7 @@
     <string name="license">ライセンス</string>
     <string name="privacy_policy">プライバシーポリシー</string>
     <string name="app_version">アプリバージョン</string>
-    <string name="about-droidkaigi">Droidkaigiについて</string>
+    <string name="about-droidkaigi">DroidKaigiについて</string>
     <string name="content_description_youtube">YouTube</string>
     <string name="content_description_x">X</string>
     <string name="content_description_medium">Medium</string>


### PR DESCRIPTION
## Issue
- nothing

## Overview (Required)
- I fixed a typo in the title of the about screen.
  - Droidkaigi → Droid「K」aigi

## Links
- nothing

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
![Screenshot_20240815_221309](https://github.com/user-attachments/assets/2f652ac8-d2d8-4fe8-b22e-3009811d3208) | ![Screenshot_20240815_220825](https://github.com/user-attachments/assets/6459e929-9f9f-4538-bb92-ea8e4ad60d15)
