### PR TITLE
Fix/486 favorite filters display mismatch 

### DIFF
--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreen.kt
@@ -158,6 +158,7 @@ private fun FavoritesScreen(
             onDay2FilterChipClick = onDay2FilterChipClick,
             onBookmarkClick = onBookmarkClick,
             contentPadding = contentPadding,
+            scrollBehavior = scrollBehavior,
             modifier = Modifier.padding(
                 top = padding.calculateTopPadding(),
             ).nestedScroll(scrollBehavior.nestedScrollConnection),

--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/component/FavoriteFilters.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/component/FavoriteFilters.kt
@@ -46,19 +46,16 @@ fun FavoriteFilters(
             selected = allFilterSelected,
             onClick = onAllFilterChipClick,
             text = stringResource(FavoritesRes.string.filter_all),
-            modifier = Modifier,
         )
         FavoriteFilterChip(
             selected = day1FilterSelected,
             onClick = onDay1FilterChipClick,
             text = stringResource(FavoritesRes.string.filter_day1),
-            modifier = Modifier,
         )
         FavoriteFilterChip(
             selected = day2FilterSelected,
             onClick = onDay2FilterChipClick,
             text = stringResource(FavoritesRes.string.filter_day2),
-            modifier = Modifier,
         )
     }
 }

--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/component/FavoriteFilters.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/component/FavoriteFilters.kt
@@ -46,16 +46,19 @@ fun FavoriteFilters(
             selected = allFilterSelected,
             onClick = onAllFilterChipClick,
             text = stringResource(FavoritesRes.string.filter_all),
+            modifier = Modifier,
         )
         FavoriteFilterChip(
             selected = day1FilterSelected,
             onClick = onDay1FilterChipClick,
             text = stringResource(FavoritesRes.string.filter_day1),
+            modifier = Modifier,
         )
         FavoriteFilterChip(
             selected = day2FilterSelected,
             onClick = onDay2FilterChipClick,
             text = stringResource(FavoritesRes.string.filter_day2),
+            modifier = Modifier,
         )
     }
 }
@@ -65,8 +68,10 @@ private fun FavoriteFilterChip(
     selected: Boolean,
     text: String,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     FilterChip(
+        modifier = modifier.padding(top = 8.dp, bottom = 12.dp),
         selected = selected,
         onClick = onClick,
         label = { Text(text) },

--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/section/FavoriteSheet.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/section/FavoriteSheet.kt
@@ -7,15 +7,20 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarColors
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -73,6 +78,7 @@ sealed interface FavoritesSheetUiState {
     ) : FavoritesSheetUiState
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FavoriteSheet(
     uiState: FavoritesSheetUiState,
@@ -83,8 +89,17 @@ fun FavoriteSheet(
     onDay2FilterChipClick: () -> Unit,
     onBookmarkClick: (TimetableItem) -> Unit,
     modifier: Modifier = Modifier,
+    scrollBehavior: TopAppBarScrollBehavior? = null,
     contentPadding: PaddingValues = PaddingValues(),
 ) {
+
+    val scrollFraction = scrollBehavior?.state?.overlappedFraction ?: 0f
+    val favoriteFiltersBackgroundColor = if (scrollFraction > 0f) {
+        TopAppBarDefaults.topAppBarColors().scrolledContainerColor
+    } else {
+        TopAppBarDefaults.topAppBarColors().containerColor
+    }
+
     Column(modifier = modifier.fillMaxSize()) {
         FavoriteFilters(
             allFilterSelected = uiState.isAllFilterSelected,
@@ -94,6 +109,9 @@ fun FavoriteSheet(
             onAllFilterChipClick = onAllFilterChipClick,
             onDay1FilterChipClick = onDay1FilterChipClick,
             onDay2FilterChipClick = onDay2FilterChipClick,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(favoriteFiltersBackgroundColor),
         )
 
         when (uiState) {
@@ -153,6 +171,7 @@ private fun EmptyView(modifier: Modifier = Modifier) {
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 @Preview
 fun FavoriteSheetPreview() {
@@ -182,6 +201,7 @@ fun FavoriteSheetPreview() {
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 @Preview
 fun FavoriteSheetNoFavoritesPreview() {

--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/section/FavoriteSheet.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/section/FavoriteSheet.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarColors
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
@@ -92,7 +91,6 @@ fun FavoriteSheet(
     scrollBehavior: TopAppBarScrollBehavior? = null,
     contentPadding: PaddingValues = PaddingValues(),
 ) {
-
     val scrollFraction = scrollBehavior?.state?.overlappedFraction ?: 0f
     val favoriteFiltersBackgroundColor = if (scrollFraction > 0f) {
         TopAppBarDefaults.topAppBarColors().scrolledContainerColor


### PR DESCRIPTION
## Issue
- close #486 

## Overview (Required)
- Set the padding of FavoriteFilterChip according to the specifications in Figma.
- Synchronized the background color of FavoriteFilters with the TopAppBar based on the scroll state.

## Links
- [Figma](https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=55499-43411&t=QBru0VRTzUukjmIe-4)

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
![before1](https://github.com/user-attachments/assets/1874c939-12b3-4a9a-b94b-c317bfafdbe7) | ![after1](https://github.com/user-attachments/assets/993efd7b-3334-449e-b18f-c8bc0721dd69)
![before2](https://github.com/user-attachments/assets/247af5ec-4462-487d-9213-6997b9930914) | ![after2](https://github.com/user-attachments/assets/8345042e-cdc2-4b2c-a751-22ea9aee4349)


## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/bfbc5ee4-0cea-4785-85b3-93151a302f97" width="300" >|<video src="https://github.com/user-attachments/assets/c0793e0e-c927-44fb-8e48-72f17b17b238" width="300" > 
