### PR TITLE
Stick session hour on Timetable and Farovite List

### DIFF
--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/section/FavoriteList.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/section/FavoriteList.kt
@@ -12,9 +12,12 @@ import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
@@ -23,9 +26,13 @@ import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.designsystem.theme.LocalRoomTheme
@@ -59,9 +66,11 @@ fun FavoriteList(
         else -> false
     }
     val columnNum by remember { derivedStateOf { if (isWideWidthScreen) 2 else 1 } }
+    val scrollState = rememberLazyListState()
 
     LazyColumn(
         modifier = modifier.fillMaxSize(),
+        state = scrollState,
         verticalArrangement = Arrangement.spacedBy(16.dp),
         contentPadding = PaddingValues(
             top = 16.dp,
@@ -71,12 +80,34 @@ fun FavoriteList(
             end = 16.dp + contentPadding.calculateEndPadding(layoutDirection),
         ),
     ) {
-        items(
+        itemsIndexed(
             items = timetableItemMap.toList(),
-            key = { it.first.key },
-        ) { (time, timetableItems) ->
-            Row {
+            key = { _, item -> item.first.key },
+        ) { index, (time, timetableItems) ->
+            var rowHeight by remember { mutableIntStateOf(0) }
+            var timeTextHeight by remember { mutableIntStateOf(0) }
+            val timeTextOffset by remember {
+                derivedStateOf {
+                    val maxOffset = rowHeight - timeTextHeight
+                    if (index == scrollState.firstVisibleItemIndex) {
+                        minOf(scrollState.firstVisibleItemScrollOffset, maxOffset).coerceAtLeast(0)
+                    } else {
+                        0
+                    }
+                }
+            }
+            Row(
+                modifier = Modifier
+                    .onGloballyPositioned {
+                        rowHeight = it.size.height
+                    },
+            ) {
                 TimetableTime(
+                    modifier = Modifier
+                        .onGloballyPositioned {
+                            timeTextHeight = it.size.height
+                        }
+                        .offset { IntOffset(0, timeTextOffset) },
                     startTime = time.startTimeString,
                     endTime = time.endTimeString,
                 )

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
@@ -12,10 +12,11 @@ import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
@@ -23,10 +24,14 @@ import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched.designsystem.theme.LocalRoomTheme
 import io.github.droidkaigi.confsched.model.Timetable
@@ -88,13 +93,35 @@ fun TimetableList(
             end = 16.dp + contentPadding.calculateEndPadding(layoutDirection),
         ),
     ) {
-        items(
+        itemsIndexed(
             // TODO: Check whether the number of recompositions increases.
             items = uiState.timetableItemMap.toList(),
-            key = { it.first.key },
-        ) { (time, timetableItems) ->
-            Row {
+            key = { _, item -> item.first.key },
+        ) { index, (time, timetableItems) ->
+            var rowHeight by remember { mutableIntStateOf(0) }
+            var timeTextHeight by remember { mutableIntStateOf(0) }
+            val timeTextOffset by remember(scrollState) {
+                derivedStateOf {
+                    val maxOffset = rowHeight - timeTextHeight
+                    if (index == scrollState.firstVisibleItemIndex) {
+                        minOf(scrollState.firstVisibleItemScrollOffset, maxOffset).coerceAtLeast(0)
+                    } else {
+                        0
+                    }
+                }
+            }
+            Row(
+                modifier = Modifier
+                    .onGloballyPositioned {
+                        rowHeight = it.size.height
+                    },
+            ) {
                 TimetableTime(
+                    modifier = Modifier
+                        .onGloballyPositioned {
+                            timeTextHeight = it.size.height
+                        }
+                        .offset { IntOffset(0, timeTextOffset) },
                     startTime = time.startTimeString,
                     endTime = time.endTimeString,
                 )


### PR DESCRIPTION
## Issue
- close #699 

## Overview (Required)
- When scroll timetable and favorites, session hour will be hidden.
- By this pr, show session hour sticky on the display.

## Links
- 

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/a02fb9bc-02c0-4ca9-b781-f2faa1897cde" width="300" > | <video src="https://github.com/user-attachments/assets/47184992-d35b-4225-b9e5-9f853f371513" width="300" >


