### PR TITLE
Display description of the timetable detail screen in device language by default

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailPresenter.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailPresenter.kt
@@ -16,6 +16,7 @@ import io.github.droidkaigi.confsched.model.SessionsRepository
 import io.github.droidkaigi.confsched.model.TimetableItem
 import io.github.droidkaigi.confsched.model.TimetableItemId
 import io.github.droidkaigi.confsched.model.TimetableSessionType.NORMAL
+import io.github.droidkaigi.confsched.model.defaultLang
 import io.github.droidkaigi.confsched.model.localSessionsRepository
 import io.github.droidkaigi.confsched.sessions.TimetableItemDetailEvent.Bookmark
 import io.github.droidkaigi.confsched.sessions.TimetableItemDetailEvent.FavoriteListNavigated
@@ -48,7 +49,7 @@ fun timetableItemDetailPresenter(
         sessionsRepository
             .timetableItemWithBookmark(timetableItemId),
     )
-    var selectedDescriptionLanguage by remember { mutableStateOf<Lang?>(null) }
+    var selectedDescriptionLanguage by remember { mutableStateOf<Lang>(defaultLang()) }
     var shouldGoToFavoriteList by remember { mutableStateOf(false) }
     val bookmarkedSuccessfullyString = stringResource(SessionsRes.string.bookmarked_successfully)
     val viewBookmarkListString = stringResource(SessionsRes.string.view_bookmark_list)
@@ -82,12 +83,6 @@ fun timetableItemDetailPresenter(
                     shouldGoToFavoriteList = false
                 }
             }
-        }
-    }
-    SafeLaunchedEffect(timetableItemStateWithBookmark?.first) {
-        val timetableItem = timetableItemStateWithBookmark?.first ?: return@SafeLaunchedEffect
-        if (selectedDescriptionLanguage == null) {
-            selectedDescriptionLanguage = Lang.valueOf(timetableItem.language.langOfSpeaker)
         }
     }
     Logger.d {

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
@@ -137,7 +137,7 @@ sealed interface TimetableItemDetailScreenUiState {
         val timetableItemDetailSectionUiState: TimetableItemDetailSectionUiState,
         val isBookmarked: Boolean,
         val isLangSelectable: Boolean,
-        val currentLang: Lang?,
+        val currentLang: Lang,
         val roomThemeKey: String,
         val shouldGoToFavoriteList: Boolean,
         override val timetableItemId: TimetableItemId,

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailContent.kt
@@ -80,7 +80,7 @@ fun TimetableItemDetailContent(
 
             is Special -> {
                 DescriptionSection(
-                    description = timetableItem.description.currentLangTitle,
+                    description = timetableItem.description.getByLang(currentLang),
                     onLinkClick = onLinkClick,
                 )
                 TargetAudienceSection(timetableItem = timetableItem)

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailContent.kt
@@ -45,6 +45,7 @@ import io.github.droidkaigi.confsched.model.Lang
 import io.github.droidkaigi.confsched.model.TimetableItem
 import io.github.droidkaigi.confsched.model.TimetableItem.Session
 import io.github.droidkaigi.confsched.model.TimetableItem.Special
+import io.github.droidkaigi.confsched.model.defaultLang
 import io.github.droidkaigi.confsched.model.fake
 import io.github.droidkaigi.confsched.sessions.SessionsRes
 import org.jetbrains.compose.resources.stringResource
@@ -56,14 +57,13 @@ const val DescriptionMoreButtonTestTag = "DescriptionMoreButtonTestTag"
 @Composable
 fun TimetableItemDetailContent(
     timetableItem: TimetableItem,
-    currentLang: Lang?,
+    currentLang: Lang,
     modifier: Modifier = Modifier,
     onLinkClick: (url: String) -> Unit,
 ) {
     Column(modifier = modifier) {
         when (timetableItem) {
             is Session -> {
-                val currentLang = currentLang ?: Lang.ENGLISH
                 DescriptionSection(
                     description = timetableItem.description.getByLang(currentLang),
                     onLinkClick = onLinkClick,

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailHeadline.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailHeadline.kt
@@ -35,11 +35,10 @@ const val TimetableItemDetailHeadlineTestTag = "TimetableItemDetailHeadlineTestT
 
 @Composable
 fun TimetableItemDetailHeadline(
-    currentLang: Lang?,
+    currentLang: Lang,
     timetableItem: TimetableItem,
     modifier: Modifier = Modifier,
 ) {
-    val currentLang = currentLang ?: Lang.ENGLISH
     Column(
         modifier = modifier
             // FIXME: Implement and use a theme color instead of fixed colors like RoomColors.primary and RoomColors.primaryDim


### PR DESCRIPTION
## Issue
- close #576

## Overview (Required)
- On the timetable detail screen, the description now reflects the device/app preferred language by default.
  - We may also want to switch the lang of the target audience description, but looks like the API has no i18n field for that.
- It still reflects the user language menu selection on the fly.
- Some codes are no longer needed, so dropped.

## Links
N/A

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Device Lang | Before | After
:--: | :--: | :--:
English | ![image](https://github.com/user-attachments/assets/ba454933-b5be-4c8e-967e-2b676c1f2635) | ![image](https://github.com/user-attachments/assets/f379d8a0-09b5-4a71-a96d-fe280615cda9)
Japanese | ![image](https://github.com/user-attachments/assets/f9ba4af3-edff-4315-bb2a-66bbac1667ee) | ![image](https://github.com/user-attachments/assets/dc1e6bfd-0831-4f6a-b61f-6fc37c69c055)
Otherwise (Chinese) | ![image](https://github.com/user-attachments/assets/aff5f678-c245-4f36-8866-f9fc769486b2) | ![image](https://github.com/user-attachments/assets/ac4690d9-4f1e-4bf3-bf98-d75fae990edf)

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/3b43895b-4d1b-492a-9602-c7363a602738" width="300" /> | <video src="https://github.com/user-attachments/assets/52ce059a-846e-48ce-b34b-3be11eb12cb3" width="300" />

