### PR TITLE
Added drag gesture and crossfade in EventMapTab

### DIFF
--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/component/EventMapTab.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/component/EventMapTab.kt
@@ -34,7 +34,7 @@ import org.jetbrains.compose.resources.painterResource
 
 const val EventMapTabTestTagPrefix = "EventMapTabTestTag:"
 const val EventMapTabImageTestTag = "EventMapTabImageTestTag"
-const val ChangeTabDragAmountThreshold = 20f
+private const val ChangeTabDragAmountThreshold = 20f
 
 @Composable
 fun EventMapTab(

--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/component/EventMapTab.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/component/EventMapTab.kt
@@ -35,7 +35,7 @@ import org.jetbrains.compose.resources.painterResource
 
 const val EventMapTabTestTagPrefix = "EventMapTabTestTag:"
 const val EventMapTabImageTestTag = "EventMapTabImageTestTag"
-private const val ChangeTabDragAmountThreshold = 20f
+private const val ChangeTabDeltaThreshold = 20f
 
 @Composable
 fun EventMapTab(
@@ -48,10 +48,10 @@ fun EventMapTab(
         modifier = modifier.draggable(
             orientation = Orientation.Horizontal,
             state = rememberDraggableState { delta ->
-                if (selectedTabIndex == 0 && delta > ChangeTabDragAmountThreshold) {
+                if (selectedTabIndex == 0 && delta > ChangeTabDeltaThreshold) {
                     selectedTabIndex = 1
                 }
-                if (selectedTabIndex == 1 && delta < -ChangeTabDragAmountThreshold) {
+                if (selectedTabIndex == 1 && delta < -ChangeTabDeltaThreshold) {
                     selectedTabIndex = 0
                 }
             },

--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/component/EventMapTab.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/component/EventMapTab.kt
@@ -2,7 +2,9 @@ package io.github.droidkaigi.confsched.eventmap.component
 
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -21,7 +23,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -44,16 +45,17 @@ fun EventMapTab(
     var selectedTabIndex by rememberSaveable { mutableStateOf(0) }
 
     Column(
-        modifier = modifier.pointerInput(Unit) {
-            detectDragGestures { _, dragAmount ->
-                if (selectedTabIndex == 0 && dragAmount.x > ChangeTabDragAmountThreshold) {
+        modifier = modifier.draggable(
+            orientation = Orientation.Horizontal,
+            state = rememberDraggableState { delta ->
+                if (selectedTabIndex == 0 && delta > ChangeTabDragAmountThreshold) {
                     selectedTabIndex = 1
                 }
-                if (selectedTabIndex == 1 && dragAmount.x < -ChangeTabDragAmountThreshold) {
+                if (selectedTabIndex == 1 && delta < -ChangeTabDragAmountThreshold) {
                     selectedTabIndex = 0
                 }
-            }
-        },
+            },
+        ),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.Start,
     ) {

--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/component/EventMapTab.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/component/EventMapTab.kt
@@ -1,6 +1,8 @@
 package io.github.droidkaigi.confsched.eventmap.component
 
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -19,6 +21,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -31,6 +34,7 @@ import org.jetbrains.compose.resources.painterResource
 
 const val EventMapTabTestTagPrefix = "EventMapTabTestTag:"
 const val EventMapTabImageTestTag = "EventMapTabImageTestTag"
+const val ChangeTabDragAmountThreshold = 20f
 
 @Composable
 fun EventMapTab(
@@ -40,7 +44,16 @@ fun EventMapTab(
     var selectedTabIndex by rememberSaveable { mutableStateOf(0) }
 
     Column(
-        modifier = modifier,
+        modifier = modifier.pointerInput(Unit) {
+            detectDragGestures { _, dragAmount ->
+                if (selectedTabIndex == 0 && dragAmount.x > ChangeTabDragAmountThreshold) {
+                    selectedTabIndex = 1
+                }
+                if (selectedTabIndex == 1 && dragAmount.x < -ChangeTabDragAmountThreshold) {
+                    selectedTabIndex = 0
+                }
+            }
+        },
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.Start,
     ) {
@@ -92,21 +105,23 @@ fun EventMapTab(
             },
         )
         Spacer(modifier = Modifier.height(24.dp))
-        val mapRes = if (selectedTabIndex == 0) {
-            Res.drawable.event_map_1f
-        } else {
-            Res.drawable.event_map_b1f
+        Crossfade(targetState = selectedTabIndex) { index ->
+            val mapRes = if (index == 0) {
+                Res.drawable.event_map_1f
+            } else {
+                Res.drawable.event_map_b1f
+            }
+            val mapContentDescription = if (index == 0) {
+                FloorLevel.Ground.floorName
+            } else {
+                FloorLevel.Basement.floorName
+            }
+            Image(
+                modifier = Modifier.testTag(EventMapTabImageTestTag),
+                painter = painterResource(mapRes),
+                contentDescription = "Map of $mapContentDescription",
+            )
         }
-        val mapContentDescription = if (selectedTabIndex == 0) {
-            FloorLevel.Ground.floorName
-        } else {
-            FloorLevel.Basement.floorName
-        }
-        Image(
-            modifier = Modifier.testTag(EventMapTabImageTestTag),
-            painter = painterResource(mapRes),
-            contentDescription = "Map of $mapContentDescription",
-        )
     }
 }
 


### PR DESCRIPTION
## Issue
none


## Overview (Required)
- I implemented it because it would be nice to be able to drag instead of tapping a button to switch between maps.
- Crossfade looks better with Animation than with a quick changeover.
- `ChangeTabDeltaThreshold = 20f` is a value that I found to be just right in terms of my own operational feel.



## Movie
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/24e718d7-f1ef-426f-9b7f-7fdbce500266" width="300" > | <video src="https://github.com/user-attachments/assets/96dca727-554a-45db-959a-cd5691df44c6" width="300" >


## Reference
[Android developers - drag-swipe-fling](https://developer.android.com/develop/ui/compose/touch-input/pointer-input/drag-swipe-fling)


## Things we tried that didn't work
At first I used `pointerInput` to get the amount of drag, but now I use `draggable` because I could not scroll with my finger on the map
