### PR TITLE
In FavoriteScreen, add animtion in FavoriteFilterChip icon

### DIFF
--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/component/FavoriteFilters.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/component/FavoriteFilters.kt
@@ -1,5 +1,10 @@
 package io.github.droidkaigi.confsched.favorites.component
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -43,17 +48,17 @@ fun FavoriteFilters(
         horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         FavoriteFilterChip(
-            selected = allFilterSelected,
+            isSelected = allFilterSelected,
             onClick = onAllFilterChipClick,
             text = stringResource(FavoritesRes.string.filter_all),
         )
         FavoriteFilterChip(
-            selected = day1FilterSelected,
+            isSelected = day1FilterSelected,
             onClick = onDay1FilterChipClick,
             text = stringResource(FavoritesRes.string.filter_day1),
         )
         FavoriteFilterChip(
-            selected = day2FilterSelected,
+            isSelected = day2FilterSelected,
             onClick = onDay2FilterChipClick,
             text = stringResource(FavoritesRes.string.filter_day2),
         )
@@ -62,18 +67,22 @@ fun FavoriteFilters(
 
 @Composable
 private fun FavoriteFilterChip(
-    selected: Boolean,
+    isSelected: Boolean,
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     FilterChip(
         modifier = modifier.padding(top = 8.dp, bottom = 12.dp),
-        selected = selected,
+        selected = isSelected,
         onClick = onClick,
         label = { Text(text) },
         leadingIcon = {
-            if (selected) {
+            AnimatedVisibility(
+                visible = isSelected,
+                enter = fadeIn() + expandHorizontally(),
+                exit = fadeOut() + shrinkHorizontally(),
+            ) {
                 Icon(
                     imageVector = Icons.Filled.Check,
                     contentDescription = null,


### PR DESCRIPTION
## Issue
none

## Overview (Required)
- Same change as #819
  - It has the same look as the EventMapChip, so we made it animate the same way.
  - Changed to make it easier to understand that it is a Boolean value that changes Visible


## Movie
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/b5153666-88a3-4007-865c-a77bca40d111" width="300" > | <video src="https://github.com/user-attachments/assets/f82d2e18-f87b-4cb1-9327-1c24e874a31f" width="300" >


## EventMapChip

https://github.com/user-attachments/assets/5d89787d-02ee-4887-8611-874ed131fc46


