### PR TITLE
[nits] PhotopickButton align is off.

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -543,7 +543,7 @@ private fun ImagePickerWithError(
                     Spacer(Modifier.width(8.dp))
                     Text(
                         text = stringResource(ProfileCardRes.string.add_image),
-                        modifier = Modifier.alignByBaseline()
+                        modifier = Modifier.alignByBaseline(),
                     )
                 }
             }

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -534,9 +534,18 @@ private fun ImagePickerWithError(
                     .padding(bottom = 20.dp)
                     .testTag(ProfileCardSelectImageButtonTestTag),
             ) {
-                Icon(Icons.Default.Add, null)
-                Spacer(Modifier.width(8.dp))
-                Text(stringResource(ProfileCardRes.string.add_image))
+                Row {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = null,
+                        modifier = Modifier.alignByBaseline(),
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text = stringResource(ProfileCardRes.string.add_image),
+                        modifier = Modifier.alignByBaseline()
+                    )
+                }
             }
             if (errorMessage.isNotEmpty()) {
                 Text(


### PR DESCRIPTION
## Issue
none

## Overview (Required)
- Icon and text were not aligned in the vertical center


## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/2d37f3e6-cbea-435a-ac9e-8a2eb9a50f58" width="300" /> | <img src="https://github.com/user-attachments/assets/1877d2a5-bfb8-4775-b396-2ab5ce6f2dee" width="300" />
