### PR TITLE
:wrench: Addressed an issue where the app would almost certainly crash with an OOM error when the VectorDrawable was displayed large on devices prior to API Level 27.

### DIFF
--- a/core/ui/src/androidMain/kotlin/io/github/droidkaigi/confsched/ui/CanShowLargeVector.android.kt
+++ b/core/ui/src/androidMain/kotlin/io/github/droidkaigi/confsched/ui/CanShowLargeVector.android.kt
@@ -1,0 +1,10 @@
+package io.github.droidkaigi.confsched.ui
+
+import android.os.Build
+import android.os.Build.VERSION_CODES
+import androidx.annotation.ChecksSdkIntAtLeast
+
+@ChecksSdkIntAtLeast(api = VERSION_CODES.O_MR1)
+actual fun canShowLargeVector(): Boolean {
+    return Build.VERSION.SDK_INT > 26
+}

--- a/core/ui/src/androidMain/kotlin/io/github/droidkaigi/confsched/ui/ProvideAboutHeaderPainter.kt
+++ b/core/ui/src/androidMain/kotlin/io/github/droidkaigi/confsched/ui/ProvideAboutHeaderPainter.kt
@@ -11,21 +11,27 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.painter.Painter
+import conference_app_2024.core.ui.generated.resources.about_header_title
 import io.github.droidkaigi.confsched.core.ui.R
+import org.jetbrains.compose.resources.painterResource
 
 @OptIn(ExperimentalAnimationGraphicsApi::class)
 @Composable
-actual fun provideAboutHeaderTitlePainter(): Painter {
-    var animationPlayed by remember { mutableStateOf(false) }
+actual fun provideAboutHeaderTitlePainter(enableAnimation: Boolean): Painter {
+    return if (enableAnimation) {
+        var animationPlayed by remember { mutableStateOf(false) }
 
-    val painter = rememberAnimatedVectorPainter(
-        animatedImageVector = AnimatedImageVector.animatedVectorResource(id = R.drawable.anim_header_title),
-        atEnd = animationPlayed,
-    )
+        val painter = rememberAnimatedVectorPainter(
+            animatedImageVector = AnimatedImageVector.animatedVectorResource(id = R.drawable.anim_header_title),
+            atEnd = animationPlayed,
+        )
 
-    LaunchedEffect(Unit) {
-        animationPlayed = true
+        LaunchedEffect(Unit) {
+            animationPlayed = true
+        }
+
+        painter
+    } else {
+        painterResource(UiRes.drawable.about_header_title)
     }
-
-    return painter
 }

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/CanShowLargeVector.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/CanShowLargeVector.kt
@@ -1,0 +1,3 @@
+package io.github.droidkaigi.confsched.ui
+
+expect fun canShowLargeVector(): Boolean

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/ProvideAboutHeaderPainter.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/ProvideAboutHeaderPainter.kt
@@ -4,4 +4,4 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.painter.Painter
 
 @Composable
-expect fun provideAboutHeaderTitlePainter(): Painter
+expect fun provideAboutHeaderTitlePainter(enableAnimation: Boolean = true): Painter

--- a/core/ui/src/iosMain/kotlin/io/github/droidkaigi/confsched/ui/CanShowLargeVector.ios.kt
+++ b/core/ui/src/iosMain/kotlin/io/github/droidkaigi/confsched/ui/CanShowLargeVector.ios.kt
@@ -1,0 +1,6 @@
+package io.github.droidkaigi.confsched.ui
+
+actual fun canShowLargeVector(): Boolean {
+    // The process is only relevant to Android, so it always returns true.
+    return true
+}

--- a/core/ui/src/iosMain/kotlin/io/github/droidkaigi/confsched/ui/ProvideAboutHeaderPainter.kt
+++ b/core/ui/src/iosMain/kotlin/io/github/droidkaigi/confsched/ui/ProvideAboutHeaderPainter.kt
@@ -6,6 +6,6 @@ import conference_app_2024.core.ui.generated.resources.about_header_title
 import org.jetbrains.compose.resources.painterResource
 
 @Composable
-actual fun provideAboutHeaderTitlePainter(): Painter {
+actual fun provideAboutHeaderTitlePainter(enableAnimation: Boolean): Painter {
     return painterResource(UiRes.drawable.about_header_title)
 }

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/section/AboutDroidKaigiDetail.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/section/AboutDroidKaigiDetail.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
@@ -26,6 +27,7 @@ import io.github.droidkaigi.confsched.about.AboutRes
 import io.github.droidkaigi.confsched.about.component.AboutDroidKaigiDetailSummaryCard
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.ui.UiRes
+import io.github.droidkaigi.confsched.ui.canShowLargeVector
 import io.github.droidkaigi.confsched.ui.provideAboutHeaderTitlePainter
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -58,22 +60,30 @@ fun AboutDroidKaigiDetail(
     Column(
         modifier = modifier.testTag(AboutDetailTestTag),
     ) {
-        Box {
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.Center,
+        ) {
+            val imageModifier = if (canShowLargeVector()) {
+                Modifier
+                    .fillMaxWidth()
+                    .offset(y = aboutHeaderOffset.dp)
+            } else {
+                // Some API Levels are not optimized to handle VectorDrawable, so OOM occurs when large VectorDrawable is displayed.
+                // Therefore, depending on the API Level, whether or not to display an Image in its full width should be separated.
+                Modifier
+            }
             Image(
                 painter = painterResource(UiRes.drawable.about_header_year),
                 contentDescription = null,
                 contentScale = ContentScale.FillWidth,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .offset(y = aboutHeaderOffset.dp),
+                modifier = imageModifier,
             )
             Image(
-                painter = provideAboutHeaderTitlePainter(),
+                painter = provideAboutHeaderTitlePainter(canShowLargeVector()),
                 contentDescription = null,
                 contentScale = ContentScale.FillWidth,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .offset(y = aboutHeaderOffset.dp),
+                modifier = imageModifier,
             )
         }
         Text(


### PR DESCRIPTION
## Issue
- close #650 

## Overview (Required)
- For devices with API level less than 27, the behavior has been corrected so that the following two things happen.
1. The header image of the AboutScreen is no longer displayed at the full width.
2. AnimatedVectorDrawable is no longer used for the header image.

## Links
- https://github.com/DroidKaigi/conference-app-2024/pull/650#issuecomment-2297812665

## Movie (Optional)

- Before

<img src="https://github.com/user-attachments/assets/2b162690-ee72-411f-a34f-bbebd08ff5f5" width="640" >

- After

<img src="https://github.com/user-attachments/assets/72a5874d-8a6a-4a95-b1ca-6eb00cca281b" width="640" >