### PR TITLE
Move error logic to presenter about Card Editing

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -72,9 +72,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.preat.peekaboo.image.picker.toImageBitmap
 import conference_app_2024.feature.profilecard.generated.resources.add_image
-import conference_app_2024.feature.profilecard.generated.resources.add_validate_format
 import conference_app_2024.feature.profilecard.generated.resources.create_card
-import conference_app_2024.feature.profilecard.generated.resources.enter_validate_format
 import conference_app_2024.feature.profilecard.generated.resources.icon_share
 import conference_app_2024.feature.profilecard.generated.resources.image
 import conference_app_2024.feature.profilecard.generated.resources.link
@@ -147,6 +145,13 @@ internal sealed interface ProfileCardUiState {
     ) : ProfileCardUiState
 }
 
+internal data class ProfileCardError(
+    val nicknameError: String = "",
+    val occupationError: String = "",
+    val linkError: String = "",
+    val imageError: String = "",
+)
+
 internal enum class ProfileCardUiType {
     Loading,
     Edit,
@@ -157,6 +162,7 @@ internal data class ProfileCardScreenState(
     val isLoading: Boolean,
     val editUiState: ProfileCardUiState.Edit,
     val cardUiState: ProfileCardUiState.Card?,
+    val cardError: ProfileCardError,
     val uiType: ProfileCardUiType,
     val userMessageStateHolder: UserMessageStateHolder,
 )
@@ -211,6 +217,19 @@ internal fun ProfileCardScreen(
             ProfileCardUiType.Edit -> {
                 EditScreen(
                     uiState = uiState.editUiState,
+                    profileCardError = uiState.cardError,
+                    onChangeNickname = {
+                        eventEmitter.tryEmit(EditScreenEvent.OnChangeNickname(it))
+                    },
+                    onChangeOccupation = {
+                        eventEmitter.tryEmit(EditScreenEvent.OnChangeOccupation(it))
+                    },
+                    onChangeLink = {
+                        eventEmitter.tryEmit(EditScreenEvent.OnChangeLink(it))
+                    },
+                    onChangeImage = {
+                        eventEmitter.tryEmit(EditScreenEvent.OnChangeImage(it))
+                    },
                     onClickCreate = {
                         eventEmitter.tryEmit(EditScreenEvent.Create(it))
                     },
@@ -248,6 +267,11 @@ internal fun ProfileCardScreen(
 @Composable
 internal fun EditScreen(
     uiState: ProfileCardUiState.Edit,
+    profileCardError: ProfileCardError,
+    onChangeNickname: (String) -> Unit,
+    onChangeOccupation: (String) -> Unit,
+    onChangeLink: (String) -> Unit,
+    onChangeImage: (String) -> Unit,
     onClickCreate: (ProfileCard.Exists) -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
@@ -260,13 +284,6 @@ internal fun EditScreen(
     var imageByteArray: ByteArray? by remember { mutableStateOf(uiState.image?.decodeBase64Bytes()) }
     val image by remember { derivedStateOf { imageByteArray?.toImageBitmap() } }
     var selectedTheme by remember { mutableStateOf(uiState.theme) }
-
-    val (nicknameError, occupationError, linkError, imageError) = rememberValidationErrors(
-        nickname,
-        occupation,
-        link,
-        image,
-    )
 
     val isValidInputs by remember {
         derivedStateOf {
@@ -298,25 +315,34 @@ internal fun EditScreen(
             InputFieldWithError(
                 value = nickname,
                 labelString = stringResource(ProfileCardRes.string.nickname),
-                errorMessage = nicknameError,
+                errorMessage = profileCardError.nicknameError,
                 textFieldTestTag = ProfileCardNicknameTextFieldTestTag,
-                onValueChange = { nickname = it },
+                onValueChange = {
+                    nickname = it
+                    onChangeNickname(it)
+                },
             )
             InputFieldWithError(
                 value = occupation,
                 labelString = stringResource(ProfileCardRes.string.occupation),
-                errorMessage = occupationError,
+                errorMessage = profileCardError.occupationError,
                 textFieldTestTag = ProfileCardOccupationTextFieldTestTag,
-                onValueChange = { occupation = it },
+                onValueChange = {
+                    occupation = it
+                    onChangeOccupation(it)
+                },
             )
             val linkLabel = stringResource(ProfileCardRes.string.link)
                 .plus(stringResource(ProfileCardRes.string.link_example_text))
             InputFieldWithError(
                 value = link,
                 labelString = linkLabel,
-                errorMessage = linkError,
+                errorMessage = profileCardError.linkError,
                 textFieldTestTag = ProfileCardLinkTextFieldTestTag,
-                onValueChange = { link = it },
+                onValueChange = {
+                    link = it
+                    onChangeLink(it)
+                },
             )
 
             Column(
@@ -325,9 +351,15 @@ internal fun EditScreen(
                 Label(label = stringResource(ProfileCardRes.string.image))
                 ImagePickerWithError(
                     image = image,
-                    onSelectedImage = { imageByteArray = it },
-                    errorMessage = imageError,
-                    onClearImage = { imageByteArray = null },
+                    onSelectedImage = {
+                        imageByteArray = it
+                        onChangeImage(it.toBase64())
+                    },
+                    errorMessage = profileCardError.imageError,
+                    onClearImage = {
+                        imageByteArray = null
+                        onChangeImage("")
+                    },
                 )
 
                 Text(stringResource(ProfileCardRes.string.select_theme))
@@ -373,39 +405,6 @@ internal fun Label(label: String) {
         text = label,
         style = MaterialTheme.typography.titleMedium,
     )
-}
-
-@Composable
-private fun rememberValidationErrors(
-    nickname: String,
-    occupation: String,
-    link: String,
-    image: ImageBitmap?,
-): List<String> {
-    val nicknameValidationErrorString = stringResource(
-        ProfileCardRes.string.enter_validate_format,
-        stringResource(ProfileCardRes.string.nickname),
-    )
-    val occupationValidationErrorString = stringResource(
-        ProfileCardRes.string.enter_validate_format,
-        stringResource(ProfileCardRes.string.occupation),
-    )
-    val linkValidationErrorString = stringResource(
-        ProfileCardRes.string.enter_validate_format,
-        stringResource(ProfileCardRes.string.link),
-    )
-    val imageValidationErrorString = stringResource(
-        ProfileCardRes.string.add_validate_format,
-        stringResource(ProfileCardRes.string.image),
-    )
-
-    return remember(nickname, occupation, link, image) {
-        val nicknameError = if (nickname.isEmpty()) nicknameValidationErrorString else ""
-        val occupationError = if (occupation.isEmpty()) occupationValidationErrorString else ""
-        val linkError = if (link.isEmpty()) linkValidationErrorString else ""
-        val imageError = if (image == null) imageValidationErrorString else ""
-        listOf(nicknameError, occupationError, linkError, imageError)
-    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
@@ -6,16 +6,40 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import conference_app_2024.feature.profilecard.generated.resources.add_validate_format
+import conference_app_2024.feature.profilecard.generated.resources.enter_validate_format
+import conference_app_2024.feature.profilecard.generated.resources.image
+import conference_app_2024.feature.profilecard.generated.resources.link
+import conference_app_2024.feature.profilecard.generated.resources.nickname
+import conference_app_2024.feature.profilecard.generated.resources.occupation
 import io.github.droidkaigi.confsched.compose.SafeLaunchedEffect
 import io.github.droidkaigi.confsched.model.ProfileCard
 import io.github.droidkaigi.confsched.model.ProfileCardRepository
 import io.github.droidkaigi.confsched.model.localProfileCardRepository
+import io.github.droidkaigi.confsched.profilecard.ProfileCardUiType.Card
 import io.github.droidkaigi.confsched.ui.providePresenterDefaults
 import kotlinx.coroutines.flow.Flow
+import org.jetbrains.compose.resources.stringResource
 
 internal sealed interface ProfileCardScreenEvent
 
 internal sealed interface EditScreenEvent : ProfileCardScreenEvent {
+    data class OnChangeNickname(
+        val nickname: String,
+    ) : EditScreenEvent
+
+    data class OnChangeOccupation(
+        val occupation: String,
+    ) : EditScreenEvent
+
+    data class OnChangeLink(
+        val link: String,
+    ) : EditScreenEvent
+
+    data class OnChangeImage(
+        val image: String,
+    ) : EditScreenEvent
+
     data object SelectImage : EditScreenEvent
     data class Create(val profileCard: ProfileCard.Exists) : EditScreenEvent
 }
@@ -34,6 +58,7 @@ private fun ProfileCard.toEditUiState(): ProfileCardUiState.Edit {
             image = image,
             theme = theme,
         )
+
         ProfileCard.DoesNotExists, ProfileCard.Loading -> ProfileCardUiState.Edit()
     }
 }
@@ -47,6 +72,7 @@ private fun ProfileCard.toCardUiState(): ProfileCardUiState.Card? {
             image = image,
             theme = theme,
         )
+
         ProfileCard.DoesNotExists, ProfileCard.Loading -> null
     }
 }
@@ -56,10 +82,28 @@ internal fun profileCardScreenPresenter(
     events: Flow<ProfileCardScreenEvent>,
     repository: ProfileCardRepository = localProfileCardRepository(),
 ): ProfileCardScreenState = providePresenterDefaults { userMessageStateHolder ->
+    val nicknameValidationErrorString = stringResource(
+        ProfileCardRes.string.enter_validate_format,
+        stringResource(ProfileCardRes.string.nickname),
+    )
+    val occupationValidationErrorString = stringResource(
+        ProfileCardRes.string.enter_validate_format,
+        stringResource(ProfileCardRes.string.occupation),
+    )
+    val linkValidationErrorString = stringResource(
+        ProfileCardRes.string.enter_validate_format,
+        stringResource(ProfileCardRes.string.link),
+    )
+    val imageValidationErrorString = stringResource(
+        ProfileCardRes.string.add_validate_format,
+        stringResource(ProfileCardRes.string.image),
+    )
+
     val profileCard: ProfileCard by rememberUpdatedState(repository.profileCard())
     var isLoading: Boolean by remember { mutableStateOf(false) }
     val editUiState: ProfileCardUiState.Edit by rememberUpdatedState(profileCard.toEditUiState())
     val cardUiState: ProfileCardUiState.Card? by rememberUpdatedState(profileCard.toCardUiState())
+    var cardError by remember { mutableStateOf(ProfileCardError()) }
     var uiType: ProfileCardUiType by remember { mutableStateOf(ProfileCardUiType.Loading) }
 
     // at first launch, if you have a profile card, show card ui
@@ -72,29 +116,59 @@ internal fun profileCardScreenPresenter(
     }
 
     SafeLaunchedEffect(Unit) {
-        events.collect {
-            isLoading = true
-            when (it) {
-                CardScreenEvent.Edit -> {
+        events.collect { event ->
+            when (event) {
+                is CardScreenEvent.Edit -> {
+                    isLoading = true
                     userMessageStateHolder.showMessage("Edit")
                     uiType = ProfileCardUiType.Edit
+                    isLoading = false
                 }
 
-                CardScreenEvent.Share -> {
+                is CardScreenEvent.Share -> {
+                    isLoading = true
                     userMessageStateHolder.showMessage("Share Profile Card")
+                    isLoading = false
                 }
 
                 is EditScreenEvent.Create -> {
+                    isLoading = true
                     userMessageStateHolder.showMessage("Create Profile Card")
-                    repository.save(it.profileCard)
-                    uiType = ProfileCardUiType.Card
+                    repository.save(event.profileCard)
+                    uiType = Card
+                    isLoading = false
                 }
 
-                EditScreenEvent.SelectImage -> {
+                is EditScreenEvent.SelectImage -> {
+                    isLoading = true
                     userMessageStateHolder.showMessage("Select Image")
+                    isLoading = false
+                }
+
+                is EditScreenEvent.OnChangeNickname -> {
+                    cardError = cardError.copy(
+                        nicknameError = if (event.nickname.isEmpty()) nicknameValidationErrorString else "",
+                    )
+                }
+
+                is EditScreenEvent.OnChangeOccupation -> {
+                    cardError = cardError.copy(
+                        occupationError = if (event.occupation.isEmpty()) occupationValidationErrorString else "",
+                    )
+                }
+
+                is EditScreenEvent.OnChangeLink -> {
+                    cardError = cardError.copy(
+                        linkError = if (event.link.isEmpty()) linkValidationErrorString else "",
+                    )
+                }
+
+                is EditScreenEvent.OnChangeImage -> {
+                    cardError = cardError.copy(
+                        imageError = if (event.image.isEmpty()) imageValidationErrorString else "",
+                    )
                 }
             }
-            isLoading = false
         }
     }
 
@@ -102,6 +176,7 @@ internal fun profileCardScreenPresenter(
         isLoading = isLoading,
         editUiState = editUiState,
         cardUiState = cardUiState,
+        cardError = cardError,
         uiType = uiType,
         userMessageStateHolder = userMessageStateHolder,
     )


### PR DESCRIPTION
## Issue
- close #507 

## Overview (Required)
- Move 'if the string is empty, show an error message' logic to ProfileCardScreenPresenter
  - Make `ProfileCardError` data class to store error message values.
  - When the input value is changed at the text fields, added EditScreenEvents are triggerd.
  - In the presenter, caluculate the error message values for the triggered event.

⚠️ Specifiaction Changes
Before the change, there was an error message in the initial state.
I considered this an not good user experience.
So, the changed error logic only works if there is a change in the input.
If the behavior before the change is more correct in this point, please let me know so I can try to correct it again.

## Links
- 

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/67e5c6c2-bdfb-47b6-b10b-b259970b28da" width="300" > | <video src="https://github.com/user-attachments/assets/cdb2a079-1d6e-4b01-971a-f6159892de96" width="300" >







