### PR TITLE
fix failed test

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -53,6 +53,7 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(projects.core.model)
+                implementation(projects.core.testing)
                 implementation(libs.kotlinTest)
                 implementation(libs.okIo)
                 implementation(libs.ktorKotlinxSerialization)

--- a/core/data/src/commonTest/kotlin/io/github/droidkaigi/confsched/data/profilecard/ProfileCardJsonTest.kt
+++ b/core/data/src/commonTest/kotlin/io/github/droidkaigi/confsched/data/profilecard/ProfileCardJsonTest.kt
@@ -2,12 +2,11 @@ package io.github.droidkaigi.confsched.data.profilecard
 
 import io.github.droidkaigi.confsched.model.ProfileCard
 import io.github.droidkaigi.confsched.model.ProfileCardType
+import io.github.droidkaigi.confsched.testing.utils.readResourceFile
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import okio.FileSystem
 import okio.Path.Companion.toPath
-import okio.SYSTEM
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
@@ -77,10 +76,9 @@ class ProfileCardJsonTest {
 
     @Test
     fun `throw exception when both theme and card_type are not exist`() {
-        val jsonString =
-            FileSystem.SYSTEM.read("src/commonTest/resources/profilecard/invalid.json".toPath()) {
-                readUtf8()
-            }
+        val jsonString = readResourceFile("profilecard/invalid.json".toPath()) {
+            readUtf8()
+        }
 
         assertFails {
             Json.decodeFromString<ProfileCardJson>(jsonString).toModel()
@@ -88,7 +86,7 @@ class ProfileCardJsonTest {
     }
 
     private fun readJsonString(version: Int): String {
-        return FileSystem.SYSTEM.read("src/commonTest/resources/profilecard/v$version.json".toPath()) {
+        return readResourceFile("profilecard/v$version.json".toPath()) {
             readUtf8()
         }
     }
@@ -102,10 +100,10 @@ class ProfileCardJsonTest {
     }
 
     private fun assertSerializedJson(actual: String) {
-        val expected =
-            FileSystem.SYSTEM.read("src/commonTest/resources/profilecard/v2.json".toPath()) {
-                readUtf8()
-            }
+        val expected = readResourceFile("profilecard/v2.json".toPath()) {
+            readUtf8()
+        }
+
 
         assertEquals(expected.trim(), actual.trim())
     }

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -1,40 +1,47 @@
 plugins {
-    id("droidkaigi.primitive.android")
-    id("droidkaigi.primitive.android.kotlin")
-    id("droidkaigi.primitive.android.compose")
-    id("droidkaigi.primitive.android.hilt")
+    id("droidkaigi.primitive.kmp")
+    id("droidkaigi.primitive.kmp.android")
+    id("droidkaigi.primitive.kmp.android.hilt")
+    id("droidkaigi.primitive.kmp.compose")
     id("droidkaigi.primitive.detekt")
 }
 
 android.namespace = "io.github.droidkaigi.confsched.core.testing"
 
-dependencies {
-    implementation(projects.core.model)
-    implementation(projects.core.designsystem)
-    implementation(projects.core.data)
-    implementation(projects.core.droidkaigiui)
-    implementation(projects.feature.main)
-    implementation(projects.feature.sessions)
-    implementation(projects.feature.profilecard)
-    implementation(projects.feature.about)
-    implementation(projects.feature.staff)
-    implementation(projects.feature.sponsors)
-    implementation(projects.feature.settings)
-    implementation(projects.feature.favorites)
-    implementation(projects.feature.eventmap)
-    implementation(projects.feature.contributors)
-    implementation(libs.daggerHiltAndroidTesting)
-    implementation(libs.roborazzi)
-    implementation(libs.kermit)
-    implementation(libs.coilTest)
-    api(projects.core.testingManifest)
-    api(libs.composeNavigation)
-    api(libs.roborazziRule)
-    api(libs.roborazziCompose)
-    api(libs.robolectric)
-    api(libs.composeUiTestJunit4)
-    implementation(libs.composeMaterialWindowSize)
-    implementation(libs.composablePreviewScanner)
-    implementation(libs.composablePreviewScannerJvm)
-    implementation(libs.roborazziPreviewScannerSupport)
+kotlin {
+    sourceSets {
+        androidMain {
+            dependencies {
+                implementation(projects.core.model)
+                implementation(projects.core.designsystem)
+                implementation(projects.core.data)
+                implementation(projects.core.droidkaigiui)
+                implementation(projects.feature.main)
+                implementation(projects.feature.sessions)
+                implementation(projects.feature.profilecard)
+                implementation(projects.feature.about)
+                implementation(projects.feature.staff)
+                implementation(projects.feature.sponsors)
+                implementation(projects.feature.settings)
+                implementation(projects.feature.favorites)
+                implementation(projects.feature.eventmap)
+                implementation(projects.feature.contributors)
+                implementation(libs.daggerHiltAndroidTesting)
+                implementation(libs.roborazzi)
+                implementation(libs.kermit)
+                implementation(libs.coilTest)
+                api(projects.core.testingManifest)
+                api(libs.composeNavigation)
+                api(libs.roborazziRule)
+                api(libs.roborazziCompose)
+                api(libs.robolectric)
+                api(libs.composeUiTestJunit4)
+                implementation(libs.composeMaterialWindowSize)
+                implementation(libs.composablePreviewScanner)
+                implementation(libs.composablePreviewScannerJvm)
+                implementation(libs.roborazziPreviewScannerSupport)
+            }
+
+        }
+    }
 }

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("droidkaigi.primitive.kmp.android")
     id("droidkaigi.primitive.kmp.android.hilt")
     id("droidkaigi.primitive.kmp.compose")
+    id("droidkaigi.primitive.kmp.ios")
     id("droidkaigi.primitive.detekt")
 }
 
@@ -41,7 +42,19 @@ kotlin {
                 implementation(libs.composablePreviewScannerJvm)
                 implementation(libs.roborazziPreviewScannerSupport)
             }
-
         }
+
+        commonMain  {
+            dependencies {
+                implementation(libs.okIo)
+            }
+        }
+
+        iosMain  {
+            dependencies {
+                implementation(libs.okIo)
+            }
+        }
+
     }
 }

--- a/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/utils/ReadResourceFile.kt
+++ b/core/testing/src/commonMain/kotlin/io/github/droidkaigi/confsched/testing/utils/ReadResourceFile.kt
@@ -1,0 +1,3 @@
+package io.github.droidkaigi.confsched.testing.utils
+
+expect inline fun <T> readResourceFile(filePath: okio.Path, block: okio.BufferedSource.() -> T): T

--- a/core/testing/src/iosMain/kotlin/io/github/droidkaigi/confsched/testing/utils/ReadResourceFile.ios.kt
+++ b/core/testing/src/iosMain/kotlin/io/github/droidkaigi/confsched/testing/utils/ReadResourceFile.ios.kt
@@ -1,0 +1,16 @@
+package io.github.droidkaigi.confsched.testing.utils
+
+import okio.BufferedSource
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+import platform.Foundation.NSBundle
+
+actual inline fun <T> readResourceFile(filePath: Path, block: BufferedSource.() -> T): T {
+    return FileSystem.SYSTEM.read(
+        NSBundle.mainBundle.bundlePath.toPath().parent!!.parent!!.parent!!.parent!!
+            .div("src").div("commonTest").div("resources").div(filePath)
+    ) {
+        block()
+    }
+}

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/utils/ReadResourceFile.android.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/utils/ReadResourceFile.android.kt
@@ -1,0 +1,12 @@
+package io.github.droidkaigi.confsched.testing.utils
+
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+actual inline fun <T> readResourceFile(filePath: okio.Path, block: okio.BufferedSource.() -> T): T {
+    return FileSystem.SYSTEM.read(
+        "src".toPath().div("commonTest").div("resources").div(filePath)
+    ) {
+        block()
+    }
+}


### PR DESCRIPTION
## Issue
- close #776 

## Overview (Required)
- In the test for reading JSON files, the test was failing because the file could not be found when the target was iOS. According to [this slide](https://speakerdeck.com/ryunen344/okioniai-woip-mete?slide=53), since the working directory differs by platform, hardcoding the path can prevent resource retrieval on one of the platforms. Therefore, we implemented a utility function in core:testing for reading files specific to each platform and abstracted the file reading method on the consumer side.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
