### PR TITLE
Enable to display category chip data (from State) in SearchView 

### DIFF
--- a/app-ios/Sources/SearchFeature/Resources/Localizable.xcstrings
+++ b/app-ios/Sources/SearchFeature/Resources/Localizable.xcstrings
@@ -2,11 +2,30 @@
   "sourceLanguage" : "en",
   "strings" : {
     "「%@」と一致する検索結果がありません" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nothing matched your search criteria \"%@\""
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」と一致する検索結果がありません"
+          }
+        }
+      }
     },
     "9/11" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "9/11"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "9/11"
@@ -21,12 +40,24 @@
             "state" : "translated",
             "value" : "9/12"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "9/12"
+          }
         }
       }
     },
     "9/13" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "9/13"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "9/13"
@@ -41,6 +72,12 @@
             "state" : "translated",
             "value" : "Category"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カテゴリ"
+          }
         }
       }
     },
@@ -50,6 +87,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Session type"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セッション種別"
           }
         }
       }
@@ -61,6 +104,12 @@
             "state" : "translated",
             "value" : "Supported languages"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "対応言語"
+          }
         }
       }
     },
@@ -70,6 +119,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Day"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開催日"
           }
         }
       }

--- a/app-ios/Sources/SearchFeature/SearchView.swift
+++ b/app-ios/Sources/SearchFeature/SearchView.swift
@@ -121,7 +121,7 @@ public struct SearchView: View {
     }
 
     // MEMO: All Category can get from timetable TimetableCategories get timetable model.
-    // (searchCategoryFilterChip have not conform to Selectable protocol.)
+    // (TimetableCategory don't have to conform to Selectable protocol.)
     private func searchCategoryFilterChip(
         allCategories: [TimetableCategory],
         selection: TimetableCategory?,

--- a/app-ios/Sources/SearchFeature/SearchView.swift
+++ b/app-ios/Sources/SearchFeature/SearchView.swift
@@ -91,7 +91,8 @@ public struct SearchView: View {
                         store.send(.view(.selectedDayChanged($0)))
                     }
                 )
-                searchFilterChip(
+                searchCategoryFilterChip(
+                    allCategories: store.timetable?.categories ?? [],
                     selection: store.selectedCategory,
                     defaultTitle: String(localized: "カテゴリ", bundle: .module),
                     onSelect: {
@@ -116,6 +117,37 @@ public struct SearchView: View {
             .padding(.horizontal, 16)
             .padding(.top, 8)
             .padding(.bottom, 12)
+        }
+    }
+
+    // MEMO: All Category can get from timetable TimetableCategories get timetable model.
+    // (searchCategoryFilterChip have not conform to Selectable protocol.)
+    private func searchCategoryFilterChip(
+        allCategories: [TimetableCategory],
+        selection: TimetableCategory?,
+        defaultTitle: String,
+        onSelect: @escaping (TimetableCategory) -> Void
+    ) -> some View {
+        Menu {
+            ForEach(allCategories, id: \.id) { category in
+                Button {
+                    onSelect(category)
+                } label: {
+                    HStack {
+                        if category == selection {
+                            Image(.icCheck)
+                        }
+                        Text(category.title.currentLangTitle)
+                    }
+                }
+            }
+
+        } label: {
+            SelectionChip(
+                title: selection?.title.currentLangTitle ?? defaultTitle,
+                isMultiSelect: true,
+                isSelected: selection != nil
+            ) {}
         }
     }
 
@@ -174,23 +206,6 @@ extension DroidKaigi2024Day {
 
     public static var options: [DroidKaigi2024Day] {
         [.conferenceDay1, .conferenceDay2]
-    }
-}
-
-#if hasFeature(RetroactiveAttribute)
-extension TimetableCategory: @retroactive Selectable {}
-#else
-extension TimetableCategory: Selectable {}
-#endif
-
-extension TimetableCategory {
-    public var caseTitle: String {
-        title.currentLangTitle
-    }
-    
-    static public var allCases: [TimetableCategory] {
-        // TODO: use correct
-        []
     }
 }
 


### PR DESCRIPTION
## Issue
- https://github.com/DroidKaigi/conference-app-2024/issues/442

## Overview (Required)
- We have created a new `private func searchCategoryFilterChip` so that you can filter by category list.
  - All Category can get from timetable TimetableCategories get timetable model.
  - (TimetableCategory don't have to conform to Selectable protocol.)
- In addition, we are adjusting the localization strings required for SearchView.

## Movie
ja | en
:--: | :--:
<video src="https://github.com/user-attachments/assets/ddac6e7c-fa0f-4fa4-a314-82f78c74af61" width="300" > | <video src="https://github.com/user-attachments/assets/0fdb5c65-f529-408b-a525-e348bafd93d7" width="300" >

