### PR TITLE
In EventMap, add animtion in EventMapChip icon

### DIFF
--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/component/EventMapTab.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/component/EventMapTab.kt
@@ -1,6 +1,11 @@
 package io.github.droidkaigi.confsched.eventmap.component
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.draggable
@@ -59,7 +64,7 @@ fun EventMapTab(
             FloorLevel.entries.reversed().forEachIndexed { index, floorLevel ->
                 EventMapChip(
                     modifier = Modifier.testTag(EventMapTabTestTagPrefix.plus(floorLevel.floorName)),
-                    selected = selectedTabIndex == index,
+                    isSelected = selectedTabIndex == index,
                     text = floorLevel.floorName,
                     onClick = { selectedTabIndex = index },
                 )
@@ -88,18 +93,22 @@ fun EventMapTab(
 
 @Composable
 private fun EventMapChip(
-    selected: Boolean,
+    isSelected: Boolean,
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     FilterChip(
         modifier = modifier,
-        selected = selected,
+        selected = isSelected,
         onClick = onClick,
         label = { Text(text) },
         leadingIcon = {
-            if (selected) {
+            AnimatedVisibility(
+                visible = isSelected,
+                enter = fadeIn() + expandHorizontally(),
+                exit = fadeOut() + shrinkHorizontally(),
+            ) {
                 Icon(
                     imageVector = Icons.Filled.Check,
                     contentDescription = null,


### PR DESCRIPTION
## Issue
none

## Overview
- I thought the LanguageSwitcher animation for TimetableItemDetailScreen was great, so I thought we should have a similar animation for EventMapTab.
- This is not directly related to this PR, but I changed it because I thought `isSelected` was better than `selected` as it was easier to see that it was Boolean.


## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/a5cd3f24-bbfa-4670-b535-cdef619b5fa9" width="300" > | <video src="https://github.com/user-attachments/assets/85cefd75-97aa-4501-8dd2-6cb74e08451c" width="300" >



## Ref
LanguageSwitcher

https://github.com/user-attachments/assets/7a9db6c3-5125-499a-8833-66203384ba45


