### PR TITLE
Add extension for SwiftGen code to conform to unchecked Sendable

### DIFF
--- a/app-ios/Sources/Theme/ColorAsset+Sendable.swift
+++ b/app-ios/Sources/Theme/ColorAsset+Sendable.swift
@@ -1,0 +1,5 @@
+#if hasFeature(RetroactiveAttribute)
+extension ColorAsset: @retroactive @unchecked Sendable {}
+#else
+extension ColorAsset: @unchecked Sendable {}
+#endif

--- a/app-ios/Sources/Theme/FontConvertible+Sendable.swift
+++ b/app-ios/Sources/Theme/FontConvertible+Sendable.swift
@@ -1,0 +1,5 @@
+#if hasFeature(RetroactiveAttribute)
+extension FontConvertible: @retroactive @unchecked Sendable {}
+#else
+extension FontConvertible: @unchecked Sendable {}
+#endif


### PR DESCRIPTION
## Issue
- In progress #431

## Overview (Required)
- Added an extension to make SwiftGen-generated types conform to unchecked Sendable
  - Why didn't this PR customize the stencil?
    - Because it had `lazy var color: Color` and it seemed like I had to make stencil `@unchecked Sendable `after all.
    -  Additionally, since the class involved are Color or Font, the likelihood of data races in normal usage scenarios is minimal.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
