### PR TITLE
Fix unselected icons color on bottom bar

### DIFF
--- a/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeBottomNavigation.kt
+++ b/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeBottomNavigation.kt
@@ -193,10 +193,6 @@ fun BottomBarTabs(
             modifier = modifier.fillMaxSize(),
         ) {
             for (tab in MainScreenTab.entries) {
-                val alpha by animateFloatAsState(
-                    targetValue = if (selectedTab == tab) 1f else .35f,
-                    label = "alpha",
-                )
                 val scale by animateFloatAsState(
                     targetValue = if (selectedTab == tab) 1f else .98f,
                     visibilityThreshold = .000001f,
@@ -216,7 +212,6 @@ fun BottomBarTabs(
                     modifier =
                     Modifier
                         .scale(scale)
-                        .alpha(alpha)
                         .fillMaxHeight()
                         .weight(1f)
                         .pointerInput(Unit) {


### PR DESCRIPTION
## Issue
- close #574 

## Overview (Required)
- Make the tint of the unselected icons in the lower bar equivalent to the design of Figma.
- Unnecessary alpha values were set and removed.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/7877f14b-281c-4af1-9f16-2bd13a7db10b" width="300" /> | <img src="https://github.com/user-attachments/assets/ef923323-77f6-4a5a-8987-d7ec45823e9b" width="300" />



## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
