### PR TITLE
Removed problematic toast (was not specified in Figma for this view)

### DIFF
--- a/app-ios/Sources/TimetableFeature/Resource/Localizable.xcstrings
+++ b/app-ios/Sources/TimetableFeature/Resource/Localizable.xcstrings
@@ -14,16 +14,6 @@
     "|" : {
 
     },
-    "AddFavorite" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ブックマークに追加されました"
-          }
-        }
-      }
-    },
     "Timetable" : {
       "localizations" : {
         "ja" : {

--- a/app-ios/Sources/TimetableFeature/TimetableListView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableListView.swift
@@ -40,7 +40,6 @@ public struct TimetableView: View {
             }
             Spacer()
         }
-        .toast($store.toast)
         .background(AssetColors.Surface.surface.swiftUIColor)
         .frame(maxWidth: .infinity)
         .toolbar{

--- a/app-ios/Sources/TimetableFeature/TimetableReducer.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableReducer.swift
@@ -105,9 +105,7 @@ public struct TimetableReducer : Sendable{
                     }))
                 }
             case let .favoriteResponse(.success(isFavorited)):
-                if !isFavorited {
-                    state.toast = .init(text: String(localized: "AddFavorite", bundle: .module))
-                }
+                //No response here on purpose. Toasts look bad here.
                 return .none
             case let .favoriteResponse(.failure(error)):
                 print(error.localizedDescription)

--- a/app-ios/Sources/TimetableFeature/TimetableReducer.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableReducer.swift
@@ -25,7 +25,7 @@ public struct TimetableReducer : Sendable{
         case view(View)
         case requestDay(DayTab)
         case response(Result<[TimetableItemWithFavorite], any Error>)
-        case favoriteResponse(Result<Bool, any Error>)
+        case favoriteResponse(Result<Void, any Error>)
         
         public enum View : Sendable {
             case onAppear
@@ -100,11 +100,9 @@ public struct TimetableReducer : Sendable{
                 return .run { send in
                     await send(.favoriteResponse(Result {
                         try await timetableClient.toggleBookmark(id: item.timetableItem.id)
-                        return item.isFavorited
                     }))
                 }
-            case .favoriteResponse(.success(_)):
-                //No response here on purpose. Toasts look bad here.
+            case .favoriteResponse(.success):
                 return .none
             case let .favoriteResponse(.failure(error)):
                 print(error.localizedDescription)

--- a/app-ios/Sources/TimetableFeature/TimetableReducer.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableReducer.swift
@@ -14,7 +14,6 @@ public struct TimetableReducer : Sendable{
     @ObservableState
     public struct State: Equatable {
         var timetableItems: [TimetableTimeGroupItems] = [] //Should be simple objects
-        var toast: ToastState?
         
         public init(timetableItems: [TimetableTimeGroupItems] = []) {
             self.timetableItems = timetableItems

--- a/app-ios/Sources/TimetableFeature/TimetableReducer.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableReducer.swift
@@ -103,7 +103,7 @@ public struct TimetableReducer : Sendable{
                         return item.isFavorited
                     }))
                 }
-            case let .favoriteResponse(.success(isFavorited)):
+            case .favoriteResponse(.success(_)):
                 //No response here on purpose. Toasts look bad here.
                 return .none
             case let .favoriteResponse(.failure(error)):


### PR DESCRIPTION
## Issue
- close #617

## Overview (Required)
- Toast message removed from timetable list view. The toast conflicted with the floating tab bar and was not specified in Figma (unlike the detail view) so it was removed to match spec.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
