### PR TITLE
Switch Compose Multiplatform

### DIFF
--- a/app-ios/Sources/AboutFeature/AboutReducer.swift
+++ b/app-ios/Sources/AboutFeature/AboutReducer.swift
@@ -14,6 +14,7 @@ public struct AboutReducer {
     public enum Action: ViewAction {
         case view(View)
         case presentation(PresentationAction<Destination.Action>)
+        case delegate(Delegate)
         
         @CasePathable
         public enum View {
@@ -26,9 +27,20 @@ public struct AboutReducer {
             case youtubeTapped
             case xcomTapped
             case mediumTapped
+            case switchComposeModeTapped
+        }
+        
+        @CasePathable
+        public enum Delegate {
+            case switchComposeMode
+        }
+        
+        @CasePathable
+        public enum Alert: Equatable {
+            case switchComposeMode
         }
     }
-
+    
     @Reducer(state: .equatable)
     public enum Destination {
         case codeOfConduct
@@ -36,6 +48,7 @@ public struct AboutReducer {
         case youtube
         case xcom
         case medium
+        case alert(AlertState<AboutReducer.Action.Alert>)
     }
 
     public var body: some ReducerOf<Self> {
@@ -56,12 +69,30 @@ public struct AboutReducer {
             case .view(.mediumTapped):
                 state.destination = .medium
                 return .none
+            case .view(.switchComposeModeTapped):
+                state.destination = .alert(AlertState(title: {
+                    TextState("SwitchComposeModeAlertTitle", bundle: .module)
+                }, actions: {
+                    ButtonState(action: .switchComposeMode) {
+                        TextState("Switch", bundle: .module)
+                    }
+                    ButtonState(role: .cancel) {
+                        TextState("Cancel", bundle: .module)
+                    }
+                }, message: {
+                    TextState("SwitchComposeModeAlertMessage", bundle: .module)
+                }))
+                return .none
             case .view:
                 return .none
             case .presentation(.dismiss):
                 state.destination = nil
                 return .none
+            case .presentation(.presented(.alert(.switchComposeMode))):
+                return .send(.delegate(.switchComposeMode))
             case .presentation:
+                return .none
+            case .delegate:
                 return .none
             }
         }

--- a/app-ios/Sources/AboutFeature/AboutView.swift
+++ b/app-ios/Sources/AboutFeature/AboutView.swift
@@ -39,6 +39,7 @@ public struct AboutView: View {
                 SafariView(url: .medium)
                     .ignoresSafeArea()
             })
+            .alert($store.scope(state: \.destination?.alert, action: \.presentation.alert))
     }
     
     @ViewBuilder var content: some View {
@@ -155,6 +156,25 @@ public struct AboutView: View {
                                 .textStyle(.titleMedium)
                         } icon: {
                             Image(.icPrivacyTip)
+                        }
+                        .labelStyle(AboutLabelStyle())
+                        Spacer()
+                    })
+                    .padding(.init(top: 24, leading: 12, bottom: 24, trailing: 16))
+
+                    Divider()
+                        .background(AssetColors.Outline.outlineVariant.swiftUIColor)
+
+                    Button(action: {
+                        send(.switchComposeModeTapped)
+                    }, label: {
+                        Label {
+                            Text(String(localized: "SwitchComposeMultiplatform", bundle: .module))
+                                .textStyle(.titleMedium)
+                        } icon: {
+                            Image(systemName: "switch.2")
+                                .resizable()
+                                .frame(width: 18, height: 18)
                         }
                         .labelStyle(AboutLabelStyle())
                         Spacer()

--- a/app-ios/Sources/AboutFeature/Localizable.xcstrings
+++ b/app-ios/Sources/AboutFeature/Localizable.xcstrings
@@ -33,6 +33,22 @@
         }
       }
     },
