### PR TITLE
Not to show any card at first on SearchScreen

### DIFF
--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/Filters.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/Filters.kt
@@ -7,4 +7,13 @@ public data class Filters(
     val languages: List<Lang> = emptyList(),
     val filterFavorite: Boolean = false,
     val searchWord: String = "",
-)
+) {
+
+    fun isEmpty() = days.isEmpty() &&
+        categories.isEmpty() &&
+        sessionTypes.isEmpty() &&
+        languages.isEmpty() &&
+        searchWord.isEmpty()
+
+    fun isNotEmpty() = isEmpty().not()
+}

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/Filters.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/Filters.kt
@@ -9,6 +9,11 @@ public data class Filters(
     val searchWord: String = "",
 ) {
 
+    /**
+     * Checks if all filtering criteria are empty.
+     *
+     * @return True if all criteria are empty; false otherwise.
+     */
     fun isEmpty() = days.isEmpty() &&
         categories.isEmpty() &&
         sessionTypes.isEmpty() &&

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/Filters.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/Filters.kt
@@ -18,6 +18,7 @@ public data class Filters(
         categories.isEmpty() &&
         sessionTypes.isEmpty() &&
         languages.isEmpty() &&
+        !filterFavorite &&
         searchWord.isEmpty()
 
     fun isNotEmpty() = isEmpty().not()

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/Filters.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/Filters.kt
@@ -18,7 +18,7 @@ public data class Filters(
         categories.isEmpty() &&
         sessionTypes.isEmpty() &&
         languages.isEmpty() &&
-        !filterFavorite &&
+        filterFavorite.not() &&
         searchWord.isEmpty()
 
     fun isNotEmpty() = isEmpty().not()

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/Timetable.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/Timetable.kt
@@ -56,7 +56,7 @@ public data class Timetable(
     }
 
     public fun filtered(filters: Filters): Timetable {
-        if (filters.isEmpty()) {
+        if (!filters.filterFavorite && filters.isEmpty()) {
             return copy(timetableItems = TimetableItemList())
         }
         var timetableItems = timetableItems.toList()

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/Timetable.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/Timetable.kt
@@ -56,6 +56,9 @@ public data class Timetable(
     }
 
     public fun filtered(filters: Filters): Timetable {
+        if (filters.isEmpty()) {
+            return copy(timetableItems = TimetableItemList())
+        }
         var timetableItems = timetableItems.toList()
         if (filters.days.isNotEmpty()) {
             timetableItems = timetableItems.filter { timetableItem ->

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/Timetable.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/Timetable.kt
@@ -56,9 +56,6 @@ public data class Timetable(
     }
 
     public fun filtered(filters: Filters): Timetable {
-        if (!filters.filterFavorite && filters.isEmpty()) {
-            return copy(timetableItems = TimetableItemList())
-        }
         var timetableItems = timetableItems.toList()
         if (filters.days.isNotEmpty()) {
             timetableItems = timetableItems.filter { timetableItem ->

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/SearchScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/SearchScreenRobot.kt
@@ -2,6 +2,7 @@ package io.github.droidkaigi.confsched.testing.robot
 
 import androidx.compose.ui.test.assertAll
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.filter
@@ -267,6 +268,12 @@ class SearchScreenRobot @Inject constructor(
             .assertAll(hasText(text = searchWord, ignoreCase = true))
     }
 
+    fun checkTimetableListExists() {
+        composeTestRule
+            .onNode(hasTestTag(TimetableListTestTag))
+            .assertExists()
+    }
+
     fun checkTimetableListDisplayed() {
         composeTestRule
             .onNode(hasTestTag(TimetableListTestTag))
@@ -278,5 +285,12 @@ class SearchScreenRobot @Inject constructor(
             .onAllNodesWithTag(TimetableItemCardTestTag)
             .onFirst()
             .assertIsDisplayed()
+    }
+
+    fun checkTimetableListItemsNotDisplayed() {
+        composeTestRule
+            .onAllNodesWithTag(TimetableItemCardTestTag)
+            .onFirst()
+            .assertIsNotDisplayed()
     }
 }

--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenPresenter.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenPresenter.kt
@@ -99,7 +99,12 @@ private fun favoritesSheet(
 ): FavoritesSheetUiState {
     val filteredSessions by rememberUpdatedState(
         favoriteSessions
-            .filtered(Filters(days = selectedDayFilters.toList())),
+            .filtered(
+                Filters(
+                    filterFavorite = true,
+                    days = selectedDayFilters.toList(),
+                ),
+            ),
     )
 
     return if (filteredSessions.isEmpty()) {

--- a/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
+++ b/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
@@ -46,10 +46,10 @@ class SearchScreenTest(
                         setupTimetableServer(ServerStatus.Operational)
                         setupSearchScreenContent()
                     }
-                    itShould("show non-filtered timetable items") {
+                    itShould("no timetable items are displayed") {
                         captureScreenWithChecks {
-                            checkTimetableListDisplayed()
-                            checkTimetableListItemsDisplayed()
+                            checkTimetableListExists()
+                            checkTimetableListItemsNotDisplayed()
                         }
                     }
                     describe("input search word to TextField") {
@@ -60,6 +60,8 @@ class SearchScreenTest(
                             captureScreenWithChecks {
                                 checkDemoSearchWordDisplayed()
                                 checkTimetableListItemsHasDemoText()
+                                checkTimetableListDisplayed()
+                                checkTimetableListItemsDisplayed()
                             }
                         }
                     }
@@ -84,6 +86,8 @@ class SearchScreenTest(
                                         checkTimetableListItemByConferenceDay(
                                             checkDay = conference,
                                         )
+                                        checkTimetableListDisplayed()
+                                        checkTimetableListItemsDisplayed()
                                     }
                                 }
                             }
@@ -108,6 +112,8 @@ class SearchScreenTest(
                                 itShould("selected category ${category.categoryName}") {
                                     captureScreenWithChecks {
                                         checkTimetableListItemByCategory(category)
+                                        checkTimetableListDisplayed()
+                                        checkTimetableListItemsDisplayed()
                                     }
                                 }
                             }
@@ -133,6 +139,8 @@ class SearchScreenTest(
                                 itShould("selected language ${language.name}") {
                                     captureScreenWithChecks {
                                         checkTimetableListItemByLanguage(language)
+                                        checkTimetableListDisplayed()
+                                        checkTimetableListItemsDisplayed()
                                     }
                                 }
                             }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenPresenter.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenPresenter.kt
@@ -15,6 +15,7 @@ import io.github.droidkaigi.confsched.model.Lang
 import io.github.droidkaigi.confsched.model.SessionsRepository
 import io.github.droidkaigi.confsched.model.TimetableCategory
 import io.github.droidkaigi.confsched.model.TimetableItem
+import io.github.droidkaigi.confsched.model.TimetableItemList
 import io.github.droidkaigi.confsched.model.TimetableSessionType
 import io.github.droidkaigi.confsched.model.localSessionsRepository
 import io.github.droidkaigi.confsched.sessions.SearchScreenEvent.Bookmark
@@ -65,7 +66,7 @@ fun searchScreenPresenter(
         }
     }
     val filteredSessions by rememberUpdatedState(
-        sessions.filtered(filters).timetableItems,
+        if (filters.isEmpty()) TimetableItemList() else sessions.filtered(filters).timetableItems,
     )
 
     val searchFilterDayUiState: SearchFilterUiState<DroidKaigi2024Day> by rememberUpdatedState(

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenPresenter.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenPresenter.kt
@@ -1,9 +1,11 @@
 package io.github.droidkaigi.confsched.sessions
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import io.github.droidkaigi.confsched.compose.SafeLaunchedEffect
@@ -51,17 +53,19 @@ fun searchScreenPresenter(
     val selectedSessionTypes = rememberRetained { mutableStateListOf<TimetableSessionType>() }
     val selectedCategories = rememberRetained { mutableStateListOf<TimetableCategory>() }
     val selectedLanguages = rememberRetained { mutableStateListOf<Lang>() }
-
-    val filteredSessions by rememberUpdatedState(
-        sessions.filtered(
+    val filters by remember {
+        derivedStateOf {
             Filters(
                 searchWord = searchWord,
                 days = selectedDays,
                 categories = selectedCategories,
                 sessionTypes = selectedSessionTypes,
                 languages = selectedLanguages,
-            ),
-        ).timetableItems,
+            )
+        }
+    }
+    val filteredSessions by rememberUpdatedState(
+        sessions.filtered(filters).timetableItems,
     )
 
     val searchFilterDayUiState: SearchFilterUiState<DroidKaigi2024Day> by rememberUpdatedState(
@@ -147,7 +151,7 @@ fun searchScreenPresenter(
     }
 
     when {
-        filteredSessions.isEmpty() -> {
+        filters.isNotEmpty() && filteredSessions.isEmpty() -> {
             SearchScreenUiState.Empty(
                 searchWord = searchWord,
                 searchFilterDayUiState = searchFilterDayUiState,


### PR DESCRIPTION
## Issue
- close #496 

## Overview (Required)
- nobonobopurin-san says at issue, I'd like to adjust search screen such as followings
  - all filters are not set and search text is empty -> nothing to show
  - some filters are set or search text is not empty -> show search result
  - filter criteria are not empty and filter result is empty -> show empty message

## Links
- https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=54953-72675&t=Lg4yETysBVrI2dXJ-0

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/ac8a2a35-c0d4-44d8-889d-4fa3c7063d98" width="300" > | <video src="https://github.com/user-attachments/assets/e106c343-7da5-465e-839c-6b5cf0f45e96" width="300" >

