### PR TITLE
Only build the XCFramework for the current configuration from Xcode

### DIFF
--- a/build_xcframework_with_xcode_environment_variable.sh
+++ b/build_xcframework_with_xcode_environment_variable.sh
@@ -6,8 +6,9 @@ if [ -z "$SDK_NAME" ] || [ -z "$ARCHS" ]; then
     exit 1
 fi
 
-# Initialize the target architecture
+# Initialize the target architecture and configuration (debug vs. release)
 target_arch=""
+target_configuration=""
 
 # Determine the target architecture based on SDK_NAME and ARCHS
 if [[ "$SDK_NAME" == *"simulator"* ]]; then
@@ -20,6 +21,13 @@ elif [[ "$SDK_NAME" == *"iphoneos"* ]] && [[ "$ARCHS" == *"arm64"* ]]; then
     target_arch="arm64"
 fi
 
+# Assign the correct framework to build based on Xcode's configuration (or build all on unknown values)
+if [[ "$CONFIGURATION" == *"Debug"* ]]; then
+  target_configuration="Debug"
+elif [[ "$CONFIGURATION" == *"Release"* ]]; then
+  target_configuration="Release"
+fi
+
 # Check if a valid target architecture was determined
 if [ -z "$target_arch" ]; then
     echo "Error: Unable to determine target architecture from SDK_NAME=$SDK_NAME and ARCHS=$ARCHS"
@@ -28,6 +36,6 @@ fi
 
 # Execute Gradle command with the determined architecture
 echo "Building for architecture: $target_arch"
-./gradlew assembleSharedXCFramework --no-configuration-cache -Papp.ios.shared.arch=$target_arch
+./gradlew assembleShared${target_configuration}XCFramework --no-configuration-cache -Papp.ios.shared.arch=$target_arch
 
 echo "Build completed for $target_arch"


### PR DESCRIPTION
This prevents release frameworks from being built during debug, and vice versa.

## Issue
- relates to #789

## Overview (Required)
- Use the Xcode-provided environment variable `$CONFIGURATION` to determine whether to assemble the debug or release variant of the XCFramework
