### PR TITLE
:recycle: Added a log output option that is useful when implementing VRT.

### DIFF
--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/MiniRobots.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/MiniRobots.kt
@@ -23,15 +23,11 @@ import io.github.droidkaigi.confsched.testing.robot.SponsorsServerRobot.ServerSt
 import io.github.droidkaigi.confsched.testing.rules.RobotTestRule
 import kotlinx.coroutines.test.TestDispatcher
 import org.robolectric.RuntimeEnvironment
-import org.robolectric.shadows.ShadowLog
 import org.robolectric.shadows.ShadowLooper
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 
-inline fun <reified T : ScreenRobot> runRobot(robot: T, isShowLogOnConsole: Boolean = false, noinline block: suspend T.() -> Unit) {
-    if (isShowLogOnConsole) {
-        robot.showLogOnConsole()
-    }
+inline fun <reified T : ScreenRobot> runRobot(robot: T, noinline block: suspend T.() -> Unit) {
     robot.run(robot, block)
 }
 
@@ -53,10 +49,6 @@ interface ScreenRobot : ComposeScreenRobot, CaptureScreenRobot, WaitRobot {
         runTestWithLogging(timeout = 30.seconds) {
             thiz.block()
         }
-    }
-
-    fun showLogOnConsole() {
-        ShadowLog.stream = System.out
     }
 }
 

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/MiniRobots.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/MiniRobots.kt
@@ -23,11 +23,15 @@ import io.github.droidkaigi.confsched.testing.robot.SponsorsServerRobot.ServerSt
 import io.github.droidkaigi.confsched.testing.rules.RobotTestRule
 import kotlinx.coroutines.test.TestDispatcher
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.shadows.ShadowLog
 import org.robolectric.shadows.ShadowLooper
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 
-inline fun <reified T : ScreenRobot> runRobot(robot: T, noinline block: suspend T.() -> Unit) {
+inline fun <reified T : ScreenRobot> runRobot(robot: T, isShowLogOnConsole: Boolean = false, noinline block: suspend T.() -> Unit) {
+    if (isShowLogOnConsole) {
+        robot.showLogOnConsole()
+    }
     robot.run(robot, block)
 }
 
@@ -49,6 +53,10 @@ interface ScreenRobot : ComposeScreenRobot, CaptureScreenRobot, WaitRobot {
         runTestWithLogging(timeout = 30.seconds) {
             thiz.block()
         }
+    }
+
+    fun showLogOnConsole() {
+        ShadowLog.stream = System.out
     }
 }
 

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/rules/RobotTestRule.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/rules/RobotTestRule.kt
@@ -10,6 +10,8 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.rules.ActivityScenarioRule
+import co.touchlab.kermit.CommonWriter
+import co.touchlab.kermit.Logger
 import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.RoborazziOptions.CompareOptions
 import com.github.takahirom.roborazzi.RoborazziOptions.PixelBitConfig
@@ -89,6 +91,7 @@ class RobotTestRule(
             .around(object : TestWatcher() {
                 override fun starting(description: Description) {
                     // To see logs in the console
+                    Logger.setLogWriters(CommonWriter())
                     ShadowLog.stream = System.out
                 }
             })

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/rules/RobotTestRule.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/rules/RobotTestRule.kt
@@ -10,8 +10,6 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.rules.ActivityScenarioRule
-import co.touchlab.kermit.CommonWriter
-import co.touchlab.kermit.Logger
 import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.RoborazziOptions.CompareOptions
 import com.github.takahirom.roborazzi.RoborazziOptions.PixelBitConfig
@@ -30,6 +28,7 @@ import org.junit.rules.TestRule
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
+import org.robolectric.shadows.ShadowLog
 import javax.inject.Inject
 import kotlin.reflect.KClass
 
@@ -90,7 +89,7 @@ class RobotTestRule(
             .around(object : TestWatcher() {
                 override fun starting(description: Description) {
                     // To see logs in the console
-                    Logger.setLogWriters(CommonWriter())
+                    ShadowLog.stream = System.out
                 }
             })
             .around(


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- Every time I implemented VRT, I wrote the following temporary code in the xxxTest file to check the contents of the semantics tree.

```kotlin
@Before
fun setUp() {
    ShadowLog.stream = System.out
}
```

```kotlin
        composeTestRule
            .onRoot()
            .printToLog("TESTTEST")
```

- It was necessary to add this description when implementing the test because without it, the log would not be displayed anywhere even if printToLog is written.
- Adding the isShowLogOnConsole option facilitates log display and improves development productivity.