### PR TITLE
Translate timetable title into Japanese

### DIFF
--- a/app-ios/Sources/TimetableFeature/Resource/Localizable.xcstrings
+++ b/app-ios/Sources/TimetableFeature/Resource/Localizable.xcstrings
@@ -18,7 +18,14 @@
 
     },
     "Timetable" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイムテーブル"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/app-ios/Sources/TimetableFeature/TimetableListView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableListView.swift
@@ -46,7 +46,7 @@ public struct TimetableView: View {
         .frame(maxWidth: .infinity)
         .toolbar{
             ToolbarItem(placement: .topBarLeading) {
-                Text("Timetable")
+                Text("Timetable", bundle: .module)
                     .textStyle(.headlineMedium)
                     .foregroundStyle(AssetColors.Surface.onSurface.swiftUIColor)
                 


### PR DESCRIPTION
## Issue
- close #447

## Overview (Required)
- Fix timetable title to allow translation into Japanese

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
English | 日本語
:--: | :--:
<img src="https://github.com/user-attachments/assets/8efa7da1-3b30-4dc8-a76c-18bdb2e28e65" width="300" /> | <img src="https://github.com/user-attachments/assets/04b69d02-f9e1-4e09-b29f-98a563791612" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
