### PR TITLE
[iOS] Automatically focus search bar when navigating to search screen

### DIFF
--- a/app-ios/Sources/SearchFeature/SearchView.swift
+++ b/app-ios/Sources/SearchFeature/SearchView.swift
@@ -8,9 +8,12 @@ import Theme
 
 public struct SearchView: View {
     @Bindable private var store: StoreOf<SearchReducer>
+    @State private var isfocused: Bool
+
 
     public init(store: StoreOf<SearchReducer>) {
         self.store = store
+        self.isfocused = false
     }
 
     public var body: some View {
@@ -50,11 +53,15 @@ public struct SearchView: View {
                     store.send(.view(.searchWordChanged($0)))
                 }
             ),
+            isPresented: $isfocused,
             placement: .navigationBarDrawer(displayMode: .always)
         )
         .foregroundStyle(AssetColors.Surface.onSurface.swiftUIColor)
         .onAppear {
             store.send(.view(.onAppear))
+            DispatchQueue.main.async {
+                isfocused = true
+            }
         }
     }
 

--- a/app-ios/Sources/SearchFeature/SearchView.swift
+++ b/app-ios/Sources/SearchFeature/SearchView.swift
@@ -8,7 +8,7 @@ import Theme
 
 public struct SearchView: View {
     @Bindable private var store: StoreOf<SearchReducer>
-    @State private var isfocused: Bool = false
+    @State private var isFocused: Bool = false
 
     public init(store: StoreOf<SearchReducer>) {
         self.store = store
@@ -57,9 +57,8 @@ public struct SearchView: View {
         .foregroundStyle(AssetColors.Surface.onSurface.swiftUIColor)
         .onAppear {
             store.send(.view(.onAppear))
-            DispatchQueue.main.async {
-                isfocused = true
-            }
+            isfocused = true
+
         }
     }
 

--- a/app-ios/Sources/SearchFeature/SearchView.swift
+++ b/app-ios/Sources/SearchFeature/SearchView.swift
@@ -8,12 +8,10 @@ import Theme
 
 public struct SearchView: View {
     @Bindable private var store: StoreOf<SearchReducer>
-    @State private var isfocused: Bool
-
+    @State private var isfocused: Bool = false
 
     public init(store: StoreOf<SearchReducer>) {
         self.store = store
-        self.isfocused = false
     }
 
     public var body: some View {

--- a/app-ios/Sources/SearchFeature/SearchView.swift
+++ b/app-ios/Sources/SearchFeature/SearchView.swift
@@ -51,14 +51,13 @@ public struct SearchView: View {
                     store.send(.view(.searchWordChanged($0)))
                 }
             ),
-            isPresented: $isfocused,
+            isPresented: $isFocused,
             placement: .navigationBarDrawer(displayMode: .always)
         )
         .foregroundStyle(AssetColors.Surface.onSurface.swiftUIColor)
         .onAppear {
             store.send(.view(.onAppear))
-            isfocused = true
-
+            isFocused = true
         }
     }
 


### PR DESCRIPTION
## Issue
close #525 

## Overview (Required)
- Use `.searchable`'s `isPresented` parameter to automatically focus the search bar.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
When transitioning to search screen
As Is | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/44fe5223-5727-4489-b908-e6e756f9addd" width="300" /> | <img src="https://github.com/user-attachments/assets/deef6d08-c38b-411c-bb14-4c8288f2577a" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
