### PR TITLE
Refine sponsor grid view

### DIFF
--- a/app-ios/Sources/SponsorFeature/SponsorView.swift
+++ b/app-ios/Sources/SponsorFeature/SponsorView.swift
@@ -18,58 +18,21 @@ public struct SponsorView: View {
                     .foregroundStyle(AssetColors.Primary.primaryFixed.swiftUIColor)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 
-                ForEach(store.platinums, id: \.id) { platinum in
-                    Button {
-                        selectedSponsorData = platinum
-                    } label: {
-                        AsyncImage(url: platinum.logo) {
-                            $0.image?
-                                .resizable()
-                                .scaledToFit()
-                        }
-                        .frame(height: 110)
-                    }
-                }
+                makeSponsorGrid(columnCount: 1, items: store.platinums, imageHeight: 110)
                 
                 Text("GOLD SPONSORS")
                     .textStyle(.headlineSmall)
                     .foregroundStyle(AssetColors.Primary.primaryFixed.swiftUIColor)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 
-                LazyVGrid(columns: Array(repeating: .init(.fixed(184)), count: 2)) {
-                    ForEach(store.golds, id: \.id) { gold in
-                        Button {
-                            selectedSponsorData = gold
-                        } label: {
-                            AsyncImage(url: gold.logo) {
-                                $0.image?
-                                    .resizable()
-                                    .scaledToFit()
-                            }
-                            .frame(height: 80)
-                        }
-                    }
-                }
+                makeSponsorGrid(columnCount: 2, items: store.golds, imageHeight: 77)
                 
                 Text("SUPPORTERS")
                     .textStyle(.headlineSmall)
                     .foregroundStyle(AssetColors.Primary.primaryFixed.swiftUIColor)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 
-                LazyVGrid(columns: Array(repeating: .init(.fixed(118)), count: 3)) {
-                    ForEach(store.supporters, id: \.id) { supporter in
-                        Button {
-                            selectedSponsorData = supporter
-                        } label: {
-                            AsyncImage(url: supporter.logo) {
-                                $0.image?
-                                    .resizable()
-                                    .scaledToFit()
-                            }
-                            .frame(height: 80)
-                        }
-                    }
-                }
+                makeSponsorGrid(columnCount: 3, items: store.supporters, imageHeight: 77)
             }
             .padding(16)
         }
@@ -79,6 +42,33 @@ public struct SponsorView: View {
         }
         .navigationBarTitleDisplayMode(.large)
         .navigationTitle(String(localized: "Sponsor", bundle: .module))
+    }
+
+    @ViewBuilder
+    func makeSponsorGrid(columnCount: Int, items: [SponsorData], imageHeight: Double) -> some View {
+        let gridItems = (1...columnCount)
+            .map { _ in
+                GridItem(.flexible(), spacing: 12, alignment: .center)
+            }
+        LazyVGrid(columns: gridItems, spacing: 12) {
+            ForEach(items, id: \.id) { item in
+                Button {
+                    selectedSponsorData = item
+                } label: {
+                    ZStack {
+                        AssetColors.Inverse.inverseSurface.swiftUIColor
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                        AsyncImage(url: item.logo) {
+                            $0.image?
+                                .resizable()
+                                .scaledToFit()
+                        }
+                        .frame(height: imageHeight)
+                        .padding(.vertical, 6)
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Issue
- close #429

## Overview (Required)
- Use LazyVGrid in each sponsors section.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
![Simulator Screenshot - iPhone 15 Pro - 2024-08-16 at 23 51 48](https://github.com/user-attachments/assets/168ca9ef-7d98-4f28-883c-62c7d091b945)|![Simulator Screenshot - iPhone 15 Pro - 2024-08-16 at 23 42 05](https://github.com/user-attachments/assets/bc4aa93f-ec25-43dd-9266-ed9d75dec518)
![Simulator Screenshot - iPhone 15 Pro - 2024-08-16 at 23 51 50](https://github.com/user-attachments/assets/49c964a6-2451-4ed8-bbc3-db7c6322aa51)|![Simulator Screenshot - iPhone 15 Pro - 2024-08-16 at 23 42 08](https://github.com/user-attachments/assets/7e2c98b0-353b-428c-a96b-d8df109caff9)


## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