+    "Cancel" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
+          }
+        }
+      }
+    },
     "CodeOfConduct" : {
       "localizations" : {
         "en" : {
@@ -287,6 +303,70 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "スタッフ"
+          }
+        }
+      }
+    },
+    "Switch" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Switch"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切り替える"
+          }
+        }
+      }
+    },
+    "SwitchComposeModeAlertMessage" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Switch UI from SwiftUI to Compose Multiplatform. Are you sure you want to do?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "UIをSwiftUIからCompose Multiplatformへ切り替えます。よろしいですか？"
+          }
+        }
+      }
+    },
+    "SwitchComposeModeAlertTitle" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Switch UI"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "UIを切り替える"
+          }
+        }
+      }
+    },
+    "SwitchComposeMultiplatform" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Switch Compose Multiplatform"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compose Multiplatformへ切り替える"
           }
         }
       }

--- a/app-ios/Sources/App/RootReducer.swift
+++ b/app-ios/Sources/App/RootReducer.swift
@@ -9,6 +9,11 @@ import TimetableFeature
 import TimetableDetailFeature
 import shared
 
+public enum ViewType {
+    case swiftUI
+    case compose
+}
+
 @Reducer
 public struct RootReducer {
     public init() {}
@@ -41,6 +46,7 @@ public struct RootReducer {
         public var favorite: FavoriteReducer.State
         public var about: AboutReducer.State
         public var paths: Paths = .init()
+        public var viewType: ViewType = .swiftUI
 
         public struct Paths: Equatable {
             public var timetable = StackState<Path.Timetable.State>()
@@ -90,6 +96,20 @@ public struct RootReducer {
             AboutReducer()
         }
         navigationReducer
+        delegateReducer
+    }
+
+    private var delegateReducer: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .about(.delegate(.switchComposeMode)):
+                state.viewType = .compose
+                return .none
+            default:
+                return .none
+            }
+        }
+        .forEach(\.paths.about, action: \.paths.about)
     }
 
     private var navigationReducer: some ReducerOf<Self> {

--- a/app-ios/Sources/App/RootView.swift
+++ b/app-ios/Sources/App/RootView.swift
@@ -11,6 +11,7 @@ import TimetableDetailFeature
 import TimetableFeature
 import EventMapFeature
 import Theme
+import KMPClient
 
 public enum DroidKaigiAppTab: Hashable {
     case timetable
@@ -30,25 +31,31 @@ public struct RootView: View {
     }
 
     public var body: some View {
-        Group {
-            switch selection {
-            case .timetable:
-                timetableTab
-            case .map:
-                eventMapTab
-            case .favorite:
-                favoriteTab
-            case .about:
-                aboutTab
-            case .idCard:
-                idCardTab
+        switch store.viewType {
+        case .swiftUI:
+            Group {
+                switch selection {
+                case .timetable:
+                    timetableTab
+                case .map:
+                    eventMapTab
+                case .favorite:
+                    favoriteTab
+                case .about:
+                    aboutTab
+                case .idCard:
+                    idCardTab
+                }
             }
+            .navigationBarTitleStyle(
+                color: AssetColors.Surface.onSurface.swiftUIColor,
+                titleTextStyle: .titleMedium,
+                largeTitleTextStyle: .headlineSmall
+            )
+        case .compose:
+            KmpAppComposeViewControllerWrapper()
+                .ignoresSafeArea(.all)
         }
-        .navigationBarTitleStyle(
-            color: AssetColors.Surface.onSurface.swiftUIColor,
-            titleTextStyle: .titleMedium,
-            largeTitleTextStyle: .headlineSmall
-        )
     }
 
     @MainActor


### PR DESCRIPTION
## Issue
- close #604 

## Overview (Required)
I added logic to switch Compose Multiplatform.
For now, Timetable and TimetaleDetail screen of Compose Multiplatform only work. If you transition to other screen, app is crashed.

## Links
- 

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="https://github.com/user-attachments/assets/c72cc3a9-efb9-46aa-ad8d-d9f540c43cdb" width="300" >

