### PR TITLE
Untappable background content when loading profile

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -68,6 +68,8 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavGraphBuilder
@@ -285,9 +287,12 @@ internal fun ProfileCardScreen(
             }
         }
         if (uiState.isLoading) {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier.padding(padding).fillMaxSize(),
+            Dialog(
+                onDismissRequest = {},
+                properties = DialogProperties(
+                    dismissOnBackPress = false,
+                    dismissOnClickOutside = false
+                )
             ) {
                 CircularProgressIndicator()
             }

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -291,8 +291,8 @@ internal fun ProfileCardScreen(
                 onDismissRequest = {},
                 properties = DialogProperties(
                     dismissOnBackPress = false,
-                    dismissOnClickOutside = false
-                )
+                    dismissOnClickOutside = false,
+                ),
             ) {
                 CircularProgressIndicator()
             }


### PR DESCRIPTION
## Issue
- close #567

## Overview (Required)
- Show indicator on `Dialog` when loading profile card

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://private-user-images.githubusercontent.com/60963155/358838011-26a69751-67a4-4a4e-a797-d662009745c8.mp4?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjM5ODA1NjEsIm5iZiI6MTcyMzk4MDI2MSwicGF0aCI6Ii82MDk2MzE1NS8zNTg4MzgwMTEtMjZhNjk3NTEtNjdhNC00YTRlLWE3OTctZDY2MjAwOTc0NWM4Lm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA4MTglMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwODE4VDExMjQyMVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWRhOGZiYThkYmNlMGVhN2FkZTA3NGY3YzdlZGY5ZTc5OWU5MmJjMGU0ZTM2ZTU5NWY5MDNjYjFiNmMwYzA2ODEmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.6tEGgn9Y8XC23sv9Wkcfi-hYLpsezywNrI5MltHyJJs" width="300" > | <video src="https://github.com/user-attachments/assets/9741a4c4-3f52-4b78-81dd-cf4ce6d37268" width="300" >