### PR TITLE
:wrench: Addressed an issue where Kover fails to execute.

### DIFF
--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KoverEntryPointPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KoverEntryPointPlugin.kt
@@ -13,7 +13,10 @@ class KoverEntryPointPlugin : Plugin<Project> {
 
             rootProject.subprojects {
                 if (this@subprojects.name == target.name) return@subprojects
-                this@subprojects.pluginManager.apply(koverPlugin)
+                // https://github.com/DroidKaigi/conference-app-2024/issues/485#issuecomment-2304251937
+                this@subprojects.beforeEvaluate { // wrap with beforeEvaluate
+                    this@subprojects.pluginManager.apply(koverPlugin)
+                }
                 target.dependencies.add("kover", this@subprojects)
             }
 


### PR DESCRIPTION
## Issue
- close #485

## Overview (Required)
- The timing of the application of the KoverPlugin is now done before the project evaluation is complete.
- Without this support, the plugin will be applied while the project has already been evaluated, which will cause an error.
- Thanks to @Aniokrait for providing specific ways to respond! 👏 

## Links
- https://github.com/DroidKaigi/conference-app-2024/issues/485#issuecomment-2304251937