### PR TITLE
use AsyncImage for SponsorItem

### DIFF
--- a/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/component/SponsorItem.kt
+++ b/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/component/SponsorItem.kt
@@ -1,6 +1,5 @@
 package io.github.droidkaigi.confsched.sponsors.component
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -18,7 +17,6 @@ import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.model.Sponsor
 import io.github.droidkaigi.confsched.model.fakes
 import io.github.droidkaigi.confsched.sponsors.SponsorsRes
-import io.github.droidkaigi.confsched.ui.rememberAsyncImagePainter
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 

--- a/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/component/SponsorItem.kt
+++ b/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/component/SponsorItem.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
 import conference_app_2024.feature.sponsors.generated.resources.content_description_sponsor_logo_format
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.model.Sponsor
@@ -35,8 +36,8 @@ fun SponsorItem(
             containerColor = MaterialTheme.colorScheme.inverseSurface,
         ),
     ) {
-        Image(
-            painter = rememberAsyncImagePainter(sponsor.logo),
+        AsyncImage(
+            model = sponsor.logo,
             contentDescription = stringResource(
                 SponsorsRes.string.content_description_sponsor_logo_format,
                 sponsor.name,


### PR DESCRIPTION
## Issue
- close #628 

## Overview (Required)
- As commented [here](https://github.com/DroidKaigi/conference-app-2024/issues/628#issuecomment-2297227838), there was also a problem in 2023's app.
- And I tried to solve `LazyVerticalGrid + coil's painter problem` with `maxBitmapSize` (added to coil pj recently) but it was not a silver bullet.
- Finally, I counldn't find the cause of this issue :pray: So I would like to use AsyncImage as workaround about it.
- If it is not desired, please close this pr :bow: 

## Links
- https://github.com/DroidKaigi/conference-app-2024/issues/628#issuecomment-2297227838
- https://github.com/DroidKaigi/conference-app-2023/issues/1088
- https://github.com/coil-kt/coil/issues/1610

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/fd34c0b8-edb8-4dea-90aa-f2b7a83a0102" width="300" > | <video src="https://github.com/user-attachments/assets/40c90a35-a903-49f5-90ff-667de313330d" width="300" >




