### PR TITLE
Use cardType property instead of theme, since the property is Deprecated

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/ProfileCardJson.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/ProfileCardJson.kt
@@ -11,8 +11,6 @@ internal data class ProfileCardJson(
     val occupation: String,
     val link: String,
     val image: String,
-    @Deprecated("Use cardType instead", replaceWith = ReplaceWith("cardType"))
-    val theme: String? = null,
     @SerialName("card_type")
     val cardType: String? = null,
 )

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/ProfileCardJson.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/ProfileCardJson.kt
@@ -22,7 +22,7 @@ internal fun ProfileCardJson.toModel() = ProfileCard.Exists(
     occupation = occupation,
     link = link,
     image = image,
-    cardType = checkNotNull(cardType ?: theme).toProfileCardType(),
+    cardType = checkNotNull(cardType ?: cardType).toProfileCardType(),
 )
 
 internal fun String.toProfileCardType() = ProfileCardType.valueOf(this)

--- a/core/data/src/commonTest/kotlin/io/github/droidkaigi/confsched/data/profilecard/ProfileCardJsonTest.kt
+++ b/core/data/src/commonTest/kotlin/io/github/droidkaigi/confsched/data/profilecard/ProfileCardJsonTest.kt
@@ -24,7 +24,7 @@ class ProfileCardJsonTest {
         assertEquals("test occupation", profileCardJson.occupation)
         assertEquals("https://github.com/DroidKaigi/conference-app-2024", profileCardJson.link)
         assertEquals("BASE64_ENCODED_SAMPLE_IMAGE_STRING", profileCardJson.image)
-        assertEquals("Iguana", profileCardJson.theme)
+        assertEquals("Iguana", profileCardJson.cardType)
         assertNull(profileCardJson.cardType)
     }
 
@@ -44,7 +44,7 @@ class ProfileCardJsonTest {
         assertEquals("test occupation", profileCardJson.occupation)
         assertEquals("https://github.com/DroidKaigi/conference-app-2024", profileCardJson.link)
         assertEquals("BASE64_ENCODED_SAMPLE_IMAGE_STRING", profileCardJson.image)
-        assertNull(profileCardJson.theme)
+        assertNull(profileCardJson.cardType)
         assertEquals("Iguana", profileCardJson.cardType)
     }
 


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- The theme property is Deprecated in `ProfileCardJson`, so replace it.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
