### PR TITLE
:sparkles: Implemented a test of SettingsScreen.

### DIFF
--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/MiniRobots.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/MiniRobots.kt
@@ -10,18 +10,25 @@ import io.github.droidkaigi.confsched.data.eventmap.FakeEventMapApiClient
 import io.github.droidkaigi.confsched.data.profilecard.ProfileCardDataStore
 import io.github.droidkaigi.confsched.data.sessions.FakeSessionsApiClient
 import io.github.droidkaigi.confsched.data.sessions.SessionsApiClient
+import io.github.droidkaigi.confsched.data.settings.SettingsDataStore
 import io.github.droidkaigi.confsched.data.sponsors.FakeSponsorsApiClient
 import io.github.droidkaigi.confsched.data.sponsors.SponsorsApiClient
 import io.github.droidkaigi.confsched.data.staff.FakeStaffApiClient
 import io.github.droidkaigi.confsched.data.staff.StaffApiClient
+import io.github.droidkaigi.confsched.model.FontFamily
 import io.github.droidkaigi.confsched.model.ProfileCard
+import io.github.droidkaigi.confsched.model.Settings
 import io.github.droidkaigi.confsched.model.fake
 import io.github.droidkaigi.confsched.testing.coroutines.runTestWithLogging
 import io.github.droidkaigi.confsched.testing.robot.ProfileCardDataStoreRobot.ProfileCardInputStatus
 import io.github.droidkaigi.confsched.testing.robot.ProfileCardDataStoreRobot.ProfileCardInputStatus.AllNotEntered
 import io.github.droidkaigi.confsched.testing.robot.ProfileCardDataStoreRobot.ProfileCardInputStatus.NoInputOtherThanImage
+import io.github.droidkaigi.confsched.testing.robot.SettingsDataStoreRobot.SettingsStatus
+import io.github.droidkaigi.confsched.testing.robot.SettingsDataStoreRobot.SettingsStatus.UseDotGothic16FontFamily
+import io.github.droidkaigi.confsched.testing.robot.SettingsDataStoreRobot.SettingsStatus.UseSystemDefaultFont
 import io.github.droidkaigi.confsched.testing.robot.SponsorsServerRobot.ServerStatus
 import io.github.droidkaigi.confsched.testing.rules.RobotTestRule
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.test.TestDispatcher
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.shadows.ShadowLooper
@@ -286,4 +293,39 @@ class DefaultProfileCardDataStoreRobot @Inject constructor(
             }
         }
     }
+}
+
+interface SettingsDataStoreRobot {
+    enum class SettingsStatus {
+        UseDotGothic16FontFamily,
+        UseSystemDefaultFont,
+    }
+
+    suspend fun setupSettings(settingsStatus: SettingsStatus)
+    fun get(): Flow<Settings>
+}
+
+class DefaultSettingsDataStoreRobot @Inject constructor(
+    private val settingsDataStore: SettingsDataStore,
+) : SettingsDataStoreRobot {
+    override suspend fun setupSettings(settingsStatus: SettingsStatus) {
+        when (settingsStatus) {
+            UseDotGothic16FontFamily -> {
+                settingsDataStore.save(
+                    Settings.Exists(
+                        useFontFamily = FontFamily.DotGothic16Regular,
+                    ),
+                )
+            }
+            UseSystemDefaultFont -> {
+                settingsDataStore.save(
+                    Settings.Exists(
+                        useFontFamily = FontFamily.SystemDefault,
+                    ),
+                )
+            }
+        }
+    }
+
+    override fun get(): Flow<Settings> = settingsDataStore.get()
 }

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/SettingsScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/SettingsScreenRobot.kt
@@ -1,20 +1,108 @@
 package io.github.droidkaigi.confsched.testing.robot
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.performClick
+import io.github.droidkaigi.confsched.compose.safeCollectAsRetainedState
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
+import io.github.droidkaigi.confsched.designsystem.theme.dotGothic16FontFamily
+import io.github.droidkaigi.confsched.model.FontFamily.DotGothic16Regular
+import io.github.droidkaigi.confsched.model.FontFamily.SystemDefault
+import io.github.droidkaigi.confsched.model.Settings.DoesNotExists
+import io.github.droidkaigi.confsched.model.Settings.Exists
+import io.github.droidkaigi.confsched.model.Settings.Loading
 import io.github.droidkaigi.confsched.settings.SettingsScreen
