### PR TITLE
Invert the system bar appearance on the ProfileCardScreen, matching its light background

### DIFF
--- a/feature/profilecard/src/androidMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/InvertSystemBarAppearance.android.kt
+++ b/feature/profilecard/src/androidMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/InvertSystemBarAppearance.android.kt
@@ -1,0 +1,24 @@
+package io.github.droidkaigi.confsched.profilecard.component
+
+import android.app.Activity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.view.WindowCompat
+
+@Composable
+internal actual fun InvertSystemBarAppearance() {
+    val activity = LocalContext.current as Activity
+    val insetsController = WindowCompat.getInsetsController(activity.window, activity.window.decorView)
+
+    val originalIsAppearanceLight = remember { insetsController.isAppearanceLightStatusBars }
+
+    DisposableEffect(Unit) {
+        insetsController.isAppearanceLightStatusBars = !originalIsAppearanceLight
+
+        onDispose {
+            insetsController.isAppearanceLightStatusBars = originalIsAppearanceLight
+        }
+    }
+}

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -114,6 +114,7 @@ import io.github.droidkaigi.confsched.model.ProfileCard
 import io.github.droidkaigi.confsched.model.ProfileCardType
 import io.github.droidkaigi.confsched.profilecard.component.CapturableCard
 import io.github.droidkaigi.confsched.profilecard.component.FlipCard
+import io.github.droidkaigi.confsched.profilecard.component.InvertSystemBarAppearance
 import io.github.droidkaigi.confsched.profilecard.component.PhotoPickerButton
 import io.ktor.util.decodeBase64Bytes
 import kotlinx.coroutines.launch
@@ -711,6 +712,10 @@ internal fun CardScreen(
     val coroutineScope = rememberCoroutineScope()
     val graphicsLayer = rememberGraphicsLayer()
     var isShareReady by remember { mutableStateOf(false) }
+
+    // The background of this screen is light, contrasting any other screen in the app.
+    // Invert the content color of system bars to accommodate this unique property.
+    InvertSystemBarAppearance()
 
     ProvideProfileCardTheme(uiState.cardType.toString()) {
         Box {

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/InvertSystemBarAppearance.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/InvertSystemBarAppearance.kt
@@ -1,0 +1,6 @@
+package io.github.droidkaigi.confsched.profilecard.component
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal expect fun InvertSystemBarAppearance()

--- a/feature/profilecard/src/iosMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/InvertSystemBarAppearance.ios.kt
+++ b/feature/profilecard/src/iosMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/InvertSystemBarAppearance.ios.kt
@@ -1,0 +1,29 @@
+package io.github.droidkaigi.confsched.profilecard.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import platform.UIKit.UIApplication
+import platform.UIKit.UIUserInterfaceStyle.UIUserInterfaceStyleDark
+import platform.UIKit.UIUserInterfaceStyle.UIUserInterfaceStyleLight
+import platform.UIKit.UIWindow
+import platform.UIKit.UIWindowScene
+
+@Composable
+internal actual fun InvertSystemBarAppearance() {
+    val application = UIApplication.sharedApplication
+    val scene = application.connectedScenes.firstOrNull() as? UIWindowScene
+    val window = scene?.windows?.firstOrNull() as? UIWindow ?: return
+
+    val originalUserInterfaceStyle = remember { window.overrideUserInterfaceStyle }
+
+    DisposableEffect(Unit) {
+        window.overrideUserInterfaceStyle = if (originalUserInterfaceStyle == UIUserInterfaceStyleDark) {
+            UIUserInterfaceStyleLight
+        } else {
+            UIUserInterfaceStyleDark
+        }
+
+        onDispose { window.overrideUserInterfaceStyle = originalUserInterfaceStyle }
+    }
+}


### PR DESCRIPTION
## Issue
- close #762 

## Overview (Required)
- Introduce a side effect, `InvertSystemBarAppearance`, which changes the appearance of the system bars
- Apply this side effect to the `CardScreen` composable, which is the only screen with a light background

> [!WARNING]  
> ~Because of #768, I'm unable to verify the iOS implementation of this. It's based on the following code snippet that I am using in another SwiftUI project of mine to toggle between light and dark theme. I do not know if any other colors change unexpectedly because of this. I may need help from somebody who can compile iOS successfully before we can merge this. 🙇‍♂️~

```swift
let state = true // or false
(UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.first!.overrideUserInterfaceStyle = state ? .dark : .light
```



## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/4fde8ced-1aaa-4f06-b202-bc146ff01977" width="300" > | <video src="https://github.com/user-attachments/assets/4de27939-1bec-4ba8-a782-9be4c55942e4" width="300" >







