### PR TITLE
:sparkles: Implement share ProfileCard from an iOS Compose Multiplatform app

### DIFF
--- a/app-ios-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/shared/IosComposeKaigiApp.kt
+++ b/app-ios-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/shared/IosComposeKaigiApp.kt
@@ -11,17 +11,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.window.ComposeUIViewController
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import io.github.droidkaigi.confsched.about.aboutScreen
 import io.github.droidkaigi.confsched.favorites.navigateFavoritesScreen
 import io.github.droidkaigi.confsched.about.navigateAboutScreen
-import io.github.droidkaigi.confsched.contributors.ContributorsScreen
 import io.github.droidkaigi.confsched.contributors.contributorsScreenRoute
 import io.github.droidkaigi.confsched.contributors.contributorsScreens
 import io.github.droidkaigi.confsched.data.Repositories
@@ -52,6 +49,7 @@ import io.github.droidkaigi.confsched.sessions.searchScreens
 import io.github.droidkaigi.confsched.sessions.sessionScreens
 import io.github.droidkaigi.confsched.sessions.timetableScreenRoute
 import io.github.droidkaigi.confsched.settings.settingsScreens
+import io.github.droidkaigi.confsched.shared.share.shareTextWithImage
 import io.github.droidkaigi.confsched.sponsors.sponsorsScreenRoute
 import io.github.droidkaigi.confsched.sponsors.sponsorsScreens
 import io.github.droidkaigi.confsched.staff.staffScreenRoute
