### PR TITLE
[iOS] Favorite Feature: Remove Workshop Day tab

### DIFF
--- a/app-ios/Sources/CommonComponents/SelectionChips.swift
+++ b/app-ios/Sources/CommonComponents/SelectionChips.swift
@@ -5,11 +5,17 @@ import Theme
 public struct SelectionChips<SelectableCase: Selectable>: View where SelectableCase.AllCases: RandomAccessCollection {
     @Binding public var selected: SelectableCase?
     public var notSelectedTitle: String?
+    public var options: [SelectableCase]
 
-    public init(selected: Binding<SelectableCase?>, notSelectedTitle: String? = nil) {
-        self._selected = selected
-        self.notSelectedTitle = notSelectedTitle
-    }
+    public init(
+        selected: Binding<SelectableCase?>,
+        notSelectedTitle: String? = nil,
+        options: [SelectableCase] = SelectableCase.allCases as! [SelectableCase]
+    ) {
+            self._selected = selected
+            self.notSelectedTitle = notSelectedTitle
+            self.options = options
+        }
 
     public var body: some View {
         ScrollView(.horizontal) {
@@ -24,7 +30,7 @@ public struct SelectionChips<SelectableCase: Selectable>: View where SelectableC
                     }
                 }
 
-                ForEach(SelectableCase.allCases) { selection in
+                ForEach(options) { selection in
                     SelectionChip(
                         title: selection.caseTitle,
                         isMultiSelect: false,

--- a/app-ios/Sources/CommonComponents/SelectionChips.swift
+++ b/app-ios/Sources/CommonComponents/SelectionChips.swift
@@ -5,7 +5,7 @@ import Theme
 public struct SelectionChips<SelectableCase: Selectable>: View where SelectableCase.AllCases: RandomAccessCollection {
     @Binding public var selected: SelectableCase?
     public var notSelectedTitle: String?
-    public var options: [SelectableCase]
+    public let options: [SelectableCase]
 
     public init(
         selected: Binding<SelectableCase?>,

--- a/app-ios/Sources/FavoriteFeature/FavoriteView.swift
+++ b/app-ios/Sources/FavoriteFeature/FavoriteView.swift
@@ -77,7 +77,8 @@ public struct FavoriteView: View {
     private var daySelection: some View {
         SelectionChips<DroidKaigi2024Day>(
             selected: $store.selectedDay.sending(\.view.selectedDayChanged),
-            notSelectedTitle: String(localized: "All", bundle: .module)
+            notSelectedTitle: String(localized: "All", bundle: .module),
+            options: DroidKaigi2024Day.options
         )
     }
 }
@@ -104,6 +105,10 @@ extension DroidKaigi2024Day {
         case .conferenceDay2:
             String(localized: "9/13", bundle: .module)
         }
+    }
+
+    public static var options: [DroidKaigi2024Day] {
+        [.conferenceDay1, .conferenceDay2]
     }
 }
 


### PR DESCRIPTION
## Issue
- close #441

## Overview (Required)
- Remove workshop day from favorite view tabs.
- Add `options` argument to `SelectonChips`.
   - Default value is `allCases`.
   - Override options in `DroidKaigi2024Day`.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
