### PR TITLE
Use this year's Sponsor API

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sponsors/SponsorsApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sponsors/SponsorsApiClient.kt
@@ -8,10 +8,8 @@ import de.jensklingenberg.ktorfit.http.GET
 import io.github.droidkaigi.confsched.data.NetworkService
 import io.github.droidkaigi.confsched.data.sponsors.response.SponsorResponse
 import io.github.droidkaigi.confsched.data.sponsors.response.SponsorsResponse
-import io.github.droidkaigi.confsched.data.staff.response.StaffsResponse
 import io.github.droidkaigi.confsched.model.Plan
 import io.github.droidkaigi.confsched.model.Sponsor
-import io.github.droidkaigi.confsched.model.fakes
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sponsors/SponsorsApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sponsors/SponsorsApiClient.kt
@@ -8,6 +8,7 @@ import de.jensklingenberg.ktorfit.http.GET
 import io.github.droidkaigi.confsched.data.NetworkService
 import io.github.droidkaigi.confsched.data.sponsors.response.SponsorResponse
 import io.github.droidkaigi.confsched.data.sponsors.response.SponsorsResponse
+import io.github.droidkaigi.confsched.data.staff.response.StaffsResponse
 import io.github.droidkaigi.confsched.model.Plan
 import io.github.droidkaigi.confsched.model.Sponsor
 import io.github.droidkaigi.confsched.model.fakes
@@ -15,6 +16,11 @@ import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 
 internal interface SponsorApi {
+    /**
+     * Gets sponsor information for the DroidKaigi 2024 event.
+     *
+     * @return [SponsorsResponse]
+     */
     @GET("/events/droidkaigi2023/sponsor")
     suspend fun getSponsors(): SponsorsResponse
 }
@@ -26,11 +32,9 @@ public class DefaultSponsorsApiClient(
 
     private val sponsorApi = ktorfit.create<SponsorApi>()
     public override suspend fun sponsors(): PersistentList<Sponsor> {
-        // FIXME: When the API is ready, remove the comments below and return the actual data.
-        return Sponsor.fakes()
-//        return networkService {
-//            sponsorApi.getSponsors()
-//        }.toSponsorList()
+        return networkService {
+            sponsorApi.getSponsors()
+        }.toSponsorList()
     }
 }
 


### PR DESCRIPTION
## Issue
- close #385

## Overview (Required)
- I fixed the SponsorsApi method in DefaultSponsorsApiClient
- I added comment in the API

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/f0fe3041-cdab-4e9c-9cd8-0893f58c1821" width="300" /> | <img src="https://github.com/user-attachments/assets/f3c0a650-e74e-4ffd-b46c-b6b3b81602a0" width="300" />

