### PR TITLE
:wastebasket: [ProfileCardScreen] The process of displaying the snack bar was removed from areas where it was not necessary.

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
@@ -19,8 +19,6 @@ import io.github.droidkaigi.confsched.droidkaigiui.providePresenterDefaults
 import io.github.droidkaigi.confsched.model.ProfileCard
 import io.github.droidkaigi.confsched.model.ProfileCardRepository
 import io.github.droidkaigi.confsched.model.localProfileCardRepository
-import io.github.droidkaigi.confsched.profilecard.ProfileCardUiType.Card
-import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 
 internal sealed interface ProfileCardScreenEvent
@@ -119,30 +117,18 @@ internal fun profileCardScreenPresenter(
     EventEffect(events) { event ->
         when (event) {
             is CardScreenEvent.Edit -> {
-                isLoading = true
-                launch {
-                    userMessageStateHolder.showMessage("Edit")
-                }
                 uiType = ProfileCardUiType.Edit
-                isLoading = false
             }
 
             is EditScreenEvent.Create -> {
                 isLoading = true
-                launch {
-                    userMessageStateHolder.showMessage("Create Profile Card")
-                }
                 repository.save(event.profileCard)
-                uiType = Card
+                uiType = ProfileCardUiType.Card
                 isLoading = false
             }
 
             is EditScreenEvent.SelectImage -> {
-                isLoading = true
-                launch {
-                    userMessageStateHolder.showMessage("Select Image")
-                }
-                isLoading = false
+                // NOOP Put in some processing if necessary.
             }
 
             is EditScreenEvent.OnChangeNickname -> {


### PR DESCRIPTION
## Issue
- close #766

## Overview (Required)
- The snack bar is no longer needed to be displayed during Edit/Create/SelectImage events, so the processing has been removed.
- The process that changes the value of isLoading has also been removed for the parts that no longer contain a suspend process.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/aedc45f5-1473-4811-8f3a-05593f3dae65" width="300" > | <video src="https://github.com/user-attachments/assets/d8c835b8-767f-4896-9e38-e8ddfed815ab" width="300" >