### PR TITLE
Fix EventMap API endpoint and use actual data from the API

### DIFF
--- a/core/data/src/androidMain/kotlin/io/github/droidkaigi/confsched/data/eventmap/EventMapApiModule.kt
+++ b/core/data/src/androidMain/kotlin/io/github/droidkaigi/confsched/data/eventmap/EventMapApiModule.kt
@@ -4,12 +4,20 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import de.jensklingenberg.ktorfit.Ktorfit
+import io.github.droidkaigi.confsched.data.NetworkService
 
 @Module
 @InstallIn(SingletonComponent::class)
 public class EventMapApiModule {
     @Provides
-    public fun provideEventMapApi(): EventMapApiClient {
-        return FakeEventMapApiClient()
+    public fun provideEventMapApi(
+        networkService: NetworkService,
+        ktorfit: Ktorfit,
+    ): EventMapApiClient {
+        return DefaultEventMapApiClient(
+            networkService = networkService,
+            ktorfit = ktorfit,
+        )
     }
 }

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/eventmap/EventMapApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/eventmap/EventMapApiClient.kt
@@ -12,7 +12,12 @@ import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 
 internal interface EventMapApi {
-    @GET("/events/droidkaigi2024/eventmap")
+    /**
+     * Gets event (project) and room information for DroidKaigi 2024 event.
+     *
+     * @return [EventMapResponse]
+     */
+    @GET("/events/droidkaigi2024/projects")
     suspend fun getEventMap(): EventMapResponse
 }
 
@@ -38,13 +43,13 @@ public interface EventMapApiClient {
 public fun EventMapResponse.toEventMapList(): PersistentList<EventMapEvent> {
     val roomIdToNameMap = this.rooms.associateBy({ it.id }, { it.name.ja to it.name.en })
 
-    return this.events
-        .mapNotNull { event ->
-            roomIdToNameMap[event.roomId]?.let { roomName ->
+    return this.projects
+        .mapNotNull { project ->
+            roomIdToNameMap[project.roomId]?.let { roomName ->
                 EventMapEvent(
                     name = MultiLangText(
-                        jaTitle = event.title.ja,
-                        enTitle = event.title.en,
+                        jaTitle = project.title.ja,
+                        enTitle = project.title.en,
                     ),
                     roomName = MultiLangText(
                         jaTitle = roomName.first,
@@ -52,11 +57,11 @@ public fun EventMapResponse.toEventMapList(): PersistentList<EventMapEvent> {
                     ),
                     roomIcon = roomName.second.toRoomIcon(),
                     description = MultiLangText(
-                        jaTitle = event.i18nDesc.ja,
-                        enTitle = event.i18nDesc.en,
+                        jaTitle = project.i18nDesc.ja,
+                        enTitle = project.i18nDesc.en,
                     ),
-                    moreDetailsUrl = event.moreDetailsUrl,
-                    message = event.message?.toMultiLangText(),
+                    moreDetailsUrl = project.moreDetailsUrl,
+                    message = project.message?.toMultiLangText(),
                 )
             }
         }

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/eventmap/response/EventMapResponse.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/eventmap/response/EventMapResponse.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 public data class EventMapResponse(
-    val events: List<EventResponse> = emptyList(),
+    val projects: List<ProjectResponse> = emptyList(),
     val rooms: List<RoomResponse> = emptyList(),
     val status: String = "",
 )

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/eventmap/response/ProjectResponse.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/eventmap/response/ProjectResponse.kt
@@ -3,7 +3,7 @@ package io.github.droidkaigi.confsched.data.eventmap.response
 import kotlinx.serialization.Serializable
 
 @Serializable
-public data class EventResponse(
+public data class ProjectResponse(
     val i18nDesc: I18nDescResponse,
     val id: String,
     val message: MessageResponse?,

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/data/eventmap/FakeEventMapApiModule.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/data/eventmap/FakeEventMapApiModule.kt
@@ -7,7 +7,6 @@ import dagger.hilt.testing.TestInstallIn
 import io.github.droidkaigi.confsched.data.eventmap.EventMapApiClient
 import io.github.droidkaigi.confsched.data.eventmap.EventMapApiModule
 import io.github.droidkaigi.confsched.data.eventmap.FakeEventMapApiClient
-import io.github.droidkaigi.confsched.data.sessions.SessionsApiModule
 import javax.inject.Singleton
 
 @Module

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/data/eventmap/FakeEventMapApiModule.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/data/eventmap/FakeEventMapApiModule.kt
@@ -1,0 +1,24 @@
+package io.github.droidkaigi.confsched.testing.data.eventmap
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import io.github.droidkaigi.confsched.data.eventmap.EventMapApiClient
+import io.github.droidkaigi.confsched.data.eventmap.EventMapApiModule
+import io.github.droidkaigi.confsched.data.eventmap.FakeEventMapApiClient
+import io.github.droidkaigi.confsched.data.sessions.SessionsApiModule
+import javax.inject.Singleton
+
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [EventMapApiModule::class],
+)
+class FakeEventMapApiModule {
+    @Provides
+    @Singleton
+    fun provideEventMapApi(): EventMapApiClient {
+        return FakeEventMapApiClient()
+    }
+}


### PR DESCRIPTION
## Issue
- close #602

## Overview (Required)
- Change EventMap API endpoint to actual one (mentioned in the Issue)
- Use the data fetched from the API as default
- Rename `event` to `project`
  - I wonder if it would be better that we do rename on module level

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/78a57ad5-0826-43cd-a399-5a067a2d5c46" width="300" /> | <img src="https://github.com/user-attachments/assets/6861dfca-7f30-4f85-805b-16c6ba1a266d" width="300" />
