### PR TITLE
change rippleColor in TimetableItemCard

### DIFF
--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/TimetableItemCard.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/TimetableItemCard.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -23,6 +24,7 @@ import androidx.compose.material.icons.Icons.Outlined
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -48,6 +50,7 @@ import androidx.compose.ui.unit.sp
 import conference_app_2024.core.droidkaigiui.generated.resources.bookmarked
 import conference_app_2024.core.droidkaigiui.generated.resources.image
 import conference_app_2024.core.droidkaigiui.generated.resources.not_bookmarked
+import io.github.droidkaigi.confsched.designsystem.theme.LocalRoomTheme
 import io.github.droidkaigi.confsched.designsystem.theme.ProvideRoomTheme
 import io.github.droidkaigi.confsched.designsystem.theme.primaryFixed
 import io.github.droidkaigi.confsched.droidkaigiui.DroidKaigiUiRes
@@ -99,7 +102,11 @@ fun TimetableItemCard(
                     ),
                     shape = RoundedCornerShape(4.dp),
                 )
-                .clickable { onTimetableItemClick(timetableItem) },
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = rememberRipple(color = LocalRoomTheme.current.primaryColor),
+                    onClick = { onTimetableItemClick(timetableItem) },
+                ),
         ) {
             val contentPadding = 12.dp
             Column(


### PR DESCRIPTION
## Issue
- close #780 

## Overview
- Changed so that ripple is displayed according to the color of the room when the TimetableItemCard in the TimetableList is tapped.

<img width="473" alt="image" src="https://github.com/user-attachments/assets/0e65c7e7-d2c2-4fc4-b17a-e734857b1c9c">


## Links
- [Figma](https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=54901-56626&t=94gBozQ71SBBtf4Y-4)


## Movie
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/ea82a012-5267-4c5f-8d2b-83c52cd6ed5e" width="300" > | <video src="https://github.com/user-attachments/assets/822d5c62-0bc2-4a3e-8138-94291639fa72" width="300" >
