### PR TITLE
Add scrolled screen test for FavoritesScreenTest

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sessions/FakeSessionsApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sessions/FakeSessionsApiClient.kt
@@ -50,7 +50,11 @@ public class FakeSessionsApiClient : SessionsApiClient {
     public companion object {
         public val defaultSession: SessionResponse = SessionsAllResponse.fake()
             .filterConferenceDaySessions().sessions.find { it.sessionType == "NORMAL" }!!
-        public val defaultSessionId: String = defaultSession!!.id
+        public val defaultSessionId: String = defaultSession.id
+
+        public val defaultSessions: List<SessionResponse> = SessionsAllResponse.fake()
+            .filterConferenceDaySessions().sessions.take(6)
+        public val defaultSessionIds: List<String> = defaultSessions.map { it.id }
 
         public val defaultSessionWithLongDescription: SessionResponse = SessionsAllResponse.fake()
             .filterConferenceDaySessions().sessions.find {

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sessions/FakeSessionsApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sessions/FakeSessionsApiClient.kt
@@ -53,7 +53,7 @@ public class FakeSessionsApiClient : SessionsApiClient {
         public val defaultSessionId: String = defaultSession.id
 
         public val defaultSessions: List<SessionResponse> = SessionsAllResponse.fake()
-            .filterConferenceDaySessions().sessions.take(6)
+            .filterConferenceDaySessions().sessions.filter { it.sessionType == "NORMAL" }.take(6)
         public val defaultSessionIds: List<String> = defaultSessions.map { it.id }
 
         public val defaultSessionWithLongDescription: SessionResponse = SessionsAllResponse.fake()

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sessions/FakeSessionsApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sessions/FakeSessionsApiClient.kt
@@ -53,7 +53,7 @@ public class FakeSessionsApiClient : SessionsApiClient {
         public val defaultSessionId: String = defaultSession.id
 
         public val defaultSessions: List<SessionResponse> = SessionsAllResponse.fake()
-            .filterConferenceDaySessions().sessions.filter { it.sessionType == "NORMAL" }.take(6)
+            .filterConferenceDaySessions().sessions.filter { it.sessionType == "NORMAL" }.take(7)
         public val defaultSessionIds: List<String> = defaultSessions.map { it.id }
 
         public val defaultSessionWithLongDescription: SessionResponse = SessionsAllResponse.fake()

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/FavoritesScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/FavoritesScreenRobot.kt
@@ -39,6 +39,12 @@ class FavoritesScreenRobot @Inject constructor(
         waitUntilIdle()
     }
 
+    suspend fun setupSingleFavoriteSession() {
+        userDataStore.toggleFavorite(
+            TimetableItemId(FakeSessionsApiClient.defaultSessionId),
+        )
+    }
+
     suspend fun setupFavoriteSessions() {
         FakeSessionsApiClient.defaultSessionIds.forEach {
             userDataStore.toggleFavorite(TimetableItemId(it))

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/FavoritesScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/FavoritesScreenRobot.kt
@@ -39,10 +39,10 @@ class FavoritesScreenRobot @Inject constructor(
         waitUntilIdle()
     }
 
-    suspend fun setupFavoriteSession() {
-        userDataStore.toggleFavorite(
-            TimetableItemId(FakeSessionsApiClient.defaultSessionId),
-        )
+    suspend fun setupFavoriteSessions() {
+        FakeSessionsApiClient.defaultSessionIds.forEach {
+            userDataStore.toggleFavorite(TimetableItemId(it))
+        }
         waitUntilIdle()
     }
 

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/FavoritesScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/FavoritesScreenRobot.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched.testing.robot
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isDisplayed
@@ -57,6 +58,14 @@ class FavoritesScreenRobot @Inject constructor(
             .onAllNodes(hasTestTag(TimetableItemCardTestTag))
             .onFirst()
             .assertIsDisplayed()
+        waitUntilIdle()
+    }
+
+    fun checkTimetableListFirstItemNotDisplayed() {
+        composeTestRule
+            .onAllNodes(hasTestTag(TimetableItemCardTestTag))
+            .onFirst()
+            .assertIsNotDisplayed()
         waitUntilIdle()
     }
 

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/FavoritesScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/FavoritesScreenRobot.kt
@@ -6,12 +6,16 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeUp
 import io.github.droidkaigi.confsched.data.sessions.FakeSessionsApiClient
 import io.github.droidkaigi.confsched.data.user.UserDataStore
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.favorites.FavoritesScreen
+import io.github.droidkaigi.confsched.favorites.FavoritesScreenTestTag
 import io.github.droidkaigi.confsched.favorites.section.FavoritesScreenEmptyViewTestTag
 import io.github.droidkaigi.confsched.model.TimetableItemId
+import io.github.droidkaigi.confsched.sessions.TimetableScreenTestTag
 import io.github.droidkaigi.confsched.ui.component.TimetableItemCardBookmarkButtonTestTag
 import io.github.droidkaigi.confsched.ui.component.TimetableItemCardTestTag
 import javax.inject.Inject
@@ -69,5 +73,16 @@ class FavoritesScreenRobot @Inject constructor(
         composeTestRule
             .onNode(hasText("Fake IO Exception"))
             .isDisplayed()
+    }
+
+    fun scrollFavorites() {
+        composeTestRule
+            .onNode(hasTestTag(FavoritesScreenTestTag))
+            .performTouchInput {
+                swipeUp(
+                    startY = visibleSize.height * 4F / 5,
+                    endY = visibleSize.height / 5F,
+                )
+            }
     }
 }

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/FavoritesScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/FavoritesScreenRobot.kt
@@ -15,7 +15,6 @@ import io.github.droidkaigi.confsched.favorites.FavoritesScreen
 import io.github.droidkaigi.confsched.favorites.FavoritesScreenTestTag
 import io.github.droidkaigi.confsched.favorites.section.FavoritesScreenEmptyViewTestTag
 import io.github.droidkaigi.confsched.model.TimetableItemId
-import io.github.droidkaigi.confsched.sessions.TimetableScreenTestTag
 import io.github.droidkaigi.confsched.ui.component.TimetableItemCardBookmarkButtonTestTag
 import io.github.droidkaigi.confsched.ui.component.TimetableItemCardTestTag
 import javax.inject.Inject

--- a/feature/favorites/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenTest.kt
+++ b/feature/favorites/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenTest.kt
@@ -77,7 +77,7 @@ class FavoritesScreenTest(
                             doIt {
                                 clickFirstSessionBookmark()
                             }
-                            itShould("display empty view") {
+                            itShould("display favorite session without first session") {
                                 captureScreenWithChecks(
                                     checks = { checkTimetableListItemsDisplayed() },
                                 )
@@ -87,9 +87,9 @@ class FavoritesScreenTest(
                             doIt {
                                 scrollFavorites()
                             }
-                            itShould("display favorite session") {
+                            itShould("first session is not displayed") {
                                 captureScreenWithChecks(
-                                    checks = { checkTimetableListItemsDisplayed() },
+                                    checks = { checkTimetableListFirstItemNotDisplayed() },
                                 )
                             }
                         }

--- a/feature/favorites/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenTest.kt
+++ b/feature/favorites/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenTest.kt
@@ -41,7 +41,7 @@ class FavoritesScreenTest(
                 describe("when server is operational") {
                     doIt {
                         setupTimetableServer(ServerStatus.Operational)
-                        setupFavoriteSession()
+                        setupFavoriteSessions()
                         setupFavoritesScreenContent()
                     }
                     itShould("display favorite session") {
@@ -91,7 +91,7 @@ class FavoritesScreenTest(
                     doIt {
                         setupTabletDevice()
                         setupTimetableServer(ServerStatus.Operational)
-                        setupFavoriteSession()
+                        setupFavoriteSessions()
                         setupFavoritesScreenContent()
                     }
                     itShould("show timetable items") {

--- a/feature/favorites/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenTest.kt
+++ b/feature/favorites/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenTest.kt
@@ -59,6 +59,16 @@ class FavoritesScreenTest(
                             )
                         }
                     }
+                    describe("scroll favorites") {
+                        doIt {
+                            scrollFavorites()
+                        }
+                        itShould("display favorite session") {
+                            captureScreenWithChecks(
+                                checks = { checkTimetableListItemsDisplayed() },
+                            )
+                        }
+                    }
                 }
 
                 describe("when server is down") {

--- a/feature/favorites/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenTest.kt
+++ b/feature/favorites/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenTest.kt
@@ -41,36 +41,60 @@ class FavoritesScreenTest(
                 describe("when server is operational") {
                     doIt {
                         setupTimetableServer(ServerStatus.Operational)
-                        setupFavoriteSessions()
-                        setupFavoritesScreenContent()
                     }
-                    itShould("display favorite session") {
-                        captureScreenWithChecks(
-                            checks = { checkTimetableListItemsDisplayed() },
-                        )
-                    }
-                    describe("click first session bookmark") {
+                    describe("setup single favorite session") {
                         doIt {
-                            clickFirstSessionBookmark()
-                        }
-                        itShould("display empty view") {
-                            captureScreenWithChecks(
-                                checks = { checkEmptyViewDisplayed() },
-                            )
-                        }
-                    }
-                    describe("scroll favorites") {
-                        doIt {
-                            scrollFavorites()
+                            setupSingleFavoriteSession()
+                            setupFavoritesScreenContent()
                         }
                         itShould("display favorite session") {
                             captureScreenWithChecks(
                                 checks = { checkTimetableListItemsDisplayed() },
                             )
                         }
+                        describe("click first session bookmark") {
+                            doIt {
+                                clickFirstSessionBookmark()
+                            }
+                            itShould("display empty view") {
+                                captureScreenWithChecks(
+                                    checks = { checkEmptyViewDisplayed() },
+                                )
+                            }
+                        }
+                    }
+                    describe("setup many favorite sessions") {
+                        doIt {
+                            setupFavoriteSessions()
+                            setupFavoritesScreenContent()
+                        }
+                        itShould("display favorite session") {
+                            captureScreenWithChecks(
+                                checks = { checkTimetableListItemsDisplayed() },
+                            )
+                        }
+                        describe("click first session bookmark") {
+                            doIt {
+                                clickFirstSessionBookmark()
+                            }
+                            itShould("display empty view") {
+                                captureScreenWithChecks(
+                                    checks = { checkTimetableListItemsDisplayed() },
+                                )
+                            }
+                        }
+                        describe("scroll favorites") {
+                            doIt {
+                                scrollFavorites()
+                            }
+                            itShould("display favorite session") {
+                                captureScreenWithChecks(
+                                    checks = { checkTimetableListItemsDisplayed() },
+                                )
+                            }
+                        }
                     }
                 }
-
                 describe("when server is down") {
                     doIt {
                         setupTimetableServer(ServerStatus.Error)


### PR DESCRIPTION
## Issue
- close #746

## Overview (Required)
- Added scrolling action method in the favorites screen robot.
- Added a fake with lots of items to scroll through.
- Separated the test setup into an environment with a single item and many items to scroll.