### PR TITLE
Chore/599: apply correct padding to timetable screen

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
@@ -85,7 +85,7 @@ fun TimetableList(
     LazyColumn(
         modifier = modifier.testTag(TimetableListTestTag),
         state = scrollState,
-        verticalArrangement = Arrangement.spacedBy(16.dp),
+        verticalArrangement = Arrangement.spacedBy(32.dp),
         contentPadding = PaddingValues(
             top = contentPadding.calculateTopPadding(),
             bottom = contentPadding.calculateBottomPadding(),


### PR DESCRIPTION
## Issue
- close #599 

## Overview (Required)
- Fixed paddings in timetable screen from 16dp to 32dp.

## Links
- https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=54876-39860&t=HSvuYQHvkIqBfsAc-4

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/54c5fbb3-a4e6-4873-9853-5cfa0f499a7a" width="300" /> | <img src="https://github.com/user-attachments/assets/605b1690-ec8d-48d9-bb92-27c72f87f672" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
