### PR TITLE
[iOS] Changed to get real event map data

### DIFF
--- a/core/data/src/iosMain/kotlin/io/github/droidkaigi/confsched/data/DataModule.kt
+++ b/core/data/src/iosMain/kotlin/io/github/droidkaigi/confsched/data/DataModule.kt
@@ -8,9 +8,9 @@ import io.github.droidkaigi.confsched.data.contributors.DefaultContributorsApiCl
 import io.github.droidkaigi.confsched.data.contributors.DefaultContributorsRepository
 import io.github.droidkaigi.confsched.data.core.defaultJson
 import io.github.droidkaigi.confsched.data.core.defaultKtorConfig
+import io.github.droidkaigi.confsched.data.eventmap.DefaultEventMapApiClient
 import io.github.droidkaigi.confsched.data.eventmap.DefaultEventMapRepository
 import io.github.droidkaigi.confsched.data.eventmap.EventMapApiClient
-import io.github.droidkaigi.confsched.data.eventmap.DefaultEventMapApiClient
 import io.github.droidkaigi.confsched.data.sessions.DefaultSessionsApiClient
 import io.github.droidkaigi.confsched.data.sessions.DefaultSessionsRepository
 import io.github.droidkaigi.confsched.data.sessions.SessionCacheDataStore

--- a/core/data/src/iosMain/kotlin/io/github/droidkaigi/confsched/data/DataModule.kt
+++ b/core/data/src/iosMain/kotlin/io/github/droidkaigi/confsched/data/DataModule.kt
@@ -10,7 +10,7 @@ import io.github.droidkaigi.confsched.data.core.defaultJson
 import io.github.droidkaigi.confsched.data.core.defaultKtorConfig
 import io.github.droidkaigi.confsched.data.eventmap.DefaultEventMapRepository
 import io.github.droidkaigi.confsched.data.eventmap.EventMapApiClient
-import io.github.droidkaigi.confsched.data.eventmap.FakeEventMapApiClient
+import io.github.droidkaigi.confsched.data.eventmap.DefaultEventMapApiClient
 import io.github.droidkaigi.confsched.data.sessions.DefaultSessionsApiClient
 import io.github.droidkaigi.confsched.data.sessions.DefaultSessionsRepository
 import io.github.droidkaigi.confsched.data.sessions.SessionCacheDataStore
@@ -121,7 +121,7 @@ public val dataModule: Module = module {
     singleOf(::DefaultContributorsApiClient) bind ContributorsApiClient::class
     singleOf(::DefaultSponsorsApiClient) bind SponsorsApiClient::class
     singleOf(::DefaultStaffApiClient) bind StaffApiClient::class
-    singleOf(::FakeEventMapApiClient) bind EventMapApiClient::class
+    singleOf(::DefaultEventMapApiClient) bind EventMapApiClient::class
 
     singleOf(::NetworkService)
     singleOf(::DefaultSessionsRepository) bind SessionsRepository::class

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/EventMapRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/EventMapRepository.kt
@@ -4,9 +4,11 @@ import androidx.compose.runtime.Composable
 import io.github.droidkaigi.confsched.model.compositionlocal.LocalRepositories
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.coroutines.flow.Flow
+import kotlin.coroutines.cancellation.CancellationException
 
 interface EventMapRepository {
 
+    @Throws(CancellationException::class)
     suspend fun refresh()
 
     @Composable


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
Currently, iOS app get fake event map data. Since api to get real event map data was implemented on server, I replaced EventMapApiClient dependency.

## Links
- 

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="https://github.com/user-attachments/assets/12022084-596f-4f6e-bdbd-3e5e3fbf82e5" width="300" >
