### PR TITLE
Add test on TimetableScreenTest about date tab and grid combination

### DIFF
--- a/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
+++ b/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
@@ -149,6 +149,18 @@ class TimetableScreenTest(private val testCase: DescribedBehavior<TimetableScree
                                 checkTimetableTabSelected(case.expectedInitialTab)
                             })
                         }
+                        describe("switch to grid timetable") {
+                            run {
+                                clickTimetableUiTypeChangeButton()
+                            }
+                            itShould("show timetable items for ${case.expectedInitialTab.name}") {
+                                captureScreenWithChecks(checks = {
+                                    checkTimetableGridDisplayed()
+                                    checkTimetableGridItemsDisplayed()
+                                    checkTimetableTabSelected(case.expectedInitialTab)
+                                })
+                            }
+                        }
                     }
                 }
                 describe("when server is down") {


### PR DESCRIPTION
## Issue
- close #564 

## Overview (Required)
- As title, add tests about date switching and grid timetable combination
