### PR TITLE
Add message to EventMap

### DIFF
--- a/app-ios/Sources/EventMapFeature/EventItem.swift
+++ b/app-ios/Sources/EventMapFeature/EventItem.swift
@@ -19,7 +19,7 @@ struct EventItem: View {
             }
             .padding(.bottom, 8)
 
-            VStack(spacing: 8) {
+            VStack(alignment: .leading ,spacing: 8) {
                 Text(event.description_.currentLangTitle)
                     .foregroundStyle(AssetColors.Surface.onSurface.swiftUIColor)
                     .textStyle(.bodyLarge)
@@ -36,6 +36,11 @@ struct EventItem: View {
                                 }
                         }
                     }
+                if let message = event.message {
+                    Text(message.currentLangTitle)
+                        .foregroundStyle(AssetColors.Tertiary.tertiary.swiftUIColor)
+                        .textStyle(.bodyMedium)
+                }
                 
                 if canBeExpanded {
                     Button {


### PR DESCRIPTION
## Issue
- close #427

## Overview (Required)
- Show message when `EventMapEvent#message` is non-null

## Links
- https://github.com/DroidKaigi/conference-app-2024/pull/424
(I referred to the Android side implementation)

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/fe0959b2-986a-4ded-a1cf-a06e2f4eb3db" width="300" /> | <img src="https://github.com/user-attachments/assets/c8e6bbfe-b52d-46da-8517-fb0188a74e07" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
