### PR TITLE
Add (at)retroactive to the extension to address the Xcode 16 warning.

### DIFF
--- a/app-ios/Sources/FavoriteFeature/FavoriteView.swift
+++ b/app-ios/Sources/FavoriteFeature/FavoriteView.swift
@@ -82,7 +82,13 @@ public struct FavoriteView: View {
     }
 }
 
-extension DroidKaigi2024Day: Selectable {
+#if hasFeature(RetroactiveAttribute)
+extension DroidKaigi2024Day: @retroactive Selectable {}
+#else
+extension DroidKaigi2024Day: Selectable {}
+#endif
+
+extension DroidKaigi2024Day {
     public var id: Self {
         self
     }

--- a/app-ios/Sources/SearchFeature/SearchView.swift
+++ b/app-ios/Sources/SearchFeature/SearchView.swift
@@ -148,7 +148,13 @@ public struct SearchView: View {
     }
 }
 
-extension DroidKaigi2024Day: Selectable {
+#if hasFeature(RetroactiveAttribute)
+extension DroidKaigi2024Day: @retroactive Selectable {}
+#else
+extension DroidKaigi2024Day: Selectable {}
+#endif
+
+extension DroidKaigi2024Day {
     public var id: Self {
         self
     }
@@ -167,7 +173,13 @@ extension DroidKaigi2024Day: Selectable {
     }
 }
 
-extension TimetableCategory: Selectable {
+#if hasFeature(RetroactiveAttribute)
+extension TimetableCategory: @retroactive Selectable {}
+#else
+extension TimetableCategory: Selectable {}
+#endif
+
+extension TimetableCategory {
     public var caseTitle: String {
         title.currentLangTitle
     }
@@ -178,7 +190,13 @@ extension TimetableCategory: Selectable {
     }
 }
 
-extension TimetableSessionType: Selectable {
+#if hasFeature(RetroactiveAttribute)
+extension TimetableSessionType: @retroactive Selectable {}
+#else
+extension TimetableSessionType: Selectable {}
+#endif
+
+extension TimetableSessionType {
     public var id: Self {
         self
     }
@@ -188,7 +206,13 @@ extension TimetableSessionType: Selectable {
     }
 }
 
-extension Lang: Selectable {
+#if hasFeature(RetroactiveAttribute)
+extension Lang: @retroactive Selectable {}
+#else
+extension Lang: Selectable {}
+#endif
+
+extension Lang {
     public var id: Self {
         self
     }


### PR DESCRIPTION
## Issue
- nothing

## Overview (Required)
- Due to [SE-0364](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0364-retroactive-conformance-warning.md), protocol compliance of external modules will be subject to warnings unless the `@retroactive` attribute is declared.
- Xcode 16 shows SE-0364 warning even on Swift 5.10. Use the `hasFeature()` macro for conditional compilation.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
