### PR TITLE
In TimetableItemDetailScreen, variable height of statusBar when scrolling

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailTopAppBar.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailTopAppBar.kt
@@ -1,5 +1,11 @@
 package io.github.droidkaigi.confsched.sessions.component
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.GTranslate
@@ -38,8 +44,17 @@ fun TimetableItemDetailTopAppBar(
     scrollBehavior: TopAppBarScrollBehavior,
     modifier: Modifier = Modifier,
 ) {
+    // Allow content to be displayed at the statusBar when scrolling
+    val statusBarHeight = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+    val variableTopPaddingHeight by remember(scrollBehavior.state.collapsedFraction) {
+        mutableStateOf(statusBarHeight * (1f - scrollBehavior.state.collapsedFraction))
+    }
+
     TopAppBar(
-        modifier = modifier,
+        modifier = modifier
+            .background(LocalRoomTheme.current.dimColor)
+            .padding(top = variableTopPaddingHeight)
+            .consumeWindowInsets(WindowInsets.statusBars),
         colors = TopAppBarDefaults.topAppBarColors().copy(
             containerColor = LocalRoomTheme.current.dimColor,
             scrolledContainerColor = LocalRoomTheme.current.dimColor,


### PR DESCRIPTION
## Issue
none

## Overview
I thought it would be better if I could hide the statusBar when scrolling with TimetableItemDetailTopScreen, so I achieved this by using `consumeWindowInsets` etc. to make the display of the height of the statusbar variable

## Links
- [Android developers - Inset consumption](https://developer.android.com/develop/ui/compose/layouts/insets#inset-consumption)


## Movie
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/36bf2116-e907-44d7-97f6-b6d4d436bedd" width="300" > | <video src="https://github.com/user-attachments/assets/c3cff19a-6be8-44b6-87b5-529b3017a747" width="300" >
