### PR TITLE
Fixed DroidKaigi typo

### DIFF
--- a/feature/about/src/commonMain/composeResources/values/strings.xml
+++ b/feature/about/src/commonMain/composeResources/values/strings.xml
@@ -15,7 +15,7 @@
     <string name="license">License</string>
     <string name="privacy_policy">Privacy Policy</string>
     <string name="app_version">App Version</string>
-    <string name="about_droidkaigi">About Droidkaigi</string>
+    <string name="about_droidkaigi">About DroidKaigi</string>
     <string name="content_description_youtube">YouTube</string>
     <string name="content_description_x">X</string>
     <string name="content_description_medium">Medium</string>


### PR DESCRIPTION
## Issue
- nothing

## Overview (Required)
- I fixed a typo in the English version “About screen”
- I fixed the missing items in "#487".

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/c3c2e683-d5ae-4084-afe7-c017a825ae53" width="300" /> | <img src="https://github.com/user-attachments/assets/d5fa5da8-0735-4c5e-988a-01410ccdf830" width="300" />