### PR TITLE
:sparkles: [Compose Multiplatform] The settings screen can now be opened.

### DIFF
--- a/app-ios-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/shared/IosComposeKaigiApp.kt
+++ b/app-ios-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/shared/IosComposeKaigiApp.kt
@@ -60,6 +60,7 @@ import io.github.droidkaigi.confsched.eventmap.eventMapScreenRoute
 import io.github.droidkaigi.confsched.favorites.favoritesScreenRoute
 import io.github.droidkaigi.confsched.model.TimetableItem
 import io.github.droidkaigi.confsched.profilecard.profileCardScreenRoute
+import io.github.droidkaigi.confsched.settings.settingsScreenRoute
 import platform.Foundation.NSURL
 import platform.UIKit.UIApplication
 import platform.UIKit.UIViewController
@@ -205,7 +206,7 @@ private fun NavGraphBuilder.mainScreen(
                             )
                         }
 
-                        AboutItem.Settings -> {} //navController.navigate(settingsScreenRoute)
+                        AboutItem.Settings -> navController.navigate(settingsScreenRoute)
 
                         AboutItem.Staff -> navController.navigate(staffScreenRoute)
                         AboutItem.X -> externalNavController.navigate(

--- a/core/data/src/iosMain/kotlin/io/github/droidkaigi/confsched/data/DataModule.kt
+++ b/core/data/src/iosMain/kotlin/io/github/droidkaigi/confsched/data/DataModule.kt
@@ -19,6 +19,9 @@ import io.github.droidkaigi.confsched.data.sessions.DefaultSessionsApiClient
 import io.github.droidkaigi.confsched.data.sessions.DefaultSessionsRepository
 import io.github.droidkaigi.confsched.data.sessions.SessionCacheDataStore
 import io.github.droidkaigi.confsched.data.sessions.SessionsApiClient
+import io.github.droidkaigi.confsched.data.settings.DefaultSettingsDataStore
+import io.github.droidkaigi.confsched.data.settings.DefaultSettingsRepository
+import io.github.droidkaigi.confsched.data.settings.SettingsDataStore
 import io.github.droidkaigi.confsched.data.sponsors.DefaultSponsorsApiClient
 import io.github.droidkaigi.confsched.data.sponsors.DefaultSponsorsRepository
 import io.github.droidkaigi.confsched.data.sponsors.SponsorsApiClient
@@ -32,6 +35,7 @@ import io.github.droidkaigi.confsched.model.ContributorsRepository
 import io.github.droidkaigi.confsched.model.EventMapRepository
 import io.github.droidkaigi.confsched.model.ProfileCardRepository
 import io.github.droidkaigi.confsched.model.SessionsRepository
+import io.github.droidkaigi.confsched.model.SettingsRepository
 import io.github.droidkaigi.confsched.model.SponsorsRepository
 import io.github.droidkaigi.confsched.model.StaffRepository
 import io.ktor.client.HttpClient
@@ -149,6 +153,8 @@ public val dataModule: Module = module {
         }
     }
 
+    // TODO Duplicate processing?
+    // TODO If not necessary, remove it in another task.
     single<ProfileCardDataStore> {
         val dataStore = createDataStore(
             coroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob()),
@@ -164,6 +170,23 @@ public val dataModule: Module = module {
             },
         )
         DefaultProfileCardDataStore(dataStore)
+    }
+
+    single<SettingsDataStore> {
+        val dataStore = createDataStore(
+            coroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob()),
+            producePath = {
+                val documentDirectory: NSURL? = NSFileManager.defaultManager.URLForDirectory(
+                    directory = NSDocumentDirectory,
+                    inDomain = NSUserDomainMask,
+                    appropriateForURL = null,
+                    create = false,
+                    error = null,
+                )
+                requireNotNull(documentDirectory).path + "/confsched2024.settings.preferences_pb"
+            },
+        )
+        DefaultSettingsDataStore(dataStore)
     }
 
     // Since Kotlin/Native doesn't support Dispatchers.IO, we use Dispatchers.Default instead.
@@ -191,6 +214,11 @@ public val dataModule: Module = module {
             ioDispatcher = get(named("IoDispatcher")),
         )
     }
+    single<SettingsRepository> {
+        DefaultSettingsRepository(
+            settingsDataStore = get(),
+        )
+    }
     single<Repositories> {
         DefaultRepositories(
             mapOf(
@@ -201,6 +229,7 @@ public val dataModule: Module = module {
                 EventMapRepository::class to get<EventMapRepository>(),
                 AboutRepository::class to get<AboutRepository>(),
                 ProfileCardRepository::class to get<ProfileCardRepository>(),
+                SettingsRepository::class to get<SettingsRepository>(),
             ),
         )
     }


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- The Repository and DataStore definitions needed for SettingsScreen were missing from the DataModule.
- As it was, SettingsScreen could not be opened from Compose Multiplatform. 
- As I mentioned in my comment, there is probably an unnecessary duplicate description in the DataModule.
- The font does not change now even if I change the settings on the settings screen.
  - This will need to be addressed in another task.

## Movie (Optional)
<video src="https://github.com/user-attachments/assets/17bcfd48-f4ee-40ac-b92b-09bb731ec52a" width="300" >