### PR TITLE
:wrench: [ProfileCardScreen] Addressed the issue of the TopAppBar display being reset when the UIType is changed, which causes the display to be incorrect.

### DIFF
--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/AnimatedTextTopAppBar.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/AnimatedTextTopAppBar.kt
@@ -72,3 +72,9 @@ fun AnimatedTextTopAppBar(
         scrollBehavior = scrollBehavior,
     )
 }
+
+@OptIn(ExperimentalMaterial3Api::class)
+fun TopAppBarScrollBehavior.resetScroll() {
+    this.state.heightOffset = 0f
+    this.state.contentOffset = 0f
+}

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.TextFieldDefaults.indicatorLine
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -100,6 +101,7 @@ import io.github.droidkaigi.confsched.profilecard.component.PhotoPickerButton
 import io.github.droidkaigi.confsched.ui.SnackbarMessageEffect
 import io.github.droidkaigi.confsched.ui.UserMessageStateHolder
 import io.github.droidkaigi.confsched.ui.component.AnimatedTextTopAppBar
+import io.github.droidkaigi.confsched.ui.component.resetScroll
 import io.ktor.util.decodeBase64Bytes
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
@@ -212,6 +214,14 @@ internal fun ProfileCardScreen(
     )
 
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+    LaunchedEffect(uiState.uiType) {
+        if (
+            uiState.uiType == ProfileCardUiType.Card ||
+            uiState.uiType == ProfileCardUiType.Edit
+        ) {
+            scrollBehavior.resetScroll()
+        }
+    }
 
     Scaffold(
         modifier = modifier,


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- When the UIType was switched, the transitionFraction was not reset, causing the TopAppBar to display incorrectly unless a screen scrolling operation was performed.
- To address this issue, the transitionFraction is now reset explicitly.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/f6fa406b-de51-4689-98bf-45d05fd4d89b" width="300" > | <video src="https://github.com/user-attachments/assets/907062b6-9abf-4256-af35-66585a1e5336" width="300" >