+import io.github.droidkaigi.confsched.settings.component.SettingsItemRowCurrentValueTextTestTag
+import io.github.droidkaigi.confsched.settings.section.SettingsAccessibilityUseFontFamilyTestTag
+import io.github.droidkaigi.confsched.settings.section.SettingsAccessibilityUseFontFamilyTestTagPrefix
 import javax.inject.Inject
 
 class SettingsScreenRobot @Inject constructor(
     screenRobot: DefaultScreenRobot,
-) : ScreenRobot by screenRobot {
+    settingsDataStoreRobot: DefaultSettingsDataStoreRobot,
+) : ScreenRobot by screenRobot,
+    SettingsDataStoreRobot by settingsDataStoreRobot {
+    private enum class FontFamily(
+        val displayName: String,
+    ) {
+        DotGothic16Regular("DotGothic"),
+        SystemDefault("System Default"),
+    }
+
     fun setupScreenContent() {
         robotTestRule.setContent {
-            KaigiTheme {
+            val settings by remember { get() }.safeCollectAsRetainedState(Loading)
+
+            val fontFamily = when (settings) {
+                DoesNotExists, Loading -> dotGothic16FontFamily()
+                is Exists -> {
+                    when ((settings as Exists).useFontFamily) {
+                        DotGothic16Regular -> dotGothic16FontFamily()
+                        SystemDefault -> null
+                    }
+                }
+            }
+
+            KaigiTheme(
+                fontFamily = fontFamily,
+            ) {
                 SettingsScreen(
                     onNavigationIconClick = {},
                 )
             }
         }
         waitUntilIdle()
+    }
+
+    fun clickUseFontItem() {
+        composeTestRule
+            .onNode(hasTestTag(SettingsAccessibilityUseFontFamilyTestTag))
+            .performClick()
+        waitUntilIdle()
+    }
+
+    fun clickSystemDefaultFontItem() {
+        composeTestRule
+            .onNode(hasTestTag(SettingsAccessibilityUseFontFamilyTestTagPrefix.plus(FontFamily.SystemDefault.displayName)))
+            .performClick()
+        waitUntilIdle()
+    }
+
+    fun clickDotGothicFontItem() {
+        composeTestRule
+            .onNode(hasTestTag(SettingsAccessibilityUseFontFamilyTestTagPrefix.plus(FontFamily.DotGothic16Regular.displayName)))
+            .performClick()
+        waitUntilIdle()
+    }
+
+    fun checkAllDisplayedAvailableFont() {
+        FontFamily.entries.forEach { fontFamily ->
+            composeTestRule
+                .onNode(hasTestTag(SettingsAccessibilityUseFontFamilyTestTagPrefix.plus(fontFamily.displayName)))
+                .assertIsDisplayed()
+                .assertExists()
+                .assertTextEquals(fontFamily.displayName)
+        }
+    }
+
+    fun checkEnsureThatSystemDefaultFontIsUsed() {
+        composeTestRule
+            .onNode(
+                matcher = hasTestTag(SettingsItemRowCurrentValueTextTestTag),
+                useUnmergedTree = true,
+            )
+            .assertTextEquals(FontFamily.SystemDefault.displayName)
+    }
+
+    fun checkEnsureThatDotGothicFontIsUsed() {
+        composeTestRule
+            .onNode(
+                matcher = hasTestTag(SettingsItemRowCurrentValueTextTestTag),
+                useUnmergedTree = true,
+            )
+            .assertTextEquals(FontFamily.DotGothic16Regular.displayName)
     }
 }

--- a/feature/settings/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/settings/SettingsScreenTest.kt
+++ b/feature/settings/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/settings/SettingsScreenTest.kt
@@ -5,9 +5,9 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import io.github.droidkaigi.confsched.testing.DescribedBehavior
 import io.github.droidkaigi.confsched.testing.describeBehaviors
 import io.github.droidkaigi.confsched.testing.execute
+import io.github.droidkaigi.confsched.testing.robot.SettingsDataStoreRobot
 import io.github.droidkaigi.confsched.testing.robot.SettingsScreenRobot
 import io.github.droidkaigi.confsched.testing.robot.runRobot
-import io.github.droidkaigi.confsched.testing.robot.todoChecks
 import io.github.droidkaigi.confsched.testing.rules.RobotTestRule
 import org.junit.Rule
 import org.junit.Test
@@ -38,13 +38,44 @@ class SettingsScreenTest(
         @ParameterizedRobolectricTestRunner.Parameters(name = "{0}")
         fun behaviors(): List<DescribedBehavior<SettingsScreenRobot>> {
             return describeBehaviors<SettingsScreenRobot>(name = "SettingsScreen") {
-                describe("when launch") {
-                    run {
+                describe("when launch use font dot gothic") {
+                    doIt {
+                        setupSettings(SettingsDataStoreRobot.SettingsStatus.UseDotGothic16FontFamily)
                         setupScreenContent()
                     }
                     itShould("show settings contents") {
                         captureScreenWithChecks {
-                            todoChecks("TODO")
+                            checkEnsureThatDotGothicFontIsUsed()
+                        }
+                    }
+                    describe("when click use font item") {
+                        doIt {
+                            clickUseFontItem()
+                        }
+                        itShould("show available fonts") {
+                            captureScreenWithChecks {
+                                checkAllDisplayedAvailableFont()
+                            }
+                        }
+                        describe("when click system default font") {
+                            doIt {
+                                clickSystemDefaultFontItem()
+                            }
+                            itShould("selected system default font") {
+                                captureScreenWithChecks {
+                                    checkEnsureThatSystemDefaultFontIsUsed()
+                                }
+                            }
+                        }
+                        describe("when click dot gothic font") {
+                            doIt {
+                                clickDotGothicFontItem()
+                            }
+                            itShould("selected dot gothic font") {
+                                captureScreenWithChecks {
+                                    checkEnsureThatDotGothicFontIsUsed()
+                                }
+                            }
                         }
                     }
                 }

--- a/feature/settings/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/settings/SettingsScreenTest.kt
+++ b/feature/settings/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/settings/SettingsScreenTest.kt
@@ -79,6 +79,47 @@ class SettingsScreenTest(
                         }
                     }
                 }
+                describe("when launch use font default system font") {
+                    doIt {
+                        setupSettings(SettingsDataStoreRobot.SettingsStatus.UseSystemDefaultFont)
+                        setupScreenContent()
+                    }
+                    itShould("show settings contents") {
+                        captureScreenWithChecks {
+                            checkEnsureThatSystemDefaultFontIsUsed()
+                        }
+                    }
+                    describe("when click use font item") {
+                        doIt {
+                            clickUseFontItem()
+                        }
+                        itShould("show available fonts") {
+                            captureScreenWithChecks {
+                                checkAllDisplayedAvailableFont()
+                            }
+                        }
+                        describe("when click dot gothic font") {
+                            doIt {
+                                clickDotGothicFontItem()
+                            }
+                            itShould("selected dot gothic font") {
+                                captureScreenWithChecks {
+                                    checkEnsureThatDotGothicFontIsUsed()
+                                }
+                            }
+                        }
+                        describe("when click system default font") {
+                            doIt {
+                                clickSystemDefaultFontItem()
+                            }
+                            itShould("selected system default font") {
+                                captureScreenWithChecks {
+                                    checkEnsureThatSystemDefaultFontIsUsed()
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/feature/settings/src/commonMain/kotlin/io/github/droidkaigi/confsched/settings/component/SettingsItemRow.kt
+++ b/feature/settings/src/commonMain/kotlin/io/github/droidkaigi/confsched/settings/component/SettingsItemRow.kt
@@ -17,7 +17,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+
+const val SettingsItemRowCurrentValueTextTestTag = "SettingsItemRowCurrentValueTextTestTag"
 
 @Composable
 fun SettingsItemRow(
@@ -56,6 +59,7 @@ fun SettingsItemRow(
                     style = MaterialTheme.typography.bodyMedium,
                 )
                 Text(
+                    modifier = Modifier.testTag(SettingsItemRowCurrentValueTextTestTag),
                     text = currentValue,
                     style = MaterialTheme.typography.bodySmall,
                 )

--- a/feature/settings/src/commonMain/kotlin/io/github/droidkaigi/confsched/settings/section/SettingsAccessibility.kt
+++ b/feature/settings/src/commonMain/kotlin/io/github/droidkaigi/confsched/settings/section/SettingsAccessibility.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import conference_app_2024.feature.settings.generated.resources.section_item_title_font
 import conference_app_2024.feature.settings.generated.resources.section_title_accessibility
@@ -17,6 +18,9 @@ import io.github.droidkaigi.confsched.settings.SettingsUiState
 import io.github.droidkaigi.confsched.settings.component.SelectableItemColumn
 import io.github.droidkaigi.confsched.settings.component.SettingsItemRow
 import org.jetbrains.compose.resources.stringResource
+
+const val SettingsAccessibilityUseFontFamilyTestTag = "SettingsAccessibilityUseFontFamilyTestTag"
+const val SettingsAccessibilityUseFontFamilyTestTagPrefix = "SettingsAccessibilityUseFontFamilyTestTag:"
 
 fun LazyListScope.accessibility(
     modifier: Modifier = Modifier,
@@ -36,13 +40,17 @@ fun LazyListScope.accessibility(
     }
     item {
         SettingsItemRow(
-            modifier = modifier,
+            modifier = modifier.testTag(SettingsAccessibilityUseFontFamilyTestTag),
             leadingIcon = Icons.Default.TextFormat,
             itemName = stringResource(SettingsRes.string.section_item_title_font),
             currentValue = uiState.useFontFamily?.displayName ?: "",
             selectableItems = {
                 FontFamily.entries.forEach { fontFamily ->
                     SelectableItemColumn(
+                        modifier = Modifier.testTag(
+                            SettingsAccessibilityUseFontFamilyTestTagPrefix
+                                .plus(fontFamily.displayName),
+                        ),
                         currentValue = fontFamily.displayName,
                         onClickItem = {
                             onSelectUseFontFamily(fontFamily)


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- Adding VRT when implementing SettingsScreen would make the PR too large.
- Therefore, we have added support for the addition of VRT in this PR.

## Links
- https://github.com/DroidKaigi/conference-app-2024/pull/637#discussion_r1721171731