### PR TITLE
:wrench: Fix the TimetableScreen so that it does not animate when it is scrolling.

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
@@ -16,12 +16,10 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import co.touchlab.kermit.Logger
 import io.github.droidkaigi.confsched.designsystem.theme.LocalRoomTheme
 import io.github.droidkaigi.confsched.model.Timetable
 import io.github.droidkaigi.confsched.model.TimetableItem

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
@@ -16,10 +16,12 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import co.touchlab.kermit.Logger
 import io.github.droidkaigi.confsched.designsystem.theme.LocalRoomTheme
 import io.github.droidkaigi.confsched.model.Timetable
 import io.github.droidkaigi.confsched.model.TimetableItem
@@ -87,7 +89,11 @@ fun TimetableList(
                     timetableItems.onEach { timetableItem ->
                         val isBookmarked =
                             uiState.timetable.bookmarks.contains(timetableItem.id)
-                        val timetableItemCardModifier = if (sharedTransitionScope != null && animatedScope != null) {
+                        val timetableItemCardModifier = if (
+                            !scrollState.isScrollInProgress &&
+                            sharedTransitionScope != null &&
+                            animatedScope != null
+                        ) {
                             with(sharedTransitionScope) {
                                 Modifier.sharedElement(
                                     state = rememberSharedContentState(


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- Addressed an issue where a timetable item would keep animating when scrolling is started after tapping on the timetable item.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/4728489d-52ae-4b4f-b7a2-4586af002411" width="300" > | <video src="https://github.com/user-attachments/assets/efa46313-b616-49ab-811e-2284a57a7e8e" width="300" >