### PR TITLE
:recycle: Connecting Compose ProfileCardScreen as an iOS app screen

### DIFF
--- a/app-ios-shared/build.gradle.kts
+++ b/app-ios-shared/build.gradle.kts
@@ -53,6 +53,7 @@ kotlin {
                     export(projects.feature.main)
                     export(projects.feature.sessions)
                     export(projects.feature.contributors)
+                    export(projects.feature.profilecard)
                     export(projects.core.model)
                     export(projects.core.data)
                     export(CommonComponentsDependencies.resources)

--- a/app-ios/Sources/App/RootView.swift
+++ b/app-ios/Sources/App/RootView.swift
@@ -189,14 +189,9 @@ public struct RootView: View {
     private var profileCardTab: some View {
         NavigationStack {
             ZStack(alignment: .bottom) {
-                ProfileCardInputView(
-                    store: Store(
-                        initialState: .init(),
-                        reducer: {
-                            ProfileCardInputReducer()
-                        }
-                    )
-                )
+                KmpProfileCardComposeViewControllerWrapper { text, image in
+                    // TODO Implement a sharing function.
+                }
                 tabItems
             }
         }

--- a/app-ios/Sources/KMPClient/Views/KmpProfileCardComposeViewControllerWrapper.swift
+++ b/app-ios/Sources/KMPClient/Views/KmpProfileCardComposeViewControllerWrapper.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+import shared
+
+public struct KmpProfileCardComposeViewControllerWrapper: UIViewControllerRepresentable {
+    public let repositories: any Repositories
+    private let onClickShareProfileCard: (String, UIImage) -> Void
+    
+    public init(onClickShareProfileCard: @escaping (String, UIImage) -> Void) {
+        self.repositories = Container.shared.get(type: (any Repositories).self)
+        self.onClickShareProfileCard = onClickShareProfileCard
+    }
+    
+    public func makeUIViewController(context: Context) -> UIViewController {
+        return profileCardViewController(
+            repositories: repositories,
+            onClickShareProfileCard: onClickShareProfileCard
+        )
+    }
+    
+    public func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+    }
+}

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -155,7 +155,7 @@ fun NavController.navigateProfileCardScreen() {
     }
 }
 
-internal sealed interface ProfileCardUiState {
+sealed interface ProfileCardUiState {
     data class Edit(
         val nickname: String = "",
         val occupation: String = "",
@@ -173,20 +173,20 @@ internal sealed interface ProfileCardUiState {
     ) : ProfileCardUiState
 }
 
-internal data class ProfileCardError(
+data class ProfileCardError(
     val nicknameError: String = "",
     val occupationError: String = "",
     val linkError: String = "",
     val imageError: String = "",
 )
 
-internal enum class ProfileCardUiType {
+enum class ProfileCardUiType {
     Loading,
     Edit,
     Card,
 }
 
-internal data class ProfileCardScreenState(
+data class ProfileCardScreenState(
     val isLoading: Boolean,
     val editUiState: ProfileCardUiState.Edit,
     val cardUiState: ProfileCardUiState.Card?,

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
@@ -23,7 +23,7 @@ import io.github.droidkaigi.confsched.model.localProfileCardRepository
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.stringResource
 
-internal sealed interface ProfileCardScreenEvent
+sealed interface ProfileCardScreenEvent
 
 internal sealed interface EditScreenEvent : ProfileCardScreenEvent {
     data class OnChangeNickname(

--- a/feature/profilecard/src/iosMain/kotlin/io/github/droidkaigi/confsched/profilecard/ImageBitmapToUiImage.kt
+++ b/feature/profilecard/src/iosMain/kotlin/io/github/droidkaigi/confsched/profilecard/ImageBitmapToUiImage.kt
@@ -1,0 +1,35 @@
+package io.github.droidkaigi.confsched.profilecard
+
+import androidx.compose.ui.graphics.ImageBitmap
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.refTo
+import platform.CoreGraphics.CGBitmapContextCreate
+import platform.CoreGraphics.CGBitmapContextCreateImage
+import platform.CoreGraphics.CGColorSpaceCreateWithName
+import platform.CoreGraphics.CGImageAlphaInfo
+import platform.CoreGraphics.kCGBitmapByteOrder32Little
+import platform.CoreGraphics.kCGColorSpaceSRGB
+import platform.UIKit.UIImage
+
+// TODO Integrate with app-ios-shared methods.
+@OptIn(ExperimentalForeignApi::class)
+internal fun ImageBitmap.toUiImage(): UIImage {
+    val buffer = IntArray(width * height)
+    readPixels(buffer)
+
+    // https://github.com/takahirom/roborazzi/blob/main/roborazzi-compose-ios/src/iosMain/kotlin/io/github/takahirom/roborazzi/RoborazziIos.kt#L88C51-L88C68
+    val colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB)
+    val bitmapInfo = CGImageAlphaInfo.kCGImageAlphaPremultipliedFirst.value or kCGBitmapByteOrder32Little
+    val context = CGBitmapContextCreate(
+        data = buffer.refTo(0),
+        width = width.toULong(),
+        height = height.toULong(),
+        bitsPerComponent = 8u,
+        bytesPerRow = (4 * width).toULong(),
+        space = colorSpace,
+        bitmapInfo = bitmapInfo,
+    )
+
+    val cgImage = CGBitmapContextCreateImage(context)
+    return cgImage?.let { UIImage.imageWithCGImage(it) } ?: UIImage()
+}

--- a/feature/profilecard/src/iosMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardViewController.kt
+++ b/feature/profilecard/src/iosMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardViewController.kt
@@ -34,4 +34,3 @@ fun profileCardScreenPresenterStateFlow(
 ) {
     profileCardScreenPresenter(events)
 }
-

--- a/feature/profilecard/src/iosMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardViewController.kt
+++ b/feature/profilecard/src/iosMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardViewController.kt
@@ -1,0 +1,37 @@
+package io.github.droidkaigi.confsched.profilecard
+
+import io.github.droidkaigi.confsched.compose.EventFlow
+import io.github.droidkaigi.confsched.data.Repositories
+import io.github.droidkaigi.confsched.droidkaigiui.composeViewController
+import io.github.droidkaigi.confsched.droidkaigiui.presenterStateFlow
+import kotlinx.coroutines.flow.Flow
+import platform.UIKit.UIImage
+import platform.UIKit.UIViewController
+import kotlin.reflect.KClass
+
+@Suppress("UNUSED")
+fun profileCardViewController(
+    repositories: Repositories,
+    onClickShareProfileCard: (String, UIImage) -> Unit,
+): UIViewController = composeViewController(repositories) {
+    ProfileCardScreen(
+        onClickShareProfileCard = { shareText, imageBitmap ->
+            onClickShareProfileCard(
+                shareText,
+                imageBitmap.toUiImage(),
+            )
+        },
+    )
+}
+
+@Suppress("unused")
+fun profileCardScreenPresenterStateFlow(
+    repositories: Map<KClass<*>, Any>,
+    events: EventFlow<ProfileCardScreenEvent>,
+): Flow<ProfileCardScreenState> = presenterStateFlow(
+    events = events,
+    repositories = repositories,
+) {
+    profileCardScreenPresenter(events)
+}
+


### PR DESCRIPTION
## Issue
- close #814

## Overview (Required)
- The parts of the UI that were implemented in SwiftUI have been changed to show the UI created in Jetpack Compose.
- Sharing functionality should be outside the scope of this task, so we have not implemented it.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/d83db853-8d8a-4842-bcb9-cdf3b4a2f182" width="300" > | <img src="https://github.com/user-attachments/assets/dbad70eb-e453-445e-be4a-e8f5041a908b" width="300" >