### PR TITLE
Favorite animation for ClassLikeNavRail

### DIFF
--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/animation/FavoriteAnimation.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/animation/FavoriteAnimation.kt
@@ -24,17 +24,17 @@ private val IconSize = 24.0.dp
 
 @Composable
 fun ProvideFavoriteAnimation(
-    isEnabled: Boolean,
+    direction: FavoriteAnimationDirection,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
     val clock = LocalClock.current
     val coroutineScope = rememberCoroutineScope()
-    val favoriteAnimationScope = remember(clock, coroutineScope, isEnabled) {
+    val favoriteAnimationScope = remember(clock, coroutineScope, direction) {
         FavoriteAnimationScope(
             clock = clock,
             coroutineScope = coroutineScope,
-            isEnabled = isEnabled,
+            direction = direction,
         )
     }
 

--- a/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/MainScreen.kt
+++ b/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/MainScreen.kt
@@ -64,6 +64,7 @@ import io.github.droidkaigi.confsched.main.section.GlassLikeNavRail
 import io.github.droidkaigi.confsched.model.isBlurSupported
 import io.github.droidkaigi.confsched.ui.SnackbarMessageEffect
 import io.github.droidkaigi.confsched.ui.UserMessageStateHolder
+import io.github.droidkaigi.confsched.ui.animation.FavoriteAnimationDirection
 import io.github.droidkaigi.confsched.ui.animation.ProvideFavoriteAnimation
 import io.github.droidkaigi.confsched.ui.compositionlocal.LocalAnimatedVisibilityScope
 import org.jetbrains.compose.resources.DrawableResource
@@ -129,7 +130,11 @@ fun MainScreen(
         userMessageStateHolder = uiState.userMessageStateHolder,
     )
     ProvideFavoriteAnimation(
-        navigationType == BottomNavigation,
+        if (navigationType == BottomNavigation) {
+            FavoriteAnimationDirection.Vertical
+        } else {
+            FavoriteAnimationDirection.Horizontal
+        },
     ) {
         MainScreen(
             uiState = uiState,

--- a/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeNavRail.kt
+++ b/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeNavRail.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.PathMeasure
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -49,6 +50,8 @@ import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeChild
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.main.MainScreenTab
+import io.github.droidkaigi.confsched.ui.animation.onGloballyPositionedWithFavoriteAnimationScope
+import io.github.droidkaigi.confsched.ui.useIf
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -203,6 +206,14 @@ fun NavRailTabs(
                     Icon(
                         painter = painterResource(iconRes),
                         contentDescription = "tab ${stringResource(tab.contentDescription)}",
+                        modifier = Modifier.useIf(
+                            tab == MainScreenTab.Favorite,
+                        ) {
+                            onGloballyPositionedWithFavoriteAnimationScope { scope, coordinates ->
+                                val position = coordinates.positionInRoot()
+                                scope?.setTargetPosition(position)
+                            }
+                        },
                     )
                 }
             }


### PR DESCRIPTION
## Issue
- close #611 

## Overview (Required)
- Add animation of favorite on timetable list when GlassLikeNavRail is displayed.
- ※Remain GlassLikeBottomNavigation's current animation.

## Links
- 


## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/9ac46aa6-1db0-4e25-a49e-009484c1af87" width="300" > | <video src="https://github.com/user-attachments/assets/b3c7f32a-9359-4541-bda4-0517c5156252" width="300" >
<video src="https://github.com/user-attachments/assets/e18009bd-aa20-4b9c-a278-fa9f2adef38a" width="300" > | <video src="https://github.com/user-attachments/assets/2980a7fd-c9a8-415e-b0ba-bda261d869f6" width="300" >

