### PR TITLE
Fix to keep the translation state when come back from favorites screen.

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailPresenter.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailPresenter.kt
@@ -25,6 +25,7 @@ import io.github.droidkaigi.confsched.sessions.TimetableItemDetailScreenUiState.
 import io.github.droidkaigi.confsched.ui.UserMessageResult.ActionPerformed
 import io.github.droidkaigi.confsched.ui.providePresenterDefaults
 import io.github.droidkaigi.confsched.ui.rememberNavigationArgument
+import io.github.takahirom.rin.rememberRetained
 import kotlinx.coroutines.flow.SharedFlow
 import org.jetbrains.compose.resources.stringResource
 
@@ -48,7 +49,7 @@ fun timetableItemDetailPresenter(
         sessionsRepository
             .timetableItemWithBookmark(timetableItemId),
     )
-    var selectedDescriptionLanguage by remember { mutableStateOf<Lang?>(null) }
+    var selectedDescriptionLanguage by rememberRetained { mutableStateOf<Lang?>(null) }
     var shouldGoToFavoriteList by remember { mutableStateOf(false) }
     val bookmarkedSuccessfullyString = stringResource(SessionsRes.string.bookmarked_successfully)
     val viewBookmarkListString = stringResource(SessionsRes.string.view_bookmark_list)


### PR DESCRIPTION
## Issue
- close #655

## Overview (Required)
- Fix to keep the translation state when come back from favorites screen.

## Links
- none

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/b4e74ef2-2477-4805-9f48-7e08757bd4be" width="300" > | <video src="https://github.com/user-attachments/assets/53d9efe6-84f7-470f-9109-f5abad262f0f" width="300" >