### PR TITLE
Use UI state in profile edit screen

### DIFF
--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/ProfileCard.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/ProfileCard.kt
@@ -1,5 +1,8 @@
 package io.github.droidkaigi.confsched.model
 
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
 sealed interface ProfileCard {
     data object Loading : ProfileCard
 
@@ -12,6 +15,33 @@ sealed interface ProfileCard {
         val image: String?,
         val theme: ProfileCardTheme,
     ) : ProfileCard
+}
+
+data class ImageData internal constructor(
+    val image: String,
+    val imageBase64: ByteArray,
+) {
+    constructor(image: String) : this(image, image.decodeBase64Bytes())
+    constructor(imageBase64: ByteArray) : this(imageBase64.toBase64(), imageBase64)
+
+    private val imageHash: Int = imageBase64.contentHashCode()
+
+    override fun equals(other: Any?): Boolean {
+        return this === other
+            || other is ImageData && imageHash == other.imageHash
+    }
+
+    override fun hashCode(): Int {
+        return imageHash
+    }
+
+    companion object {
+        @OptIn(ExperimentalEncodingApi::class)
+        private fun ByteArray.toBase64(): String = Base64.encode(this)
+
+        @OptIn(ExperimentalEncodingApi::class)
+        private fun String.decodeBase64Bytes(): ByteArray = Base64.decode(this)
+    }
 }
 
 enum class ProfileCardTheme {

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -204,6 +204,9 @@ internal fun ProfileCardScreen(
             ProfileCardUiType.Edit -> {
                 EditScreen(
                     uiState = uiState.editUiState,
+                    onUpdateEditingState = {
+                        eventEmitter.tryEmit(EditScreenEvent.Update(it))
+                    },
                     onClickCreate = {
                         eventEmitter.tryEmit(EditScreenEvent.Create(it))
                     },
@@ -241,6 +244,7 @@ internal fun ProfileCardScreen(
 @Composable
 internal fun EditScreen(
     uiState: ProfileCardUiState.Edit,
+    onUpdateEditingState: (ProfileCardUiState.Edit) -> Unit,
     onClickCreate: (ProfileCard.Exists) -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -94,7 +94,7 @@ import org.jetbrains.compose.resources.stringResource
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
-const val profileCardScreenRoute = "profilecard"
+const val profileCardScreenRoute = "profileCard"
 
 const val ProfileCardEditScreenTestTag = "ProfileCardEditScreenTestTag"
 const val ProfileCardNicknameTextFieldTestTag = "ProfileCardNicknameTextFieldTestTag"

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -83,6 +83,7 @@ import io.github.droidkaigi.confsched.compose.EventEmitter
 import io.github.droidkaigi.confsched.compose.rememberEventEmitter
 import io.github.droidkaigi.confsched.designsystem.theme.LocalProfileCardScreenTheme
 import io.github.droidkaigi.confsched.designsystem.theme.ProvideProfileCardScreenTheme
+import io.github.droidkaigi.confsched.model.ImageData
 import io.github.droidkaigi.confsched.model.ProfileCard
 import io.github.droidkaigi.confsched.model.ProfileCardTheme
 import io.github.droidkaigi.confsched.profilecard.component.PhotoPickerButton
@@ -126,7 +127,7 @@ internal sealed interface ProfileCardUiState {
         val nickname: String = "",
         val occupation: String? = null,
         val link: String? = null,
-        val image: String? = null,
+        val imageData: ImageData? = null,
         val theme: ProfileCardTheme = ProfileCardTheme.entries.first(),
     ) : ProfileCardUiState
 

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import io.github.droidkaigi.confsched.compose.SafeLaunchedEffect
+import io.github.droidkaigi.confsched.model.ImageData
 import io.github.droidkaigi.confsched.model.ProfileCard
 import io.github.droidkaigi.confsched.model.ProfileCardRepository
 import io.github.droidkaigi.confsched.model.localProfileCardRepository
@@ -31,7 +32,7 @@ private fun ProfileCard.toEditUiState(): ProfileCardUiState.Edit {
             nickname = nickname,
             occupation = occupation,
             link = link,
-            image = image,
+            imageData = image?.run(::ImageData),
             theme = theme,
         )
         ProfileCard.DoesNotExists, ProfileCard.Loading -> ProfileCardUiState.Edit()

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
@@ -12,6 +12,7 @@ import io.github.droidkaigi.confsched.model.ProfileCard
 import io.github.droidkaigi.confsched.model.ProfileCardRepository
 import io.github.droidkaigi.confsched.model.localProfileCardRepository
 import io.github.droidkaigi.confsched.ui.providePresenterDefaults
+import io.github.takahirom.rin.rememberRetained
 import kotlinx.coroutines.flow.Flow
 
 internal sealed interface ProfileCardScreenEvent
@@ -59,7 +60,8 @@ internal fun profileCardScreenPresenter(
 ): ProfileCardScreenState = providePresenterDefaults { userMessageStateHolder ->
     val profileCard: ProfileCard by rememberUpdatedState(repository.profileCard())
     var isLoading: Boolean by remember { mutableStateOf(false) }
-    val editUiState: ProfileCardUiState.Edit by rememberUpdatedState(profileCard.toEditUiState())
+    var editingUiState: ProfileCardUiState.Edit? by rememberRetained { mutableStateOf(null) }
+    val editUiState: ProfileCardUiState.Edit by rememberUpdatedState(editingUiState ?: profileCard.toEditUiState())
     val cardUiState: ProfileCardUiState.Card? by rememberUpdatedState(profileCard.toCardUiState())
     var uiType: ProfileCardUiType by remember { mutableStateOf(ProfileCardUiType.Loading) }
 

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
@@ -19,6 +19,7 @@ internal sealed interface ProfileCardScreenEvent
 
 internal sealed interface EditScreenEvent : ProfileCardScreenEvent {
     data object SelectImage : EditScreenEvent
+    data class Update(val editUiState: ProfileCardUiState.Edit) : EditScreenEvent
     data class Create(val profileCard: ProfileCard.Exists) : EditScreenEvent
 }
 
@@ -85,6 +86,10 @@ internal fun profileCardScreenPresenter(
 
                 CardScreenEvent.Share -> {
                     userMessageStateHolder.showMessage("Share Profile Card")
+                }
+
+                is EditScreenEvent.Update -> {
+                    editingUiState = it.editUiState
                 }
 
                 is EditScreenEvent.Create -> {


### PR DESCRIPTION
## Issue
- close [#ISSUE_NUMBER](https://github.com/DroidKaigi/conference-app-2024/issues/490)

## Overview (Required)
- Create a data class to effectively diff compare stored image data.
- Use Presenter data and events in profile editing screen.
- Fix typo warning.
