### PR TITLE
fix bottom navigation

### DIFF
--- a/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/MainScreen.kt
+++ b/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/MainScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -225,10 +224,14 @@ fun MainScreen(
 
     val navBackStackEntryRoute =
         mainNestedNavController.currentBackStackEntryAsState().value?.destination?.route
-    val lastEntryRoute by rememberSaveable(navBackStackEntryRoute) {
-        mutableStateOf(navBackStackEntryRoute)
+
+    // The rememberSaveable key isn't used when returning from the back stack, so we can ignore the null value of the route using this rememberSaveable.
+    // This prevents unexpected animations when navigating back.
+    // https://github.com/DroidKaigi/conference-app-2024/pull/732/files#r1727479543
+    val lastEntryRoute = rememberSaveable(navBackStackEntryRoute) {
+        navBackStackEntryRoute ?: "timetable"
     }
-    val currentTab = lastEntryRoute?.routeToTab() ?: MainScreenTab.Timetable
+    val currentTab = lastEntryRoute.routeToTab() ?: MainScreenTab.Timetable
 
     val hazeState = remember { HazeState() }
 

--- a/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/MainScreen.kt
+++ b/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/MainScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -221,8 +222,14 @@ fun MainScreen(
     modifier: Modifier = Modifier,
 ) {
     val mainNestedNavController = rememberNavController()
-    val navBackStackEntry by mainNestedNavController.currentBackStackEntryAsState()
-    val currentTab = navBackStackEntry?.destination?.route?.routeToTab()
+
+    val navBackStackEntryRoute =
+        mainNestedNavController.currentBackStackEntryAsState().value?.destination?.route
+    val lastEntryRoute by rememberSaveable(navBackStackEntryRoute) {
+        mutableStateOf(navBackStackEntryRoute)
+    }
+    val currentTab = lastEntryRoute?.routeToTab() ?: MainScreenTab.Timetable
+
     val hazeState = remember { HazeState() }
 
     val scaffoldPadding = remember { mutableStateOf(PaddingValues(0.dp)) }
@@ -234,7 +241,7 @@ fun MainScreen(
                 onTabSelected = {
                     onTabSelected(mainNestedNavController, it)
                 },
-                currentTab = currentTab ?: MainScreenTab.Timetable,
+                currentTab = currentTab,
                 modifier = Modifier.padding(scaffoldPadding.value),
             )
         }
@@ -247,7 +254,7 @@ fun MainScreen(
                         onTabSelected = {
                             onTabSelected(mainNestedNavController, it)
                         },
-                        currentTab = currentTab ?: MainScreenTab.Timetable,
+                        currentTab = currentTab,
                         modifier = Modifier.navigationBarsPadding(),
                     )
                 }


### PR DESCRIPTION
## Issue
- close #701 

## Overview (Required)
- The destination of backStackEntry is saved by rememberSaveable. If it goes outside the mainScreen, such as the contribute screen, the destination is saved and can be restored when it comes back. Pass navBackStackEntryRoute to inputs of rememberSaveable and update the value when route changes.

## Links
- https://developer.android.com/develop/ui/compose/state#store-state

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/73732ef3-2227-4d5d-938a-c723dfb5a991" width="300" > | <video src="https://github.com/user-attachments/assets/5be9376e-9073-4036-835a-87af0e0ede2b" width="300" >








