### PR TITLE
:wrench: Move the ContributorsScreenTest implementation to ContributorsScreenRobot and hide it.

### DIFF
--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/ContributorsScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/ContributorsScreenRobot.kt
@@ -37,7 +37,13 @@ class ContributorsScreenRobot @Inject constructor(
             .performScrollToIndex(10)
     }
 
-    fun checkRangeContributorItemsDisplayed(
+    fun checkShowFirstAndSecondContributors() {
+        checkRangeContributorItemsDisplayed(
+            fromTo = 0..2,
+        )
+    }
+
+    private fun checkRangeContributorItemsDisplayed(
         fromTo: IntRange,
     ) {
         val contributorsList = Contributor.fakes().subList(fromTo.first, fromTo.last)

--- a/feature/contributors/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/contributors/ContributorsScreenTest.kt
+++ b/feature/contributors/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/contributors/ContributorsScreenTest.kt
@@ -47,9 +47,7 @@ class ContributorsScreenTest(private val testCase: DescribedBehavior<Contributor
                         }
                         itShould("show first and second contributors") {
                             captureScreenWithChecks {
-                                checkRangeContributorItemsDisplayed(
-                                    fromTo = 0..2,
-                                )
+                                checkShowFirstAndSecondContributors()
                             }
                         }
 


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- As the title says.