### PR TITLE
 In TimetableItemDetailScreen, add animations to DescriptionSection

### DIFF
--- a/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/component/ClickableLinkText.kt
+++ b/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/component/ClickableLinkText.kt
@@ -1,5 +1,7 @@
 package io.github.droidkaigi.confsched.designsystem.component
 
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -19,6 +21,8 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+
+private const val ClickableTextExpandAnimateDurationMillis = 1000
 
 @Composable
 private fun findResults(
@@ -118,9 +122,11 @@ fun ClickableLinkText(
     }
 
     ClickableText(
-        modifier = modifier.onGloballyPositioned { coordinates ->
-            layoutResult.value = coordinates
-        },
+        modifier = modifier
+            .animateContentSize(animationSpec = tween(ClickableTextExpandAnimateDurationMillis))
+            .onGloballyPositioned { coordinates ->
+                layoutResult.value = coordinates
+            },
         text = annotatedString,
         style = style,
         overflow = overflow,

--- a/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/component/ClickableLinkText.kt
+++ b/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/component/ClickableLinkText.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched.designsystem.component
 
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.EaseInQuart
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.MaterialTheme
@@ -22,7 +23,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 
-private const val ClickableTextExpandAnimateDurationMillis = 1000
+private const val ClickableTextExpandAnimateDurationMillis = 300
 
 @Composable
 private fun findResults(
@@ -123,7 +124,9 @@ fun ClickableLinkText(
 
     ClickableText(
         modifier = modifier
-            .animateContentSize(animationSpec = tween(ClickableTextExpandAnimateDurationMillis))
+            .animateContentSize(
+                animationSpec = tween(ClickableTextExpandAnimateDurationMillis, easing = EaseInQuart),
+            )
             .onGloballyPositioned { coordinates ->
                 layoutResult.value = coordinates
             },

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailContent.kt
@@ -1,5 +1,8 @@
 package io.github.droidkaigi.confsched.sessions.component
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -115,7 +118,11 @@ private fun DescriptionSection(
             overflow = if (isExpand) TextOverflow.Clip else TextOverflow.Ellipsis,
         )
         Spacer(Modifier.height(16.dp))
-        if (isExpand.not()) {
+        AnimatedVisibility(
+            visible = isExpand.not(),
+            enter = EnterTransition.None,
+            exit = fadeOut(),
+        ) {
             OutlinedButton(
                 modifier = Modifier.fillMaxWidth(),
                 onClick = { isExpand = true },


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- In the DescriptionSection, I thought it would be even better if the More button had an animation instead of just switching quickly.
- `ClickableTextExpandAnimateDurationMillis = 1000` may be a bit long, but I set it because I thought it would be richer UI and not disturb the user.



## Movie
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/91f3b2ce-34a6-4a90-8c90-1065dbfcee6f" width="300" > | <video src="https://github.com/user-attachments/assets/61b69787-a17d-480a-98a4-e75fa9e58926" width="300" >

#### After and 5x slowed

https://github.com/user-attachments/assets/da33a610-9289-48c5-a3f2-a9b46df8f073

