### PR TITLE
Expanded Lunch Field (Grid)

### DIFF
--- a/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/theme/RoomTheme.kt
+++ b/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/theme/RoomTheme.kt
@@ -37,6 +37,12 @@ sealed interface RoomTheme {
         override val dimColor = Color(0xFF121E25)
     }
 
+    data object Lunch : RoomTheme {
+        override val primaryColor = Color(0xFFC1C8C9)
+        override val containerColor = Color(0xFFC1C8C9).copy(alpha = 0.1f)
+        override val dimColor = Color(0xFF121E25)
+    }
+
     val primaryColor: Color
     val containerColor: Color
     val dimColor: Color
@@ -49,6 +55,7 @@ sealed interface RoomTheme {
                 "giraffe" -> Giraffe
                 "flamingo" -> Flamingo
                 "jellyfish" -> Jellyfish
+                "lunch" -> Lunch
                 else -> null
             }
         }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/TimetableItem.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/TimetableItem.kt
@@ -99,6 +99,8 @@ public sealed class TimetableItem {
         "https://2024.droidkaigi.jp/en/timetable/${id.value}"
     }
 
+    public val isLunch: Boolean get() = startsTimeString.startsWith("13:00") && title.enTitle.lowercase().contains("lunch")
+
     fun getSupportedLangString(isJapaneseLocale: Boolean): String {
         val japanese = if (isJapaneseLocale) "日本語" else "Japanese"
         val english = if (isJapaneseLocale) "英語" else "English"

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
@@ -106,7 +106,7 @@ fun TimetableGridItem(
         derivedStateOf { (height - TimetableGridItemSizes.padding * 2) / 4 > titleMinHeightDp * 3 / 2 }
     }
 
-    ProvideRoomTheme(timetableItem.room.getThemeKey()) {
+    ProvideRoomTheme( if(timetableItem.isLunch) { "lunch" } else { timetableItem.room.getThemeKey()} ) {
         val titleTextStyle = MaterialTheme.typography.labelLarge.let {
             check(it.fontSize.isSp)
             val (titleFontSize, titleLineHeight) = calculateFontSizeAndLineHeight(
@@ -161,13 +161,15 @@ fun TimetableGridItem(
                         modifier = Modifier
                             .weight(1f, fill = false),
                     ) {
-                        Icon(
-                            modifier = Modifier.height(TimetableGridItemSizes.scheduleHeight),
-                            imageVector = vectorResource(checkNotNull(timetableItem.room.icon)),
-                            contentDescription = timetableItem.room.name.currentLangTitle,
-                            tint = LocalRoomTheme.current.primaryColor,
-                        )
-                        Spacer(modifier = Modifier.width(4.dp))
+                        if (!timetableItem.isLunch) {
+                            Icon(
+                                modifier = Modifier.height(TimetableGridItemSizes.scheduleHeight),
+                                imageVector = vectorResource(checkNotNull(timetableItem.room.icon)),
+                                contentDescription = timetableItem.room.name.currentLangTitle,
+                                tint = LocalRoomTheme.current.primaryColor,
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+                        }
                         var scheduleTextStyle = MaterialTheme.typography.labelSmall
                         if (titleTextStyle.fontSize < scheduleTextStyle.fontSize) {
                             scheduleTextStyle =

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableGrid.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableGrid.kt
@@ -520,11 +520,27 @@ private data class TimetableItemLayout(
     private val displayEndsAt = timetableItem.endsAt.minus(1, DateTimeUnit.MINUTE)
     val height =
         ((displayEndsAt - timetableItem.startsAt).inWholeMinutes * minutePx).roundToInt()
-    val width = with(density) { TimetableSizes.columnWidth.roundToPx() }
-    val left = rooms.indexOf(timetableItem.room) * width
     val top = ((timetableItem.startsAt - dayStart).inWholeMinutes * minutePx).toInt()
-    val right = left + width
     val bottom = top + height
+    
+    val width: Int
+    val left: Int
+    val right: Int
+
+    init {
+        if (timetableItem.isLunch) {
+            width = with(density) { TimetableSizes.columnWidth.roundToPx() * 5 }
+            left = 0 //rooms.indexOf(RoomType.RoomF) * width //.indexOf(timetableItem.room) * width
+            right = left + width
+        } else {
+            width = with(density) { TimetableSizes.columnWidth.roundToPx() }
+            left = rooms.indexOf(timetableItem.room) * width
+            right = left + width
+        }
+    }
+
+
+
 
     fun isVisible(
         screenWidth: Int,


### PR DESCRIPTION
## Issue
- close #683 

## Overview (Required)
- Added in special lunch implementation for grid view (stretched, special color, special icon). This now should match the iOS implementation.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/9973113e-5f3e-4e2f-94f9-1c8604a1293f" width="300" /> | <img src="https://github.com/user-attachments/assets/78c76ef7-6929-4b3d-afb8-5d4eea2dc058" width="300" />


## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
