### PR TITLE
Remove redundant source set dependency

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -44,7 +44,6 @@ kotlin {
         }
 
         iosMain {
-            dependsOn(getByName("commonMain"))
             dependencies {
                 implementation(libs.ktorClientDarwin)
                 api(libs.koin)


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- This PR removes a redundant source set dependency from the build script and resolves the following build warning:

```
> Configure project :core:data
w: Redundant dependsOn edges between Kotlin Source Sets found.
Please remove the following dependsOn invocations from your build scripts:
 * iosMain.dependsOn(commonMain)
They are already added from Kotlin Target Hierarchy template https://kotl.in/hierarchy-template
```

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
