### PR TITLE
Enable largeHeap to prevent OutOfMemoryError on some devices (Android)

### DIFF
--- a/app-android/src/main/AndroidManifest.xml
+++ b/app-android/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:largeHeap="true"
         android:localeConfig="@xml/locales_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- Due to recurring OutOfMemoryError issues when loading `animated image vector(anim_header_title.xml)` resource on certain devices (Medium Tablet API 25), this commit enables the `largeHeap` configuration in the AndroidManifest. 
- In an effort to address these memory issues, enabling the `largeHeap` configuration in the AndroidManifest has been considered as a temporary solution. This change aims to provide more heap space to prevent crashes and improve the stability of the application on devices with limited memory resources.

- However, it's important to note that using `largeHeap=true` is generally discouraged as it can lead to poorer system performance and longer garbage collection times, negatively impacting the user experience. This decision was not made lightly; alternatives such as resizing the `animated-vector` files or optimizing memory management within the app were considered. Unfortunately, the inherent complexity of the vectors and the anticipated loss of quality in animations from resizing the vector files were problematic.

## Links
- [android:largeHeap](https://developer.android.com/guide/topics/manifest/application-element?hl=en)

## Screenshot (Optional if screenshot test is present or unrelated to UI)
<img width="902" alt="image" src="https://github.com/user-attachments/assets/a01fac15-a78b-4eed-8e68-64d9307204c6">

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/97eaa3f8-85f6-4251-b6d1-0948cb6e7632" width="300" > | <video src="https://github.com/user-attachments/assets/b47fa837-5dcb-4684-bad2-11f6eebc647c" width="300" >


