### PR TITLE
changed font color for EventMapItem content title and button text

### DIFF
--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/component/EventMapItem.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/component/EventMapItem.kt
@@ -27,6 +27,7 @@ import conference_app_2024.feature.eventmap.generated.resources.read_more
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.designsystem.theme.LocalRoomTheme
 import io.github.droidkaigi.confsched.designsystem.theme.ProvideRoomTheme
+import io.github.droidkaigi.confsched.designsystem.theme.primaryFixed
 import io.github.droidkaigi.confsched.droidkaigiui.toResDrawable
 import io.github.droidkaigi.confsched.eventmap.EventMapRes
 import io.github.droidkaigi.confsched.model.EventMapEvent
@@ -62,7 +63,7 @@ fun EventMapItem(
                 Text(
                     text = eventMapEvent.name.currentLangTitle,
                     style = MaterialTheme.typography.titleMedium,
-                    color = LocalRoomTheme.current.primaryColor,
+                    color = MaterialTheme.colorScheme.primaryFixed,
                 )
             }
             Spacer(Modifier.height(8.dp))
@@ -88,7 +89,7 @@ fun EventMapItem(
                     Text(
                         text = stringResource(EventMapRes.string.read_more),
                         style = MaterialTheme.typography.labelLarge,
-                        color = LocalRoomTheme.current.primaryColor,
+                        color = MaterialTheme.colorScheme.primaryFixed,
                     )
                 }
             }


### PR DESCRIPTION
## Issue

- close https://github.com/DroidKaigi/conference-app-2024/issues/784

## Overview (Required)

- The font color of the content title and button text in the EventMapItem has been changed.
- Changed from `LocalRoomTheme.current.primaryColor` to `MaterialTheme.colorScheme.primaryFixed`.

## Links

- [Figma](https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=55725-8925&t=mFxMogCMCYJ1nVM0-0)

## Screenshot (Optional if screenshot test is present or unrelated to UI)

Before | After | Figma
:--: | :--: | :--: 
<img src="https://github.com/user-attachments/assets/ae5c4440-870b-4c16-b367-acc8c91a8e59" width="300" /> | <img src="https://github.com/user-attachments/assets/7080718d-73df-41ca-bc02-f5503278d76f" width="300" /> | <img src="https://github.com/user-attachments/assets/b3beed74-8566-4b79-bf2c-3f0da062f371" width="300" />
