### PR TITLE
[iOS] Update build phase settings

### DIFF
--- a/app-ios/App/App.xcodeproj/project.pbxproj
+++ b/app-ios/App/App.xcodeproj/project.pbxproj
@@ -180,6 +180,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		8C619CE72C405A97003E28A8 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- This PR disables "Based on dependency analysis" in the 'Run Script' build phase to resolve the following Xcode warning:

```
Run script build phase 'Run Script' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase.
```

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
