### PR TITLE
added margin to timetable grid view #618

### DIFF
--- a/app-ios/Sources/TimetableFeature/TimetableListView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableListView.swift
@@ -103,8 +103,8 @@ struct TimetableListView: View {
             .onAppear {
                 store.send(.view(.onAppear))
             }.background(AssetColors.Surface.surface.swiftUIColor)
-            // bottom floating tabbar padding
-            Color.clear.padding(.bottom, 60)
+            
+            bottomTabBarPadding
         }
     }
 }
@@ -154,8 +154,10 @@ struct TimetableGridView: View {
                     }
                 }
             }
+            .padding(.trailing)
+            
+            bottomTabBarPadding
         }
-        
     }
 }
 
@@ -188,6 +190,11 @@ struct TimeGroupMiniList: View {
         }.background(Color.clear)
             
     }
+}
+
+fileprivate var bottomTabBarPadding: some View {
+    // bottom floating tabbar padding
+    Color.clear.padding(.bottom, 60)
 }
 
 extension RoomType {


### PR DESCRIPTION
## Issue
- close #618 

## Overview (Required)
- Added 16 end paddings to gridView.
- The bottom padding was specified as 16. However I have changed it to 60(including the height of the bottom tab), to match the case of the List View. Therefore, we have added 68(60 +  default spacing 8).


## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/53409ab0-2fe3-44d6-942e-fff99dd0b5ff" width="300"> | <img src="https://github.com/user-attachments/assets/e6db9957-279f-4c3d-8f4d-43055fdbbda0" width="300"> 

