### PR TITLE
:wastebasket: Removed unnecessary duplicate definitions.

### DIFF
--- a/core/data/src/iosMain/kotlin/io/github/droidkaigi/confsched/data/DataModule.kt
+++ b/core/data/src/iosMain/kotlin/io/github/droidkaigi/confsched/data/DataModule.kt
@@ -153,25 +153,6 @@ public val dataModule: Module = module {
         }
     }
 
-    // TODO Duplicate processing?
-    // TODO If not necessary, remove it in another task.
-    single<ProfileCardDataStore> {
-        val dataStore = createDataStore(
-            coroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob()),
-            producePath = {
-                val documentDirectory: NSURL? = NSFileManager.defaultManager.URLForDirectory(
-                    directory = NSDocumentDirectory,
-                    inDomain = NSUserDomainMask,
-                    appropriateForURL = null,
-                    create = false,
-                    error = null,
-                )
-                requireNotNull(documentDirectory).path + "/confsched2024.profilecard.preferences_pb"
-            },
-        )
-        DefaultProfileCardDataStore(dataStore)
-    }
-
     single<SettingsDataStore> {
         val dataStore = createDataStore(
             coroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob()),


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- In DataModule, there was a duplicate definition that was removed.

## Links
- https://github.com/DroidKaigi/conference-app-2024/pull/823#discussion_r1732847192