### PR TITLE
Improved timetable tab design

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridTab.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridTab.kt
@@ -49,8 +49,10 @@ fun TimetableDayTab(
         stateList.addAll(DroidKaigi2024Day.visibleDays().map { 24.dp }) // default indicator width
         stateList
     }
+    val paddingAroundTab =
+        (tabWidth - indicatorWidths.reduce { acc, width -> acc + width }) / (indicatorWidths.size * 2)
     Column(
-        modifier = modifier.padding(horizontal = 20.dp, vertical = 16.dp),
+        modifier = modifier.padding(horizontal = 20.dp - paddingAroundTab, vertical = 16.dp),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.Start,
     ) {

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridTab.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridTab.kt
@@ -2,12 +2,9 @@ package io.github.droidkaigi.confsched.sessions.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
@@ -16,11 +13,16 @@ import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
@@ -42,8 +44,13 @@ fun TimetableDayTab(
     }
     val selectedTabIndex = selectedDay.tabIndex()
     val selectedColor = Color(0xFF4AFF82)
+    val indicatorWidths = remember {
+        val stateList = mutableStateListOf<Dp>()
+        stateList.addAll(DroidKaigi2024Day.visibleDays().map { 24.dp }) // default indicator width
+        stateList
+    }
     Column(
-        modifier = modifier.padding(top = 16.dp, start = 16.dp, end = 16.dp),
+        modifier = modifier.padding(horizontal = 20.dp, vertical = 16.dp),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.Start,
     ) {
@@ -52,21 +59,23 @@ fun TimetableDayTab(
             selectedTabIndex = selectedTabIndex,
             indicator = @Composable { tabPositions ->
                 if (selectedTabIndex < tabPositions.size) {
-                    TabRowDefaults.SecondaryIndicator(
-                        modifier = Modifier
-                            .wrapContentWidth()
-                            .tabIndicatorOffset(tabPositions[selectedTabIndex]),
+                    TabRowDefaults.PrimaryIndicator(
+                        modifier = Modifier.tabIndicatorOffset(tabPositions[selectedTabIndex]),
+                        width = indicatorWidths[selectedTabIndex],
+                        height = 2.dp,
                         color = selectedColor,
+                        shape = RectangleShape,
                     )
                 }
             },
             tabs = {
-                DroidKaigi2024Day.visibleDays().forEach { conferenceDay ->
+                DroidKaigi2024Day.visibleDays().forEachIndexed { index, conferenceDay ->
                     val isSelected = conferenceDay == selectedDay
                     Tab(
                         modifier = Modifier
                             .testTag(TimetableTabTestTag.plus(conferenceDay.ordinal))
-                            .requiredHeightIn(min = 26.dp),
+                            .requiredHeightIn(min = 26.dp)
+                            .let { if (isSelected) it.padding(bottom = 2.dp) else it },
                         selected = isSelected,
                         onClick = {
                             onDaySelected(conferenceDay)
@@ -77,12 +86,13 @@ fun TimetableDayTab(
                         FloorText(
                             text = conferenceDay.monthAndDay(),
                             isSelected = isSelected,
+                            onTextLayout = { indicatorWidths[index] = with(density) { it.size.width.toDp() } },
                         )
                     }
                 }
             },
+            divider = { /* Divider is not needed */ },
         )
-        Spacer(modifier = Modifier.height(24.dp))
     }
 }
 
@@ -90,9 +100,9 @@ fun TimetableDayTab(
 private fun FloorText(
     text: String,
     isSelected: Boolean,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
 ) {
     Text(
-        modifier = Modifier.padding(bottom = 4.dp),
         text = text,
         style = MaterialTheme.typography.titleMedium,
         fontSize = 16.sp,
@@ -102,6 +112,7 @@ private fun FloorText(
         } else {
             Color.White
         },
+        onTextLayout = onTextLayout,
     )
 }
 


### PR DESCRIPTION
## Issue
- close #704

## Overview (Required)
- Adjusted the selected indicator width
- Removed the divider under TabRow
- Other padding adjustments

## Links
- https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=55496-41054&t=i5tCQutiAXEMUvIh-4

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/b2082223-2ef7-45da-94d1-dd3ced978e23" width="300" /> | <img src="https://github.com/user-attachments/assets/192a3c92-cb21-45d2-b90b-fc8e4a35a498" width="300" />

