### PR TITLE
:sparkles: [Compose Multiplatform] Added the ability to move from session details to the list of favorites.

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched/KaigiApp.kt
@@ -56,6 +56,7 @@ import io.github.droidkaigi.confsched.eventmap.eventMapScreenRoute
 import io.github.droidkaigi.confsched.eventmap.eventMapScreens
 import io.github.droidkaigi.confsched.eventmap.navigateEventMapScreen
 import io.github.droidkaigi.confsched.favorites.favoritesScreenRoute
+import io.github.droidkaigi.confsched.favorites.favoritesScreenWithNavigationIconRoute
 import io.github.droidkaigi.confsched.favorites.favoritesScreens
 import io.github.droidkaigi.confsched.favorites.navigateFavoritesScreen
 import io.github.droidkaigi.confsched.main.MainNestedGraphStateHolder
@@ -152,7 +153,11 @@ private fun KaigiNavHost(
                     onLinkClick = externalNavController::navigate,
                     onCalendarRegistrationClick = externalNavController::navigateToCalendarRegistration,
                     onShareClick = externalNavController::onShareClick,
-                    onFavoriteListClick = { navController.navigate(favoritesScreenRoute) },
+                    onFavoriteListClick = {
+                        navController.navigate(
+                            favoritesScreenWithNavigationIconRoute
+                        )
+                    },
                 )
 
                 contributorsScreens(
@@ -180,6 +185,7 @@ private fun KaigiNavHost(
                 )
 
                 favoritesScreens(
+                    onNavigationIconClick = navController::popBackStack,
                     onTimetableItemClick = navController::navigateToTimetableItemDetailScreen,
                     contentPadding = PaddingValues(),
                 )
@@ -209,6 +215,7 @@ private fun NavGraphBuilder.mainScreen(
                 onEventMapItemClick = externalNavController::navigate,
             )
             favoritesScreens(
+                onNavigationIconClick = navController::popBackStack,
                 onTimetableItemClick = navController::navigateToTimetableItemDetailScreen,
                 contentPadding = contentPadding,
             )

--- a/app-android/src/main/java/io/github/droidkaigi/confsched/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched/KaigiApp.kt
@@ -155,7 +155,7 @@ private fun KaigiNavHost(
                     onShareClick = externalNavController::onShareClick,
                     onFavoriteListClick = {
                         navController.navigate(
-                            favoritesScreenWithNavigationIconRoute
+                            favoritesScreenWithNavigationIconRoute,
                         )
                     },
                 )

--- a/app-ios-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/shared/IosComposeKaigiApp.kt
+++ b/app-ios-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/shared/IosComposeKaigiApp.kt
@@ -58,6 +58,7 @@ import io.github.droidkaigi.confsched.staff.staffScreens
 import io.github.droidkaigi.confsched.droidkaigiui.NavHostWithSharedAxisX
 import io.github.droidkaigi.confsched.eventmap.eventMapScreenRoute
 import io.github.droidkaigi.confsched.favorites.favoritesScreenRoute
+import io.github.droidkaigi.confsched.favorites.favoritesScreenWithNavigationIconRoute
 import io.github.droidkaigi.confsched.model.TimetableItem
 import io.github.droidkaigi.confsched.profilecard.profileCardScreenRoute
 import platform.Foundation.NSURL
@@ -116,7 +117,11 @@ private fun KaigiNavHost(
             onLinkClick = externalNavController::navigate,
             onCalendarRegistrationClick = {},//externalNavController::navigateToCalendarRegistration,
             onShareClick = externalNavController::onShareClick,
-            onFavoriteListClick = {} // { navController.navigate(favoritesScreenRoute) }
+            onFavoriteListClick = {
+                navController.navigate(
+                    favoritesScreenWithNavigationIconRoute
+                )
+            },
         )
 
         contributorsScreens(
@@ -144,6 +149,7 @@ private fun KaigiNavHost(
         )
 
         favoritesScreens(
+            onNavigationIconClick = navController::popBackStack,
             onTimetableItemClick = navController::navigateToTimetableItemDetailScreen,
             contentPadding = PaddingValues(),
         )
@@ -170,6 +176,7 @@ private fun NavGraphBuilder.mainScreen(
                 onEventMapItemClick = externalNavController::navigate,
             )
             favoritesScreens(
+                onNavigationIconClick = navController::popBackStack,
                 onTimetableItemClick = navController::navigateToTimetableItemDetailScreen,
                 contentPadding = contentPadding,
             )

--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreen.kt
@@ -89,9 +89,9 @@ data class FavoritesScreenUiState(
 
 @Composable
 fun FavoritesScreen(
-    onNavigationIconClick: (() -> Unit)? = null,
     onTimetableItemClick: (TimetableItem) -> Unit,
     modifier: Modifier = Modifier,
+    onNavigationIconClick: (() -> Unit)? = null,
     contentPadding: PaddingValues = PaddingValues(),
     eventFlow: EventFlow<FavoritesScreenEvent> = rememberEventFlow(),
     uiState: FavoritesScreenUiState = favoritesScreenPresenter(events = eventFlow),

--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreen.kt
@@ -6,7 +6,11 @@ import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -45,14 +49,23 @@ import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 const val favoritesScreenRoute = "favorites"
+const val favoritesScreenWithNavigationIconRoute = "favoriteswithicon"
 const val FavoritesScreenTestTag = "FavoritesScreenTestTag"
 
 fun NavGraphBuilder.favoritesScreens(
+    onNavigationIconClick: () -> Unit,
     onTimetableItemClick: (TimetableItem) -> Unit,
     contentPadding: PaddingValues,
 ) {
     composable(favoritesScreenRoute) {
         FavoritesScreen(
+            onTimetableItemClick = onTimetableItemClick,
+            contentPadding = contentPadding,
+        )
+    }
+    composable(favoritesScreenWithNavigationIconRoute) {
+        FavoritesScreen(
+            onNavigationIconClick = onNavigationIconClick,
             onTimetableItemClick = onTimetableItemClick,
             contentPadding = contentPadding,
         )
@@ -76,6 +89,7 @@ data class FavoritesScreenUiState(
 
 @Composable
 fun FavoritesScreen(
+    onNavigationIconClick: (() -> Unit)? = null,
     onTimetableItemClick: (TimetableItem) -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
@@ -92,6 +106,7 @@ fun FavoritesScreen(
         uiState = uiState,
         snackbarHostState = snackbarHostState,
         onTimetableItemClick = onTimetableItemClick,
+        onNavigationIconClick = onNavigationIconClick,
         onAllFilterChipClick = {
             eventFlow.tryEmit(FavoritesScreenEvent.AllFilter)
         },
@@ -115,6 +130,7 @@ private fun FavoritesScreen(
     uiState: FavoritesScreenUiState,
     snackbarHostState: SnackbarHostState,
     onTimetableItemClick: (TimetableItem) -> Unit,
+    onNavigationIconClick: (() -> Unit)?,
     onAllFilterChipClick: () -> Unit,
     onDay1FilterChipClick: () -> Unit,
     onDay2FilterChipClick: () -> Unit,
@@ -142,6 +158,16 @@ private fun FavoritesScreen(
         topBar = {
             AnimatedTextTopAppBar(
                 title = stringResource(FavoritesRes.string.favorite),
+                navigationIcon = {
+                    if (onNavigationIconClick != null) {
+                        IconButton(onClick = { onNavigationIconClick() }) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                                contentDescription = "Back",
+                            )
+                        }
+                    }
+                },
                 scrollBehavior = scrollBehavior,
                 colors = TopAppBarDefaults.topAppBarColors().copy(
                     scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
@@ -189,6 +215,7 @@ fun FavoritesScreenPreview() {
                 ),
                 snackbarHostState = SnackbarHostState(),
                 onTimetableItemClick = {},
+                onNavigationIconClick = null,
                 onAllFilterChipClick = {},
                 onDay1FilterChipClick = {},
                 onDay2FilterChipClick = {},


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- A back button is now displayed on the top bar of the favorites list when transitioning from the session details screen to the favorites list for both Android and iOS.
- Without the above implementation, you will not be able to go back when you transition from session details to the favorites list on iOS and will not be able to do anything unless you restart the app.

## Movie (Optional)
Before iOS | After iOS
:--: | :--:
<video src="https://github.com/user-attachments/assets/8fd39915-41a8-46f8-b9bf-5388eb4cbda7" width="300" > | <video src="https://github.com/user-attachments/assets/9d8c48af-7b24-4d81-8afa-d0ca29e52662" width="300" >

Before Android | After Android
:--: | :--:
<video src="https://github.com/user-attachments/assets/3a990843-acf9-4320-8f29-ea19c5743610" width="300" > | <video src="https://github.com/user-attachments/assets/a074e9a8-8145-4e14-a79b-cfc60752c658" width="300" >