### PR TITLE
Add padding at the bottom of Sponsors Screen

### DIFF
--- a/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/section/SponsorsList.kt
+++ b/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/section/SponsorsList.kt
@@ -62,8 +62,8 @@ fun SponsorsList(
             }
             .testTag(SponsorsListLazyVerticalGridTestTag),
         contentPadding = PaddingValues(
-            start = 12.dp,
-            end = 12.dp,
+            start = 16.dp,
+            end = 16.dp,
             bottom = 48.dp + contentPadding.calculateBottomPadding()
         ),
     ) {

--- a/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/section/SponsorsList.kt
+++ b/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/section/SponsorsList.kt
@@ -64,7 +64,7 @@ fun SponsorsList(
         contentPadding = PaddingValues(
             start = 16.dp,
             end = 16.dp,
-            bottom = 48.dp + contentPadding.calculateBottomPadding()
+            bottom = 48.dp + contentPadding.calculateBottomPadding(),
         ),
     ) {
         item(span = { GridItemSpan(maxLineSpan) }) {

--- a/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/section/SponsorsList.kt
+++ b/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/section/SponsorsList.kt
@@ -61,7 +61,11 @@ fun SponsorsList(
                 }
             }
             .testTag(SponsorsListLazyVerticalGridTestTag),
-        contentPadding = contentPadding + PaddingValues(horizontal = 12.dp),
+        contentPadding = PaddingValues(
+            start = 12.dp,
+            end = 12.dp,
+            bottom = 48.dp + contentPadding.calculateBottomPadding()
+        ),
     ) {
         item(span = { GridItemSpan(maxLineSpan) }) {
             SponsorHeader(


### PR DESCRIPTION
## Issue
- close #614

## Overview (Required)
- Add padding at the bottom of Sponsors Screen
- Change start and end padding to match design

<img width="366" alt="スクリーンショット 2024-08-19 0 35 20" src="https://github.com/user-attachments/assets/fd40b77f-e761-40a2-b91f-a85b7ff71397">

## Links
none

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/93a122bb-2a26-4659-897c-6aa4c914fc7a" width="300" /> | <img src="https://github.com/user-attachments/assets/4f4074b8-81a6-4039-bb9b-9007f18da211" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
