### PR TITLE
Update the touch targets for the header icons on TimetableScreen

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
@@ -3,7 +3,6 @@ package io.github.droidkaigi.confsched.sessions
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -18,6 +17,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -162,26 +162,29 @@ private fun TimetableScreen(
                             fontWeight = FontWeight.W400,
                             modifier = Modifier.weight(1F),
                         )
-                        Icon(
-                            imageVector = Icons.Default.Search,
-                            contentDescription = null,
-                            modifier = Modifier.padding(8.dp).clickable {
-                                onSearchClick()
-                            },
-                        )
+                        IconButton(
+                            onClick = onSearchClick,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Search,
+                                contentDescription = null,
+                            )
+                        }
                         Crossfade(targetState = uiState.timetableUiType) { timetableUiType ->
                             val iconRes = if (timetableUiType == Grid) {
                                 SessionsRes.drawable.ic_view_timeline
                             } else {
                                 SessionsRes.drawable.ic_grid_view
                             }
-                            Image(
-                                painter = painterResource(iconRes),
-                                contentDescription = null,
-                                modifier = Modifier.padding(8.dp).clickable {
-                                    onTimetableUiChangeClick()
-                                }.testTag(TimetableUiTypeChangeButtonTestTag),
-                            )
+                            IconButton(
+                                onClick = onTimetableUiChangeClick,
+                                modifier = Modifier.testTag(TimetableUiTypeChangeButtonTestTag),
+                            ) {
+                                Image(
+                                    painter = painterResource(iconRes),
+                                    contentDescription = null,
+                                )
+                            }
                         }
                     }
                 },


### PR DESCRIPTION
## Issue
- close #804 

## Overview (Required)
- Update the touch targets for the header icons on TimetableScreen to 48x48dp, as specified in the Figma design
- Update the ripple effect for the icons to be circular in shape

## Links
- [DroidKaigi 2024 App UI – Figma](https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=54849-12900&t=B5y8N0yYgNnqssOR-0)

## Screenshot (Optional if screenshot test is present or unrelated to UI)

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://private-user-images.githubusercontent.com/60963155/361245449-c5269137-daa5-493d-9e88-bc40d4d5ef10.mov?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjQ3MDY0MzcsIm5iZiI6MTcyNDcwNjEzNywicGF0aCI6Ii82MDk2MzE1NS8zNjEyNDU0NDktYzUyNjkxMzctZGFhNS00OTNkLTllODgtYmM0MGQ0ZDVlZjEwLm1vdj9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA4MjYlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwODI2VDIxMDIxN1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWYzNmExYTg1ODUzMjkxNzMyNmI4YzM1YjFhOGI2YjVkOGYzM2M5NDc3OGE5NDFhNzE1MTY2YmRjZmY3M2RlNTgmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.igBwaxcwaRCFeYpVvyRVSLxHqpX5Giqp41OLaiAZLq8" width="300" > | <video src="https://github.com/user-attachments/assets/d64feaeb-088b-4f39-a64c-2d0d7c9ac60e" width="300" >