### PR TITLE
In EditScreen, make ClearButton look the same as Figma

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.geometry.CornerRadius
@@ -536,6 +537,7 @@ private fun ImagePickerWithError(
     onClearImage: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val clearButtonShadowColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
     Column(modifier = modifier) {
         image?.let {
             Box(
@@ -554,8 +556,15 @@ private fun ImagePickerWithError(
                     onClick = onClearImage,
                     modifier = Modifier
                         .graphicsLayer {
-                            translationX = 6.dp.toPx()
-                            translationY = -6.dp.toPx()
+                            translationX = 9.dp.toPx()
+                            translationY = -9.dp.toPx()
+                        }
+                        .drawBehind {
+                            drawCircle(
+                                color = clearButtonShadowColor,
+                                radius = 12.dp.toPx(),
+                                center = Offset(x = 12.dp.toPx(), y = 14.dp.toPx()),
+                            )
                         }
                         .size(24.dp)
                         .align(Alignment.TopEnd),

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -54,9 +55,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -537,7 +538,6 @@ private fun ImagePickerWithError(
     onClearImage: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val clearButtonShadowColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
     Column(modifier = modifier) {
         image?.let {
             Box(
@@ -559,13 +559,7 @@ private fun ImagePickerWithError(
                             translationX = 9.dp.toPx()
                             translationY = -9.dp.toPx()
                         }
-                        .drawBehind {
-                            drawCircle(
-                                color = clearButtonShadowColor,
-                                radius = 12.dp.toPx(),
-                                center = Offset(x = 12.dp.toPx(), y = 14.dp.toPx()),
-                            )
-                        }
+                        .shadow(elevation = 4.dp, shape = CircleShape)
                         .size(24.dp)
                         .align(Alignment.TopEnd),
                     colors = IconButtonDefaults


### PR DESCRIPTION
## Issue
none

## Overview (Required)
- I fixed the ClearButton in EditScreen because it looked different from Figma.
- In Figma, the shadows were blurred, but since it had little effect on the appearance and it seemed impossible to achieve this without a certain amount of ingenuity, a fill was used.


## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After | Figma
:--: | :--: | :--:
<img src="https://github.com/user-attachments/assets/ecf5b56d-6f51-462c-964f-cd1ff9eb6519" width="300" /> | <img src="https://github.com/user-attachments/assets/b5715cdb-3bc4-4c3a-a790-54f95ea0b791" width="300" />  | <img src="https://github.com/user-attachments/assets/d039d90e-06c6-48cf-aa89-84d9eead7acb" width="300" />


## Figma
https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=55588-34615&t=VpbDVe3CvbfpqvxU-4