### PR TITLE
feat: add session time in FavoritesScreen

### DIFF
--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/TimetableTime.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/TimetableTime.kt
@@ -1,4 +1,4 @@
-package io.github.droidkaigi.confsched.sessions.component
+package io.github.droidkaigi.confsched.ui.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement

--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreen.kt
@@ -23,15 +23,15 @@ import io.github.droidkaigi.confsched.compose.rememberEventEmitter
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.favorites.section.FavoriteSheet
 import io.github.droidkaigi.confsched.favorites.section.FavoritesSheetUiState
+import io.github.droidkaigi.confsched.favorites.section.FavoritesSheetUiState.FavoriteListUiState.TimeSlot
 import io.github.droidkaigi.confsched.model.DroidKaigi2024Day
-import io.github.droidkaigi.confsched.model.Timetable
 import io.github.droidkaigi.confsched.model.TimetableItem
-import io.github.droidkaigi.confsched.model.fake
 import io.github.droidkaigi.confsched.ui.SnackbarMessageEffect
 import io.github.droidkaigi.confsched.ui.UserMessageStateHolder
 import io.github.droidkaigi.confsched.ui.UserMessageStateHolderImpl
 import io.github.droidkaigi.confsched.ui.component.AnimatedTextTopAppBar
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -102,7 +102,7 @@ fun FavoritesScreen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun FavoritesScreen(
+private fun FavoritesScreen(
     uiState: FavoritesScreenUiState,
     snackbarHostState: SnackbarHostState,
     onTimetableItemClick: (TimetableItem) -> Unit,
@@ -151,7 +151,12 @@ fun FavoritesScreenPreview() {
                     favoritesSheetUiState = FavoritesSheetUiState.FavoriteListUiState(
                         allFilterSelected = false,
                         currentDayFilter = persistentListOf(DroidKaigi2024Day.ConferenceDay1),
-                        timeTable = Timetable.fake(),
+                        timetableItemMap = persistentMapOf(
+                            TimeSlot(
+                                startTimeString = "10:00",
+                                endTimeString = "11:00",
+                            ) to listOf(),
+                        ),
                     ),
                     userMessageStateHolder = UserMessageStateHolderImpl(),
                 ),

--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreen.kt
@@ -26,6 +26,8 @@ import io.github.droidkaigi.confsched.favorites.section.FavoritesSheetUiState
 import io.github.droidkaigi.confsched.favorites.section.FavoritesSheetUiState.FavoriteListUiState.TimeSlot
 import io.github.droidkaigi.confsched.model.DroidKaigi2024Day
 import io.github.droidkaigi.confsched.model.TimetableItem
+import io.github.droidkaigi.confsched.model.TimetableItem.Session
+import io.github.droidkaigi.confsched.model.fake
 import io.github.droidkaigi.confsched.ui.SnackbarMessageEffect
 import io.github.droidkaigi.confsched.ui.UserMessageStateHolder
 import io.github.droidkaigi.confsched.ui.UserMessageStateHolderImpl
@@ -155,7 +157,9 @@ fun FavoritesScreenPreview() {
                             TimeSlot(
                                 startTimeString = "10:00",
                                 endTimeString = "11:00",
-                            ) to listOf(),
+                            ) to listOf(
+                                Session.fake(),
+                            ),
                         ),
                     ),
                     userMessageStateHolder = UserMessageStateHolderImpl(),

--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenPresenter.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenPresenter.kt
@@ -12,6 +12,7 @@ import io.github.droidkaigi.confsched.favorites.FavoritesScreenEvent.Bookmark
 import io.github.droidkaigi.confsched.favorites.FavoritesScreenEvent.Day1Filter
 import io.github.droidkaigi.confsched.favorites.FavoritesScreenEvent.Day2Filter
 import io.github.droidkaigi.confsched.favorites.section.FavoritesSheetUiState
+import io.github.droidkaigi.confsched.favorites.section.FavoritesSheetUiState.FavoriteListUiState.TimeSlot
 import io.github.droidkaigi.confsched.model.DroidKaigi2024Day
 import io.github.droidkaigi.confsched.model.DroidKaigi2024Day.ConferenceDay1
 import io.github.droidkaigi.confsched.model.DroidKaigi2024Day.ConferenceDay2
