### PR TITLE
Perform haptic feedback when favoriting a session (either from the list or detail screens)

### DIFF
--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/TimetableItemCard.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched/ui/component/TimetableItemCard.kt
@@ -34,8 +34,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -71,6 +73,8 @@ fun TimetableItemCard(
     modifier: Modifier = Modifier,
     highlightWord: String = "",
 ) {
+    val haptic = LocalHapticFeedback.current
+
     val highlightBackgroundColor = MaterialTheme.colorScheme.surfaceTint.copy(alpha = 0.14f)
     val annotatedTitleString = remember(
         timetableItem.title.currentLangTitle,
@@ -176,6 +180,10 @@ fun TimetableItemCard(
             FavoriteButton(
                 isBookmarked = isBookmarked,
                 onClick = {
+                    if (!isBookmarked) {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    }
+
                     onBookmarkClick(timetableItem, true)
                 },
             )

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailBottomAppBar.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailBottomAppBar.kt
@@ -12,6 +12,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
 import conference_app_2024.feature.sessions.generated.resources.calendar_add_on
 import conference_app_2024.feature.sessions.generated.resources.content_description_calendar
@@ -34,6 +36,8 @@ fun TimetableItemDetailBottomAppBar(
     modifier: Modifier = Modifier,
     onShareClick: (TimetableItem) -> Unit,
 ) {
+    val haptic = LocalHapticFeedback.current
+
     BottomAppBar(
         modifier = modifier,
         actions = {
@@ -53,7 +57,13 @@ fun TimetableItemDetailBottomAppBar(
         floatingActionButton = {
             FloatingActionButton(
                 modifier = Modifier.testTag(TimetableItemDetailBookmarkIconTestTag),
-                onClick = { onBookmarkClick(timetableItem) },
+                onClick = {
+                    if (!isBookmarked) {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    }
+
+                    onBookmarkClick(timetableItem)
+                },
                 containerColor = MaterialTheme.colorScheme.secondaryContainer,
             ) {
                 val contentDescription = if (isBookmarked) {


### PR DESCRIPTION
## Issue
- close #756

## Overview (Required)
- Similar to [last year's app](https://github.com/DroidKaigi/conference-app-2023/pull/1126/files), invoke some haptic feedback when the favorite button is clicked on a session
- The vibration only happens when you "favorite" a session, not when you "unfavorite" a session
