### PR TITLE
Use app version from BuildConfigProvider at AboutScreen

### DIFF
--- a/core/data/src/androidMain/kotlin/io/github/droidkaigi/confsched/data/about/AboutRepositoryModule.kt
+++ b/core/data/src/androidMain/kotlin/io/github/droidkaigi/confsched/data/about/AboutRepositoryModule.kt
@@ -1,0 +1,35 @@
+package io.github.droidkaigi.confsched.data.about
+
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.ClassKey
+import dagger.multibindings.IntoMap
+import io.github.droidkaigi.confsched.data.di.RepositoryQualifier
+import io.github.droidkaigi.confsched.model.AboutRepository
+import io.github.droidkaigi.confsched.model.BuildConfigProvider
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+public abstract class AboutRepositoryModule {
+    @Binds
+    @RepositoryQualifier
+    @IntoMap
+    @ClassKey(AboutRepository::class)
+    public abstract fun bind(repository: DefaultAboutRepository): Any
+
+    public companion object {
+        @Provides
+        @Singleton
+        public fun provideAboutRepository(
+            buildConfigProvider: BuildConfigProvider,
+        ): AboutRepository {
+            return DefaultAboutRepository(
+                buildConfigProvider = buildConfigProvider,
+            )
+        }
+    }
+}

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/about/DefaultAboutRepository.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/about/DefaultAboutRepository.kt
@@ -1,0 +1,15 @@
+package io.github.droidkaigi.confsched.data.about
+
+import androidx.compose.runtime.Composable
+import io.github.droidkaigi.confsched.model.AboutRepository
+import io.github.droidkaigi.confsched.model.BuildConfigProvider
+import io.github.droidkaigi.confsched.ui.Inject
+
+public class DefaultAboutRepository @Inject constructor(
+    private val buildConfigProvider: BuildConfigProvider,
+) : AboutRepository {
+    @Composable
+    override fun versionName(): String {
+        return buildConfigProvider.versionName
+    }
+}

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/AboutRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/AboutRepository.kt
@@ -1,0 +1,14 @@
+package io.github.droidkaigi.confsched.model
+
+import androidx.compose.runtime.Composable
+import io.github.droidkaigi.confsched.model.compositionlocal.LocalRepositories
+
+interface AboutRepository {
+    @Composable
+    fun versionName(): String
+}
+
+@Composable
+fun localAboutRepository(): AboutRepository {
+    return LocalRepositories.current[AboutRepository::class] as AboutRepository
+}

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/AboutScreen.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/AboutScreen.kt
@@ -59,6 +59,10 @@ fun NavController.navigateAboutScreen() {
     }
 }
 
+data class AboutUiState(
+    val versionName: String,
+)
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AboutScreen(
@@ -66,6 +70,7 @@ fun AboutScreen(
     contentPadding: PaddingValues = PaddingValues(),
     onAboutItemClick: (AboutItem) -> Unit,
 ) {
+    val uiState = aboutScreenPresenter()
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
     val snackbarHostState = remember { SnackbarHostState() }
     val layoutDirection = LocalLayoutDirection.current
@@ -124,7 +129,7 @@ fun AboutScreen(
             )
             item {
                 AboutFooterLinks(
-                    versionName = "0.1.0",
+                    versionName = uiState.versionName,
                     onYouTubeClick = {
                         onAboutItemClick(YouTube)
                     },

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/AboutScreenPresenter.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/AboutScreenPresenter.kt
@@ -1,0 +1,15 @@
+package io.github.droidkaigi.confsched.about
+
+import androidx.compose.runtime.Composable
+import io.github.droidkaigi.confsched.model.AboutRepository
+import io.github.droidkaigi.confsched.model.localAboutRepository
+import io.github.droidkaigi.confsched.ui.providePresenterDefaults
+
+@Composable
+fun aboutScreenPresenter(
+    aboutRepository: AboutRepository = localAboutRepository(),
+): AboutUiState = providePresenterDefaults { _ ->
+    AboutUiState(
+        versionName = aboutRepository.versionName(),
+    )
+}


### PR DESCRIPTION
## Issue
- close #484 

## Overview (Required)
- Make `AboutUiState`, `AboutScreenPresenter` and `AboutRepository` to get app version from buildConfigProvider

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Nothing

## Movie (Optional)
Nothing
