### PR TITLE
Change the background color of the sponsor logo in iOS

### DIFF
--- a/app-ios/Sources/SponsorFeature/SponsorView.swift
+++ b/app-ios/Sources/SponsorFeature/SponsorView.swift
@@ -56,8 +56,7 @@ public struct SponsorView: View {
                     selectedSponsorData = item
                 } label: {
                     ZStack {
-                        AssetColors.Inverse.inverseSurface.swiftUIColor
-                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                        Color.white.clipShape(RoundedRectangle(cornerRadius: 12))
                         AsyncImage(url: item.logo) {
                             $0.image?
                                 .resizable()


### PR DESCRIPTION
## Issue
- https://github.com/DroidKaigi/conference-app-2024/pull/610

## Overview (Required)
- This is the same fix for iOS App

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
After1 | After2
:--: | :--:
![Simulator Screenshot - iPhone 15 Pro - 2024-08-19 at 01 19 37](https://github.com/user-attachments/assets/1cf9b741-fb57-4f0a-b3ea-a1253bf4ca7f)|![Simulator Screenshot - iPhone 15 Pro - 2024-08-19 at 01 19 48](https://github.com/user-attachments/assets/8498a114-f450-41a5-a6b7-7ab9d85bad17)

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
