### PR TITLE
fix: AnimatedTextTopAppBar does not function in ProfileCardScreen

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -325,8 +325,8 @@ internal fun EditScreen(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .verticalScroll(rememberScrollState())
             .nestedScroll(scrollBehavior.nestedScrollConnection)
+            .verticalScroll(rememberScrollState())
             .padding(contentPadding)
             .padding(horizontal = 16.dp)
             .testTag(ProfileCardEditScreenColumnTestTag),


### PR DESCRIPTION
## Issue
- close #593 

## Overview (Required)
- Rearranged the order of modifiers in EditScreen so that nestedScroll works correctly.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/af4fc294-c5f5-4e8b-b279-1c6cc8172ce4" width="300" /> | <img src="https://github.com/user-attachments/assets/64a032ea-0f43-4dee-9c9b-17a77c33f6d3" width="300" />

