### PR TITLE
Show more button only if session description is long

### DIFF
--- a/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/component/ClickableLinkText.kt
+++ b/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/component/ClickableLinkText.kt
@@ -113,7 +113,9 @@ fun ClickableLinkText(
     val isOverflowing by remember {
         derivedStateOf {
             val actualHeight = layoutResult.value?.size?.height?.toFloat() ?: 0f
-            val expectedHeight = with(density) { style.fontSize.toPx() * maxLines }
+            val expectedHeight = with(density) {
+                style.fontSize.toPx() + style.lineHeight.toPx() * (maxLines - 1)
+            }
             actualHeight > expectedHeight
         }
     }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailContent.kt
@@ -107,6 +107,7 @@ private fun DescriptionSection(
     onLinkClick: (url: String) -> Unit,
 ) {
     var isExpand by remember { mutableStateOf(false) }
+    var isOverFlow by remember { mutableStateOf(false) }
 
     Column(modifier = Modifier.padding(8.dp)) {
         ClickableLinkText(
@@ -116,10 +117,13 @@ private fun DescriptionSection(
             style = MaterialTheme.typography.bodyLarge,
             maxLines = if (isExpand) Int.MAX_VALUE else 7,
             overflow = if (isExpand) TextOverflow.Clip else TextOverflow.Ellipsis,
+            onOverflow = {
+                isOverFlow = it
+            },
         )
         Spacer(Modifier.height(16.dp))
         AnimatedVisibility(
-            visible = isExpand.not(),
+            visible = isExpand.not() && isOverFlow,
             enter = EnterTransition.None,
             exit = fadeOut(),
         ) {


### PR DESCRIPTION
## Issue

- close https://github.com/DroidKaigi/conference-app-2024/issues/511

## Overview (Required)

- The more button in the `DescriptionSection` of the `TimetableItemDetailScreen` was displayed even if the session description was short.
- I have changed the specification to display the session description even if it is short.
  - `short` means less than 7 lines of description.
  - = https://github.com/DroidKaigi/conference-app-2024/blob/a1a0fdc8d53d1bb078644e4a0ae661feecf9b08f/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailContent.kt#L117

## Links

-

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/88768a97-49f3-4d52-8f3b-96ffbebb7dc9" width=300 /> | <img src="https://github.com/user-attachments/assets/ec4aa719-41e7-4349-b0c7-688e091d6184" width=300 />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/9bddd21d-af1f-4b1b-b046-cc7a602017a7" width="300" /> | <video src="https://github.com/user-attachments/assets/28399445-669a-4751-a90d-3919635dab8f" width="300" />
