### PR TITLE
In FavoriteScreen, fixed favorite filters being removed when resizing screen

### DIFF
--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenPresenter.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/FavoritesScreenPresenter.kt
@@ -3,7 +3,6 @@ package io.github.droidkaigi.confsched.favorites
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import io.github.droidkaigi.confsched.compose.EventEffect
@@ -23,6 +22,7 @@ import io.github.droidkaigi.confsched.model.SessionsRepository
 import io.github.droidkaigi.confsched.model.Timetable
 import io.github.droidkaigi.confsched.model.TimetableItem
 import io.github.droidkaigi.confsched.model.localSessionsRepository
+import io.github.takahirom.rin.rememberRetained
 import kotlinx.collections.immutable.PersistentSet
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
@@ -46,8 +46,8 @@ fun favoritesScreenPresenter(
             .timetable()
             .filtered(Filters(filterFavorite = true)),
     )
-    var allFilterSelected by remember { mutableStateOf(true) }
-    var currentDayFilters by remember { mutableStateOf(emptySet<DroidKaigi2024Day>()) }
+    var allFilterSelected by rememberRetained { mutableStateOf(true) }
+    var currentDayFilters by rememberRetained { mutableStateOf(emptySet<DroidKaigi2024Day>()) }
     val favoritesSheetUiState by rememberUpdatedState(
         favoritesSheet(
             favoriteSessions = favoriteSessions,


### PR DESCRIPTION
## Issue
none

## Overview (Required)
- In the favorites screen, the filter was returning to its initial value when the device screen size was changed or rotated, so `rememberRetained` was used to prevent this from happening.


## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/de94b83c-b529-4d5b-8560-5eddf0539af6" width="300" > | <video src="https://github.com/user-attachments/assets/5d4f79e2-015c-4130-ba1b-fb09aca840a5" width="300" >
