### PR TITLE
[iOS] Search Feature: Remove filter of Workshop Day

### DIFF
--- a/app-ios/Sources/Model/Selectable.swift
+++ b/app-ios/Sources/Model/Selectable.swift
@@ -1,3 +1,10 @@
 public protocol Selectable: CaseIterable, Equatable, Identifiable, Hashable {
+    associatedtype Options: RandomAccessCollection = [Self] where Self == Self.Options.Element
+    static var options: Options { get }
     var caseTitle: String { get }
+
+}
+
+public extension Selectable {
+    static var options: Options { allCases as! Options }
 }

--- a/app-ios/Sources/SearchFeature/SearchView.swift
+++ b/app-ios/Sources/SearchFeature/SearchView.swift
@@ -123,9 +123,9 @@ public struct SearchView: View {
         selection: T?,
         defaultTitle: String,
         onSelect: @escaping (T) -> Void
-    ) -> some View where T.AllCases: RandomAccessCollection {
+    ) -> some View {
         Menu {
-            ForEach(T.allCases, id: \.id) { menuSelection in
+            ForEach(T.options, id: \.id) { menuSelection in
                 Button {
                     onSelect(menuSelection)
                 } label: {
@@ -170,6 +170,10 @@ extension DroidKaigi2024Day {
         case .conferenceDay2:
             String(localized: "9/13", bundle: .module)
         }
+    }
+
+    public static var options: [DroidKaigi2024Day] {
+        [.conferenceDay1, .conferenceDay2]
     }
 }
 


### PR DESCRIPTION
## Issue
- close #443

## Overview (Required)
- Remove workshop day from search filter options
    - Add `options` to `Selectable` protocol
        - Default value is `allCases`
    - Override `options` in `DroidKaigi2024Day`
- It is possible to overwrite `allCases` , but I thought `allCases` should list all cases, so I created Options.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/a17ef24a-ebb9-4ba0-8857-bc4ba5b4630b" width="300" /> | <img src="https://github.com/user-attachments/assets/560a1eee-64c1-4b80-b3a1-bf37aa75e0d1" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
