### PR TITLE
Prevent screen termination on back press during detail transition

### DIFF
--- a/core/designsystem/src/iosMain/kotlin/io/github/droidkaigi/confsched/designsystem/theme/Type.ios.kt
+++ b/core/designsystem/src/iosMain/kotlin/io/github/droidkaigi/confsched/designsystem/theme/Type.ios.kt
@@ -3,14 +3,25 @@ package io.github.droidkaigi.confsched.designsystem.theme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.platform.Typeface
+import org.jetbrains.skia.FontMgr
 import org.jetbrains.skia.FontStyle
 import org.jetbrains.skia.Typeface
 
 @Composable
 actual fun dotGothic16FontFamily(): FontFamily {
-    return FontFamily(Typeface(loadCustomFont("dot_gothic16_regular")))
+    val skTypeface = loadCustomFont("dot_gothic16_regular")
+
+    return try {
+        FontFamily(Typeface(skTypeface))
+    } finally {
+        skTypeface.close()
+    }
 }
 
 private fun loadCustomFont(name: String): Typeface {
-    return Typeface.makeFromName(name, FontStyle.NORMAL)
+    val fontMgr = FontMgr.default
+
+    return fontMgr.matchFamilyStyle(name, FontStyle.NORMAL)
+        ?: fontMgr.matchFamilyStyle(null, FontStyle.NORMAL) // default system font.
+        ?: Typeface.makeEmpty()
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -106,7 +106,7 @@ composeMaterialWindowSize = "dev.chrisbanes.material3:material3-window-size-clas
 composeMaterialIcon = { module = "androidx.compose.material:material-icons-extended" }
 composeUiTestManifest = { module = "androidx.compose.ui:ui-test-manifest" }
 composeUiTestJunit4 = { module = "androidx.compose.ui:ui-test-junit4" }
-composeNavigation = { module = "org.jetbrains.androidx.navigation:navigation-compose", version = "2.8.0-alpha08" }
+composeNavigation = { module = "org.jetbrains.androidx.navigation:navigation-compose", version = "2.8.0-alpha09" }
 coreBundle = { module = "org.jetbrains.androidx.core:core-bundle", version = "1.0.0" }
 composeHiltNavigation = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "composeHiltNavigation" }
 composeLintCheck = { module = "com.slack.lint.compose:compose-lint-checks", version = "1.3.1" }


### PR DESCRIPTION
## Issue
- close #661 

## Overview (Required)
- Updated navigation-compose from 2.8.0-alpha08 to 2.8.0-alpha09.
- The new version, 2.8.0-alpha09, is based on Jetpack Navigation 2.8.0-beta05, which includes important fixes introduced in 2.8.0-beta04.
  - https://developer.android.com/jetpack/androidx/releases/navigation#2.8.0-beta04
  - > Fixed an issue in Navigation Compose where after canceling the Predictive Back Gesture, the NavBackStackEntry that the user returns to never returns back to the RESUMED Lifecycle State. This also ensures the returning destination correctly animates back in instead of snapping into place after a fling. ([I97a0c](https://android-review.googlesource.com/#/q/I97a0c5fe7fe661a2fadfbb01346676482d426028), [b/346608857](https://issuetracker.google.com/issues/346608857))
  - (This is likely the relevant fix.)
- Fixed an issue where the iOS build was failing due to the Skiko dependency being updated from 0.8.9 to 0.8.11.

### Request
I'm not entirely sure if the changes made in this commit are correct: https://github.com/DroidKaigi/conference-app-2024/pull/740/commits/2ad5b97e31c3649ba53431d9846c80f6aba44aed. I have tested building the iOS app and confirmed that the Contribution screen remains unchanged. If you notice anything unusual or have any feedback, I would greatly appreciate your comments.

## Links
- https://github.com/JetBrains/compose-multiplatform/releases/tag/v1.7.0-alpha03
  - > Navigation libraries org.jetbrains.androidx.navigation:navigation-*:2.8.0-alpha09. Based on [Jetpack Navigation 2.8.0-beta05](https://developer.android.com/jetpack/androidx/releases/navigation#2.8.0-beta05)

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/1be9add1-b445-42df-8be5-b71b4dad7f89" width="300" > | <video src="https://github.com/user-attachments/assets/f8aa6293-05e1-458c-921f-eb201a235901" width="300" >
