### PR TITLE
:recycle: Make additional corrections to SearchScreenTest because it is not fully implemented.

### DIFF
--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/SearchScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/SearchScreenRobot.kt
@@ -29,6 +29,8 @@ import io.github.droidkaigi.confsched.ui.Inject
 import io.github.droidkaigi.confsched.ui.component.TimetableItemCardTestTag
 import io.github.droidkaigi.confsched.ui.component.TimetableItemCardTitleTextTestTag
 
+const val DemoSearchWord = "Demo"
+
 class SearchScreenRobot @Inject constructor(
     private val screenRobot: DefaultScreenRobot,
     private val timetableServerRobot: DefaultTimetableServerRobot,
@@ -70,7 +72,11 @@ class SearchScreenRobot @Inject constructor(
         waitUntilIdle()
     }
 
-    fun inputSearchWord(text: String) {
+    fun inputDemoSearchWord() {
+        inputSearchWord(DemoSearchWord)
+    }
+
+    private fun inputSearchWord(text: String) {
         composeTestRule
             .onNodeWithTag(SearchTextFieldAppBarTextFieldTestTag)
             .performTextInput(text)
@@ -241,13 +247,21 @@ class SearchScreenRobot @Inject constructor(
         waitUntilIdle()
     }
 
-    fun checkSearchWordDisplayed(text: String) {
+    fun checkDemoSearchWordDisplayed() {
+        checkSearchWordDisplayed(DemoSearchWord)
+    }
+
+    private fun checkSearchWordDisplayed(text: String) {
         composeTestRule
             .onNodeWithTag(SearchTextFieldAppBarTextFieldTestTag)
             .assertTextEquals(text)
     }
 
-    fun checkTimetableListItemsHasText(searchWord: String) {
+    fun checkTimetableListItemsHasDemoText() {
+        checkTimetableListItemsHasText(DemoSearchWord)
+    }
+
+    private fun checkTimetableListItemsHasText(searchWord: String) {
         composeTestRule
             .onAllNodesWithTag(TimetableItemCardTitleTextTestTag)
             .assertAll(hasText(text = searchWord, ignoreCase = true))

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/SearchScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/SearchScreenRobot.kt
@@ -176,6 +176,17 @@ class SearchScreenRobot @Inject constructor(
         waitUntilIdle()
     }
 
+    fun checkDisplayedFilterLanguageChip() {
+        composeTestRule
+            .onAllNodes(
+                hasTestTag(
+                    testTag = DropdownFilterChipTestTagPrefix,
+                    substring = true,
+                ),
+            )
+            .assertCountAtLeast(Language.entries.size)
+    }
+
     fun checkTimetableListItemByConferenceDay(
         checkDay: ConferenceDay,
     ) {

--- a/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
+++ b/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
@@ -53,14 +53,13 @@ class SearchScreenTest(
                         }
                     }
                     describe("input search word to TextField") {
-                        val searchWord = "Demo"
                         run {
-                            inputSearchWord(searchWord)
+                            inputDemoSearchWord()
                         }
                         itShould("show search word and filtered items") {
                             captureScreenWithChecks {
-                                checkSearchWordDisplayed(searchWord)
-                                checkTimetableListItemsHasText(searchWord)
+                                checkDemoSearchWordDisplayed()
+                                checkTimetableListItemsHasDemoText()
                             }
                         }
                     }

--- a/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
+++ b/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
@@ -11,7 +11,6 @@ import io.github.droidkaigi.confsched.testing.robot.SearchScreenRobot.Conference
 import io.github.droidkaigi.confsched.testing.robot.SearchScreenRobot.Language
 import io.github.droidkaigi.confsched.testing.robot.TimetableServerRobot.ServerStatus
 import io.github.droidkaigi.confsched.testing.robot.runRobot
-import io.github.droidkaigi.confsched.testing.robot.todoChecks
 import io.github.droidkaigi.confsched.testing.rules.RobotTestRule
 import org.junit.Rule
 import org.junit.Test
@@ -122,7 +121,7 @@ class SearchScreenTest(
                         }
                         itShould("show drop down menu") {
                             captureScreenWithChecks {
-                                todoChecks("todo")
+                                checkDisplayedFilterLanguageChip()
                             }
                         }
                         Language.entries.forEach { language ->


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
1. todoChecks were left unchecked, so a correction has been made to check them.
2. the part where the value is passed from ScreenTest side was moved to Robot and the process was hidden from Test side.