@@ -23,6 +24,7 @@ import io.github.droidkaigi.confsched.model.localSessionsRepository
 import io.github.droidkaigi.confsched.ui.providePresenterDefaults
 import kotlinx.collections.immutable.PersistentSet
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.collections.immutable.toPersistentSet
 import kotlinx.coroutines.flow.Flow
 
@@ -99,7 +101,14 @@ private fun favoritesSheet(
 ): FavoritesSheetUiState {
     val filteredSessions by rememberUpdatedState(
         favoriteSessions
-            .filtered(Filters(days = selectedDayFilters.toList())),
+            .filtered(Filters(days = selectedDayFilters.toList()))
+            .timetableItems.groupBy {
+                TimeSlot(it.startsTimeString, it.endsTimeString)
+            }.mapValues { entry ->
+                entry.value.sortedWith(
+                    compareBy({ it.day?.name.orEmpty() }, { it.startsTimeString }),
+                )
+            }.toPersistentMap(),
     )
 
     return if (filteredSessions.isEmpty()) {
@@ -111,7 +120,7 @@ private fun favoritesSheet(
         FavoritesSheetUiState.FavoriteListUiState(
             currentDayFilter = selectedDayFilters.toPersistentList(),
             allFilterSelected = allFilterSelected,
-            timeTable = filteredSessions,
+            timetableItemMap = filteredSessions,
         )
     }
 }

--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/section/FavoriteList.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/section/FavoriteList.kt
@@ -2,67 +2,97 @@ package io.github.droidkaigi.confsched.favorites.section
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.designsystem.theme.LocalRoomTheme
-import io.github.droidkaigi.confsched.model.Timetable
+import io.github.droidkaigi.confsched.favorites.section.FavoritesSheetUiState.FavoriteListUiState.TimeSlot
 import io.github.droidkaigi.confsched.model.TimetableItem
-import io.github.droidkaigi.confsched.model.fake
 import io.github.droidkaigi.confsched.ui.component.TimetableItemCard
 import io.github.droidkaigi.confsched.ui.component.TimetableItemTag
+import io.github.droidkaigi.confsched.ui.component.TimetableTime
 import io.github.droidkaigi.confsched.ui.icon
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.persistentMapOf
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun FavoriteList(
-    timetable: Timetable,
+    timetableItemMap: PersistentMap<TimeSlot, List<TimetableItem>>,
     onBookmarkClick: (TimetableItem) -> Unit,
     onTimetableItemClick: (TimetableItem) -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
 ) {
+    val layoutDirection = LocalLayoutDirection.current
+
     LazyColumn(
         modifier = modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-        contentPadding = PaddingValues(bottom = contentPadding.calculateBottomPadding()),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        contentPadding = PaddingValues(
+            top = 16.dp,
+            bottom = contentPadding.calculateBottomPadding(),
+            start = 16.dp + contentPadding.calculateStartPadding(layoutDirection),
+            end = 16.dp + contentPadding.calculateEndPadding(layoutDirection),
+        ),
     ) {
-        items(timetable.timetableItems) { timetableItem ->
-            TimetableItemCard(
-                modifier = Modifier.fillMaxWidth(),
-                isBookmarked = true,
-                tags = {
-                    TimetableItemTag(
-                        tagText = timetableItem.room.name.currentLangTitle,
-                        icon = timetableItem.room.icon,
-                        tagColor = LocalRoomTheme.current.primaryColor,
-                        modifier = Modifier.background(LocalRoomTheme.current.containerColor),
-                    )
-                    timetableItem.language.labels.forEach { label ->
-                        TimetableItemTag(
-                            tagText = label,
-                            tagColor = MaterialTheme.colorScheme.outline,
+        items(
+            items = timetableItemMap.toList(),
+            key = { it.first.key },
+        ) { (time, timetableItems) ->
+            Row {
+                TimetableTime(
+                    startTime = time.startTimeString,
+                    endTime = time.endTimeString,
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    timetableItems.onEach { timetableItem ->
+                        TimetableItemCard(
+                            modifier = Modifier.fillMaxWidth(),
+                            isBookmarked = true,
+                            tags = {
+                                TimetableItemTag(
+                                    tagText = timetableItem.room.name.currentLangTitle,
+                                    icon = timetableItem.room.icon,
+                                    tagColor = LocalRoomTheme.current.primaryColor,
+                                    modifier = Modifier.background(LocalRoomTheme.current.containerColor),
+                                )
+                                timetableItem.language.labels.forEach { label ->
+                                    TimetableItemTag(
+                                        tagText = label,
+                                        tagColor = MaterialTheme.colorScheme.outline,
+                                    )
+                                }
+                                timetableItem.day?.let {
+                                    TimetableItemTag(
+                                        tagText = "9/${it.dayOfMonth}",
+                                        tagColor = MaterialTheme.colorScheme.outline,
+                                    )
+                                }
+                            },
+                            timetableItem = timetableItem,
+                            onTimetableItemClick = onTimetableItemClick,
+                            onBookmarkClick = { item, _ -> onBookmarkClick(item) },
                         )
                     }
-                    timetableItem.day?.let {
-                        TimetableItemTag(
-                            tagText = "9/${it.dayOfMonth}",
-                            tagColor = MaterialTheme.colorScheme.outline,
-                        )
-                    }
-                },
-                timetableItem = timetableItem,
-                onTimetableItemClick = onTimetableItemClick,
-                onBookmarkClick = { item, _ -> onBookmarkClick(item) },
-            )
+                }
+            }
         }
     }
 }
@@ -73,7 +103,9 @@ fun FavoriteListPreview() {
     KaigiTheme {
         Surface {
             FavoriteList(
-                timetable = Timetable.fake(),
+                timetableItemMap = persistentMapOf(
+                    TimeSlot("10:00", "11:00") to listOf(),
+                ),
                 onBookmarkClick = {},
                 onTimetableItemClick = {},
             )

--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/section/FavoriteList.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/section/FavoriteList.kt
@@ -23,6 +23,8 @@ import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.designsystem.theme.LocalRoomTheme
 import io.github.droidkaigi.confsched.favorites.section.FavoritesSheetUiState.FavoriteListUiState.TimeSlot
 import io.github.droidkaigi.confsched.model.TimetableItem
+import io.github.droidkaigi.confsched.model.TimetableItem.Session
+import io.github.droidkaigi.confsched.model.fake
 import io.github.droidkaigi.confsched.ui.component.TimetableItemCard
 import io.github.droidkaigi.confsched.ui.component.TimetableItemTag
 import io.github.droidkaigi.confsched.ui.component.TimetableTime
@@ -104,7 +106,12 @@ fun FavoriteListPreview() {
         Surface {
             FavoriteList(
                 timetableItemMap = persistentMapOf(
-                    TimeSlot("10:00", "11:00") to listOf(),
+                    TimeSlot(
+                        startTimeString = "10:00",
+                        endTimeString = "11:00",
+                    ) to listOf(
+                        Session.fake(),
+                    ),
                 ),
                 onBookmarkClick = {},
                 onTimetableItemClick = {},

--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/section/FavoriteSheet.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/section/FavoriteSheet.kt
@@ -28,14 +28,15 @@ import conference_app_2024.feature.favorites.generated.resources.empty_guide
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.favorites.FavoritesRes
 import io.github.droidkaigi.confsched.favorites.component.FavoriteFilters
+import io.github.droidkaigi.confsched.favorites.section.FavoritesSheetUiState.FavoriteListUiState.TimeSlot
 import io.github.droidkaigi.confsched.model.DroidKaigi2024Day
 import io.github.droidkaigi.confsched.model.DroidKaigi2024Day.ConferenceDay1
 import io.github.droidkaigi.confsched.model.DroidKaigi2024Day.ConferenceDay2
-import io.github.droidkaigi.confsched.model.Timetable
 import io.github.droidkaigi.confsched.model.TimetableItem
-import io.github.droidkaigi.confsched.model.fake
 import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -54,8 +55,15 @@ sealed interface FavoritesSheetUiState {
     data class FavoriteListUiState(
         override val currentDayFilter: PersistentList<DroidKaigi2024Day>,
         override val allFilterSelected: Boolean,
-        val timeTable: Timetable,
-    ) : FavoritesSheetUiState
+        val timetableItemMap: PersistentMap<TimeSlot, List<TimetableItem>>,
+    ) : FavoritesSheetUiState {
+        data class TimeSlot(
+            val startTimeString: String,
+            val endTimeString: String,
+        ) {
+            val key: String get() = "$startTimeString-$endTimeString"
+        }
+    }
 
     data class Empty(
         override val currentDayFilter: PersistentList<DroidKaigi2024Day>,
@@ -91,7 +99,7 @@ fun FavoriteSheet(
 
             is FavoritesSheetUiState.FavoriteListUiState -> {
                 FavoriteList(
-                    timetable = uiState.timeTable,
+                    timetableItemMap = uiState.timetableItemMap,
                     onBookmarkClick = onBookmarkClick,
                     onTimetableItemClick = onTimetableItemClick,
                     contentPadding = contentPadding,
@@ -150,7 +158,7 @@ fun FavoriteSheetPreview() {
                 uiState = FavoritesSheetUiState.FavoriteListUiState(
                     allFilterSelected = true,
                     currentDayFilter = persistentListOf(ConferenceDay1, ConferenceDay2),
-                    timeTable = Timetable.fake(),
+                    timetableItemMap = persistentMapOf(TimeSlot("10:00", "11:00") to listOf()),
                 ),
                 onAllFilterChipClick = {},
                 onDay1FilterChipClick = {},

--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/section/FavoriteSheet.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/section/FavoriteSheet.kt
@@ -33,6 +33,8 @@ import io.github.droidkaigi.confsched.model.DroidKaigi2024Day
 import io.github.droidkaigi.confsched.model.DroidKaigi2024Day.ConferenceDay1
 import io.github.droidkaigi.confsched.model.DroidKaigi2024Day.ConferenceDay2
 import io.github.droidkaigi.confsched.model.TimetableItem
+import io.github.droidkaigi.confsched.model.TimetableItem.Session
+import io.github.droidkaigi.confsched.model.fake
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.persistentListOf
@@ -158,7 +160,14 @@ fun FavoriteSheetPreview() {
                 uiState = FavoritesSheetUiState.FavoriteListUiState(
                     allFilterSelected = true,
                     currentDayFilter = persistentListOf(ConferenceDay1, ConferenceDay2),
-                    timetableItemMap = persistentMapOf(TimeSlot("10:00", "11:00") to listOf()),
+                    timetableItemMap = persistentMapOf(
+                        TimeSlot(
+                            startTimeString = "10:00",
+                            endTimeString = "11:00",
+                        ) to listOf(
+                            Session.fake(),
+                        ),
+                    ),
                 ),
                 onAllFilterChipClick = {},
                 onDay1FilterChipClick = {},

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
@@ -22,10 +22,10 @@ import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched.designsystem.theme.LocalRoomTheme
 import io.github.droidkaigi.confsched.model.Timetable
 import io.github.droidkaigi.confsched.model.TimetableItem
-import io.github.droidkaigi.confsched.sessions.component.TimetableTime
 import io.github.droidkaigi.confsched.sessions.timetableDetailSharedContentStateKey
 import io.github.droidkaigi.confsched.ui.component.TimetableItemCard
 import io.github.droidkaigi.confsched.ui.component.TimetableItemTag
+import io.github.droidkaigi.confsched.ui.component.TimetableTime
 import io.github.droidkaigi.confsched.ui.compositionlocal.LocalAnimatedVisibilityScope
 import io.github.droidkaigi.confsched.ui.compositionlocal.LocalSharedTransitionScope
 import io.github.droidkaigi.confsched.ui.icon


### PR DESCRIPTION
## Issue
- close #378 

## Overview (Required)
- I have added session time in FavoritesScreen

## Links
- Figma: https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=55499-43411&t=0iY0wsW8N4Frvy7m-4

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/d6a15cc2-b02c-4240-bd09-eaa9847c592a" width="300" /> | <img src="https://github.com/user-attachments/assets/767bcb43-adef-425d-b887-518a868f6fec" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
