### PR TITLE
Enable to show contents under the bottom nav bar

### DIFF
--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/PaddingValuesExt.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/PaddingValuesExt.kt
@@ -1,0 +1,18 @@
+package io.github.droidkaigi.confsched.ui
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalLayoutDirection
+
+@Composable
+operator fun PaddingValues.plus(other: PaddingValues): PaddingValues {
+    val layoutDirection = LocalLayoutDirection.current
+    return PaddingValues(
+        top = this.calculateTopPadding() + other.calculateTopPadding(),
+        start = this.calculateStartPadding(layoutDirection) + other.calculateStartPadding(layoutDirection),
+        end = this.calculateEndPadding(layoutDirection) + other.calculateEndPadding(layoutDirection),
+        bottom = this.calculateBottomPadding() + other.calculateBottomPadding(),
+    )
+}

--- a/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched/contributors/ContributorsScreen.kt
+++ b/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched/contributors/ContributorsScreen.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched.contributors
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -129,9 +130,10 @@ fun ContributorsScreen(
         Contributors(
             contributors = uiState.contributors,
             onContributorsItemClick = onContributorsItemClick,
+            contentPadding = PaddingValues(bottom = padding.calculateBottomPadding()),
             modifier = Modifier
                 .fillMaxSize()
-                .padding(padding)
+                .padding(top = padding.calculateTopPadding())
                 .let {
                     if (scrollBehavior != null) {
                         it.nestedScroll(scrollBehavior.nestedScrollConnection)
@@ -148,9 +150,11 @@ private fun Contributors(
     contributors: PersistentList<Contributor>,
     onContributorsItemClick: (url: String) -> Unit,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(),
 ) {
     LazyColumn(
         modifier = modifier,
+        contentPadding = contentPadding,
     ) {
         items(contributors) {
             ContributorsItem(

--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
@@ -35,6 +35,7 @@ import io.github.droidkaigi.confsched.model.EventMapEvent
 import io.github.droidkaigi.confsched.ui.SnackbarMessageEffect
 import io.github.droidkaigi.confsched.ui.UserMessageStateHolder
 import io.github.droidkaigi.confsched.ui.component.AnimatedTextTopAppBar
+import io.github.droidkaigi.confsched.ui.plus
 import io.github.droidkaigi.confsched.ui.rememberUserMessageStateHolder
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
@@ -119,7 +120,10 @@ fun EventMapScreen(
         EventMap(
             eventMapEvents = uiState.eventMap,
             onEventMapItemClick = onEventMapItemClick,
-            modifier = Modifier.fillMaxSize().padding(padding)
+            contentPadding = PaddingValues(bottom = padding.calculateBottomPadding()),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = padding.calculateTopPadding())
                 .nestedScroll(scrollBehavior.nestedScrollConnection),
         )
     }
@@ -130,11 +134,12 @@ private fun EventMap(
     eventMapEvents: PersistentList<EventMapEvent>,
     onEventMapItemClick: (url: String) -> Unit,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(),
 ) {
     LazyColumn(
         modifier = modifier
             .testTag(EventMapLazyColumnTestTag),
-        contentPadding = PaddingValues(horizontal = 16.dp),
+        contentPadding = contentPadding + PaddingValues(horizontal = 16.dp),
     ) {
         item {
             EventMapTab()

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreen.kt
@@ -148,7 +148,7 @@ fun SearchScreen(
         containerColor = MaterialTheme.colorScheme.surface,
     ) { innerPadding ->
         Column(
-            modifier = Modifier.padding(innerPadding),
+            modifier = Modifier.padding(top = innerPadding.calculateTopPadding()),
         ) {
             HorizontalDivider()
             SearchFilters(
@@ -176,6 +176,7 @@ fun SearchScreen(
                     highlightWord = uiState.searchWord,
                     onBookmarkClick = { timetableItem, _ -> onTimetableItemBookmark(timetableItem) },
                     onTimetableItemClick = onTimetableItemClick,
+                    contentPadding = PaddingValues(bottom = innerPadding.calculateBottomPadding()),
                 )
             }
         }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/SearchList.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/SearchList.kt
@@ -13,13 +13,14 @@ fun SearchList(
     onTimetableItemClick: (TimetableItem) -> Unit,
     onBookmarkClick: (TimetableItem, Boolean) -> Unit,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(),
 ) {
     TimetableList(
         uiState = uiState,
         scrollState = rememberLazyListState(),
         onBookmarkClick = onBookmarkClick,
         onTimetableItemClick = onTimetableItemClick,
-        contentPadding = PaddingValues(),
+        contentPadding = contentPadding,
         highlightWord = highlightWord,
         modifier = modifier,
     )

--- a/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/SponsorsScreen.kt
+++ b/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/SponsorsScreen.kt
@@ -1,6 +1,8 @@
 package io.github.droidkaigi.confsched.sponsors
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons.AutoMirrored.Filled
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -139,11 +141,13 @@ fun SponsorsScreen(
         },
     ) { padding ->
         SponsorsList(
-            modifier = Modifier.fillMaxSize(),
-            padding = padding,
+            modifier = Modifier
+                .padding(top = padding.calculateTopPadding())
+                .fillMaxSize(),
             uiState = uiState.sponsorsListUiState,
             scrollBehavior = scrollBehavior,
             onSponsorsItemClick = onSponsorsItemClick,
+            contentPadding = PaddingValues(bottom = padding.calculateBottomPadding()),
         )
     }
 }

--- a/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/section/SponsorsList.kt
+++ b/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/section/SponsorsList.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -30,6 +29,7 @@ import io.github.droidkaigi.confsched.sponsors.SponsorsListUiState
 import io.github.droidkaigi.confsched.sponsors.SponsorsRes
 import io.github.droidkaigi.confsched.sponsors.component.SponsorHeader
 import io.github.droidkaigi.confsched.sponsors.component.SponsorItem
+import io.github.droidkaigi.confsched.ui.plus
 import kotlinx.collections.immutable.toPersistentList
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -37,18 +37,17 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SponsorsList(
-    padding: PaddingValues,
     uiState: SponsorsListUiState,
     onSponsorsItemClick: (url: String) -> Unit,
     scrollBehavior: TopAppBarScrollBehavior?,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(),
 ) {
     LazyVerticalGrid(
         columns = GridCells.Fixed(6),
         verticalArrangement = Arrangement.spacedBy(12.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         modifier = modifier
-            .padding(padding)
             .let {
                 if (scrollBehavior != null) {
                     it.nestedScroll(scrollBehavior.nestedScrollConnection)
@@ -56,7 +55,7 @@ fun SponsorsList(
                     it
                 }
             },
-        contentPadding = PaddingValues(horizontal = 12.dp),
+        contentPadding = contentPadding + PaddingValues(horizontal = 12.dp),
     ) {
         item(span = { GridItemSpan(maxLineSpan) }) {
             SponsorHeader(
@@ -137,7 +136,6 @@ fun SponsorsListPreview() {
                     goldSponsors = Sponsor.fakes().filter { it.plan == GOLD }.toPersistentList(),
                     supporters = Sponsor.fakes().filter { it.plan == SUPPORTER }.toPersistentList(),
                 ),
-                padding = PaddingValues(),
                 onSponsorsItemClick = {},
                 scrollBehavior = null,
             )

--- a/feature/staff/src/commonMain/kotlin/io/github/droidkaigi/confsched/staff/StaffScreen.kt
+++ b/feature/staff/src/commonMain/kotlin/io/github/droidkaigi/confsched/staff/StaffScreen.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched.staff
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -118,7 +119,7 @@ fun StaffScreen(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(padding)
+                .padding(top = padding.calculateTopPadding())
                 .testTag(StaffScreenLazyColumnTestTag)
                 .let {
                     if (scrollBehavior != null) {
@@ -127,6 +128,7 @@ fun StaffScreen(
                         it
                     }
                 },
+            contentPadding = PaddingValues(bottom = padding.calculateBottomPadding()),
         ) {
             items(uiState.staff) { staff ->
                 StaffItem(


### PR DESCRIPTION
## Issue
- close #471

## Overview (Required)
- On some screens, contents aren't displayed under the bottom nav bar (please refer "before" images) 
- I'd like to adjust bottom nav bar area like as timeline screen

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/c8686fb3-144d-4d5a-b3e8-7d0bf98d5aa7" width="170" /><img src="https://github.com/user-attachments/assets/b1dad2ef-d5eb-44e5-a42b-45ca4dee546e" width="170" /> | <img src="https://github.com/user-attachments/assets/9a90cd43-addd-4b4f-a9ca-a23b16a78c56" width="170" /><img src="https://github.com/user-attachments/assets/1afe725c-9e7f-42d7-b404-18093bddf616" width="170" />
<img src="https://github.com/user-attachments/assets/1c2ef7af-3e67-40e3-8cc1-5aca9b9ab455" width="170" /><img src="https://github.com/user-attachments/assets/46bd171b-d0a7-444d-b860-2e0ae17d2d96" width="170" /> | <img src="https://github.com/user-attachments/assets/f28454da-2979-404d-a8e0-74c3f2e84473" width="170" /><img src="https://github.com/user-attachments/assets/2c0e5fbf-8e93-4ce2-b238-78df4052bab6" width="170" />
<img src="https://github.com/user-attachments/assets/22271dd2-cf30-4997-8b06-9edd3c674df2" width="170" /><img src="https://github.com/user-attachments/assets/de5344a9-1662-43ae-b919-8cc492e0855e" width="170" /> | <img src="https://github.com/user-attachments/assets/423635d3-3f17-4046-be08-0529b7793c80" width="170" /><img src="https://github.com/user-attachments/assets/8f594de2-1ab1-4201-9e80-09ef81bf77f6" width="170" />
<img src="https://github.com/user-attachments/assets/3bfad97d-b539-41cd-913b-c25928861d2e" width="170" /><img src="https://github.com/user-attachments/assets/ad95b7ea-bc43-4798-bc0e-7b3767d4e60f" width="170" /> | <img src="https://github.com/user-attachments/assets/f5a620ae-bacd-47a6-9575-6d245ad3a3f2" width="170" /><img src="https://github.com/user-attachments/assets/115f32be-0f05-462d-9daf-90df9d8895a6" width="170" />
<img src="https://github.com/user-attachments/assets/b713d929-623d-45a8-b4de-8f40d1fa61a5" width="170" /><img src="https://github.com/user-attachments/assets/7927bee9-873f-4b3f-a0cd-17e6c63b3777" width="170" /> | <img src="https://github.com/user-attachments/assets/b4a09f79-3b33-455c-a358-94c90653a725" width="170" /><img src="https://github.com/user-attachments/assets/c714176c-5ac0-4d0d-9fd0-21ba75d33a75" width="170" />
