### PR TITLE
Enable to view conference day tab even if font size is large

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridTab.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridTab.kt
@@ -43,7 +43,7 @@ fun TimetableDayTab(
     val selectedTabIndex = selectedDay.tabIndex()
     val selectedColor = Color(0xFF4AFF82)
     Column(
-        modifier = modifier.padding(top = 16.dp, start = 16.dp),
+        modifier = modifier.padding(top = 16.dp, start = 16.dp, end = 16.dp),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.Start,
     ) {

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridTab.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridTab.kt
@@ -5,8 +5,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
@@ -17,8 +19,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
@@ -32,17 +34,21 @@ fun TimetableDayTab(
     onDaySelected: (day: DroidKaigi2024Day) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val density = LocalDensity.current
+    val tabWidth = with(density) {
+        // calculate width from sp
+        // NOTE: 6 is a magic number here
+        ((16.sp * 6) * fontScale).toDp()
+    }
     val selectedTabIndex = selectedDay.tabIndex()
     val selectedColor = Color(0xFF4AFF82)
     Column(
-        modifier = modifier.padding(start = 12.dp),
+        modifier = modifier.padding(top = 16.dp, start = 16.dp),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.Start,
     ) {
         TabRow(
-            modifier = Modifier
-                .padding(horizontal = 20.dp)
-                .width(106.dp),
+            modifier = Modifier.width(tabWidth),
             selectedTabIndex = selectedTabIndex,
             indicator = @Composable { tabPositions ->
                 if (selectedTabIndex < tabPositions.size) {
@@ -60,11 +66,7 @@ fun TimetableDayTab(
                     Tab(
                         modifier = Modifier
                             .testTag(TimetableTabTestTag.plus(conferenceDay.ordinal))
-                            .padding(
-                                horizontal = 8.dp,
-                                vertical = 16.dp,
-                            )
-                            .height(26.dp),
+                            .requiredHeightIn(min = 26.dp),
                         selected = isSelected,
                         onClick = {
                             onDaySelected(conferenceDay)
@@ -90,8 +92,9 @@ private fun FloorText(
     isSelected: Boolean,
 ) {
     Text(
+        modifier = Modifier.padding(bottom = 4.dp),
         text = text,
-        fontWeight = FontWeight.W400,
+        style = MaterialTheme.typography.titleMedium,
         fontSize = 16.sp,
         lineHeight = 23.8.sp,
         color = if (isSelected) {


### PR DESCRIPTION
## Issue
- no issue

## Overview (Required)
- As attached screenshots, conference day tab is not shown correctly if font size is changed.
- Font was not set
- layout was little bit far from figma's
  <img src="https://github.com/user-attachments/assets/5e4791d2-842c-4fa3-9f33-5428e94f33b9" width="300" />
- **If this pr is not fit to the app, please close** :bow:

## Links
- https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=54849-12900&t=Kr9KWAn23JSTK8Y7-0

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/ec7b682b-07e5-4319-a52f-e12f967227ee" width="300" /> | <img src="https://github.com/user-attachments/assets/42348403-cf34-4a0a-86e1-6971e49b2c69" width="300" />
<img src="https://github.com/user-attachments/assets/aa4e9629-d52e-4f50-b8b3-7c297e2ff4fe" width="300" /> | <img src="https://github.com/user-attachments/assets/01275064-16c3-427c-8140-84c1e9abb0df" width="300" />