@@ -101,9 +99,7 @@ private fun KaigiNavHost(
         mainScreen(
             windowSize = windowSize,
             navController = navController,
-            onClickShareProfileCard = { shareText, image ->
-
-            }
+            onClickShareProfileCard = ::shareTextWithImage
         )
         sessionScreens(
             onNavigationIconClick = navController::popBackStack,

--- a/app-ios-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/shared/share/ShareTextWithImage.kt
+++ b/app-ios-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/shared/share/ShareTextWithImage.kt
@@ -1,0 +1,5 @@
+package io.github.droidkaigi.confsched.shared.share
+
+import androidx.compose.ui.graphics.ImageBitmap
+
+expect fun shareTextWithImage(text: String, image: ImageBitmap)

--- a/app-ios-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/shared/share/ImageBitmapToUiImage.kt
+++ b/app-ios-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/shared/share/ImageBitmapToUiImage.kt
@@ -1,0 +1,30 @@
+package io.github.droidkaigi.confsched.shared.share
+
+import androidx.compose.ui.graphics.ImageBitmap
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.refTo
+import platform.CoreGraphics.CGBitmapContextCreate
+import platform.CoreGraphics.CGBitmapContextCreateImage
+import platform.CoreGraphics.CGColorSpaceCreateDeviceRGB
+import platform.CoreGraphics.CGImageAlphaInfo
+import platform.UIKit.UIImage
+
+@OptIn(ExperimentalForeignApi::class)
+fun ImageBitmap.toUiImage(): UIImage? {
+    val buffer = IntArray(width * height)
+    readPixels(buffer)
+
+    val colorSpace = CGColorSpaceCreateDeviceRGB()
+    val context = CGBitmapContextCreate(
+        data = buffer.refTo(0),
+        width = width.toULong(),
+        height = height.toULong(),
+        bitsPerComponent = 8u,
+        bytesPerRow = (4 * width).toULong(),
+        space = colorSpace,
+        bitmapInfo = CGImageAlphaInfo.kCGImageAlphaPremultipliedLast.value
+    )
+
+    val cgImage = CGBitmapContextCreateImage(context)
+    return cgImage?.let { UIImage.imageWithCGImage(it) }
+}

--- a/app-ios-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/shared/share/ImageBitmapToUiImage.kt
+++ b/app-ios-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/shared/share/ImageBitmapToUiImage.kt
@@ -5,8 +5,10 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.refTo
 import platform.CoreGraphics.CGBitmapContextCreate
 import platform.CoreGraphics.CGBitmapContextCreateImage
-import platform.CoreGraphics.CGColorSpaceCreateDeviceRGB
+import platform.CoreGraphics.CGColorSpaceCreateWithName
 import platform.CoreGraphics.CGImageAlphaInfo
+import platform.CoreGraphics.kCGBitmapByteOrder32Little
+import platform.CoreGraphics.kCGColorSpaceSRGB
 import platform.UIKit.UIImage
 
 @OptIn(ExperimentalForeignApi::class)
@@ -14,7 +16,9 @@ fun ImageBitmap.toUiImage(): UIImage? {
     val buffer = IntArray(width * height)
     readPixels(buffer)
 
-    val colorSpace = CGColorSpaceCreateDeviceRGB()
+    // https://github.com/takahirom/roborazzi/blob/main/roborazzi-compose-ios/src/iosMain/kotlin/io/github/takahirom/roborazzi/RoborazziIos.kt#L88C51-L88C68
+    val colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB)
+    val bitmapInfo = CGImageAlphaInfo.kCGImageAlphaPremultipliedFirst.value or kCGBitmapByteOrder32Little
     val context = CGBitmapContextCreate(
         data = buffer.refTo(0),
         width = width.toULong(),
@@ -22,7 +26,7 @@ fun ImageBitmap.toUiImage(): UIImage? {
         bitsPerComponent = 8u,
         bytesPerRow = (4 * width).toULong(),
         space = colorSpace,
-        bitmapInfo = CGImageAlphaInfo.kCGImageAlphaPremultipliedLast.value
+        bitmapInfo = bitmapInfo,
     )
 
     val cgImage = CGBitmapContextCreateImage(context)

--- a/app-ios-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/shared/share/ShareTextWithImage.ios.kt
+++ b/app-ios-shared/src/iosMain/kotlin/io/github/droidkaigi/confsched/shared/share/ShareTextWithImage.ios.kt
@@ -1,0 +1,25 @@
+package io.github.droidkaigi.confsched.shared.share
+
+import androidx.compose.ui.graphics.ImageBitmap
+import platform.UIKit.UIActivityViewController
+import platform.UIKit.UIApplication
+
+actual fun shareTextWithImage(text: String, image: ImageBitmap) {
+    val items = mutableListOf<Any>(text)
+    image.toUiImage()?.let {
+        items.add(it)
+        println("Success to create UIImage from ImageBitmap.")
+    } ?: run {
+        println("Failed to create UIImage from ImageBitmap.")
+    }
+
+    val activityViewController = UIActivityViewController(items, null)
+    val keyWindow = UIApplication.sharedApplication.keyWindow
+    val rootViewController = keyWindow?.rootViewController
+
+    rootViewController?.presentViewController(
+        viewControllerToPresent = activityViewController,
+        animated = true,
+        completion = null,
+    )
+}


### PR DESCRIPTION
## Issue
- close #731

## Overview (Required)
- Profile cards can be shared in the same way as in Android.

### Note
- Currently, ProfileCard has the following two problems, which make it difficult to confirm that it works

1. The keyboard does not close when editing the ProfileCardScreen, so it is not possible to press the Create Card button.
   - In the attached video, we have added a note to the implementation to close the keyboard when you tap in the screen.
   - Its content is not included as it is not relevant to this PR.
2. The application crashes when ProfileCardScreen is opened with a ProfileCard already created.
    - https://github.com/DroidKaigi/conference-app-2024/issues/745

## Links
- https://medium.com/mobile-innovation-network/imagebitmap-to-uiimage-compose-multiplatform-0e1f121d7da8
- https://github.com/takahirom/roborazzi/blob/main/roborazzi-compose-ios/src/iosMain/kotlin/io/github/takahirom/roborazzi/RoborazziIos.kt#L88C51-L88C68

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Android | iOS
:--: | :--:
<img src="https://github.com/user-attachments/assets/71d5a4e7-767a-4c3a-ab76-f6bf0fb58900" width="300" /> | <img src="https://github.com/user-attachments/assets/8e2a6e00-6fe7-48e7-aa0d-1cd814c9390f" width="300" />

## Movie (Optional)
<img src="https://github.com/user-attachments/assets/313de916-4184-4397-aff2-e3f44e32ac78" width="300" > 