### PR TITLE
[iOS] Add text style to labels on timetable

### DIFF
--- a/app-ios/Sources/TimetableFeature/TimetableListView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableListView.swift
@@ -125,14 +125,14 @@ struct TimetableGridView: View {
                     
                     ForEach(rooms, id: \.self) { column in
                         let room = column.toRoom()
-                        Text(room.name.currentLangTitle).foregroundStyle(room.roomTheme.primaryColor)
+                        Text(room.name.currentLangTitle).foregroundStyle(room.roomTheme.primaryColor).textStyle(.titleMedium)
                             .frame(width: 192)
                     }
                 }
                 ForEach(store.timetableItems, id: \.self) { timeBlock in
                     GridRow {
                         VStack {
-                            Text(timeBlock.startsTimeString).foregroundStyle(AssetColors.Surface.onSurface.swiftUIColor)
+                            Text(timeBlock.startsTimeString).foregroundStyle(AssetColors.Surface.onSurface.swiftUIColor).textStyle(.labelMedium)
                             Spacer()
                             
                         }.frame(height: 153)
@@ -168,9 +168,9 @@ struct TimeGroupMiniList: View {
     var body: some View {
         HStack {
             VStack {
-                Text(contents.startsTimeString)
-                Text("|")
-                Text(contents.endsTimeString)
+                Text(contents.startsTimeString).textStyle(.titleMedium)
+                Text("|").font(.system(size: 8))
+                Text(contents.endsTimeString).textStyle(.titleMedium)
                 Spacer()
             }.padding(10).foregroundStyle(AssetColors.Surface.onSurface.swiftUIColor)
             VStack {


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- This PR adds text style to the labels on the timetable

## Links
- https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=54849-10371&t=fn3hGR5zfnLtiF5A-0

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/250c299c-4186-4060-8ed5-ab9110a05c7e" width="300" /> | <img src="https://github.com/user-attachments/assets/268109e9-f27d-4ef7-9a3e-360a57b970dd" width="300" />
<img src="https://github.com/user-attachments/assets/af59a28e-c41a-447b-a3bf-dffa127cc995" width="300" /> | <img src="https://github.com/user-attachments/assets/cf5bed42-f728-4425-939b-3108adde457a" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >