### PR TITLE
fix: center single-line description on AboutScreen

### DIFF
--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/section/AboutDroidKaigiDetail.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/section/AboutDroidKaigiDetail.kt
@@ -81,6 +81,7 @@ fun AboutDroidKaigiDetail(
             style = MaterialTheme.typography.titleMedium,
             textAlign = TextAlign.Center,
             modifier = Modifier
+                .fillMaxWidth()
                 .padding(
                     start = 16.dp,
                     end = 16.dp,


### PR DESCRIPTION
## Issue
- close #612 

## Overview (Required)
- The issue occurred when the description text fit within a single line relative to the device's width.
- The layout was adjusted to always use the full screen width, ensuring the description text is consistently centered, even on a single line.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/05e7554d-928a-4e60-9156-014d3c85f0ae" width="300" /> | <img src="https://github.com/user-attachments/assets/fc5a06ac-666e-45a7-a18d-d86a85a81578" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
