### PR TITLE
Container conform to `Sendable` to resolve Swfit 6 warning

### DIFF
--- a/app-ios/Sources/KMPClient/Helpers/Container.swift
+++ b/app-ios/Sources/KMPClient/Helpers/Container.swift
@@ -6,7 +6,7 @@ public func prepareFirebase() {
     FirebaseApp.configure()
 }
 
-public struct Container {
+public struct Container: Sendable {
     public static let shared: Container = .init()
 
     private let entryPoint: KmpEntryPoint


### PR DESCRIPTION
## Issue
- In progress #431

## Overview (Required)
- Container type conforms to `Sendable`

## Links
- https://twitter.com/omochimetaru/status/1825402485084979428

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/cba23f51-f133-4064-9e80-291de510ad50" width="300" /> | <img src="https://github.com/user-attachments/assets/29d59167-2a14-4dc9-b9ce-871d658cf29e" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
