### PR TITLE
Fix scroll container color of the AnimatedLargeTopAppBar

### DIFF
--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/AnimatedLargeTopAppBar.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/AnimatedLargeTopAppBar.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarColors
 import androidx.compose.material3.TopAppBarDefaults
@@ -38,7 +39,9 @@ fun AnimatedLargeTopAppBar(
     modifier: Modifier = Modifier,
     actions: @Composable RowScope.() -> Unit = {},
     windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
-    colors: TopAppBarColors = TopAppBarDefaults.largeTopAppBarColors(),
+    colors: TopAppBarColors = TopAppBarDefaults.largeTopAppBarColors().copy(
+        scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
+    ),
     scrollBehavior: TopAppBarScrollBehavior? = null,
 ) {
     val density = LocalDensity.current.density


### PR DESCRIPTION
## Issue
- N/A

(similar #595)

## Overview (Required)
- On the staff screen and contributor screen, the background color of the top app bar differs from the Figma design when scrolling
- I specified the container color during scrolling, just like in the AnimatedTextTopAppBar.

## Links
- [Figma](https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=54953-64722)

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/b18d15f1-75fb-45eb-918e-f4be6d93fb09" width="300" /> | <img src="https://github.com/user-attachments/assets/d08fdaad-715c-4037-b7a8-3ef57ba060b9" width="300" />
<img src="https://github.com/user-attachments/assets/d570930e-c28e-4ad0-b2c4-d2e649f50126" width="300" /> | <img src="https://github.com/user-attachments/assets/8906be5c-f4bc-4898-901f-8932bfc8432d" width="300" />
