### PR TITLE
【Fix】fix dropdown background #578

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/DropdownFilterChip.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/DropdownFilterChip.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched.sessions.component
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
@@ -58,6 +59,7 @@ fun <T> DropdownFilterChip(
         DropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
+            modifier = Modifier.background(MaterialTheme.colorScheme.surfaceContainer),
         ) {
             uiState.selectableItems.forEach { item ->
                 DropdownMenuItem(


### PR DESCRIPTION
## Issue
- close #578

## Overview (Required)
- Dropdown menu background color looked different from the expected color in Figma.

At the time the issue was created, there was also a dropdown menu in the TimetableItemDetailScreen. However, it seems that the dropdown menu is no longer present on that screen. So, I fixex the one in the SearchScreen.

## Links
- [Figma](https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=54965-73535&t=wOtXEZH07pFix45M-4)

## Screenshot (Optional if screenshot test is present or unrelated to UI)

**SearchScreen**

Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/f23d4055-5bf6-4045-b8d3-1a97e1f05036" width="300" /> | <img src="https://github.com/user-attachments/assets/8d7eb100-3169-4dc3-8336-7c7f9216bc88" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
