### PR TITLE
:sparkles: [Compose Multiplatform] Fixed so that fonts are applied according to the settings.

### DIFF
--- a/app-ios-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/shared/IosComposeKaigiApp.kt
+++ b/app-ios-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/shared/IosComposeKaigiApp.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.window.ComposeUIViewController
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -26,6 +27,7 @@ import io.github.droidkaigi.confsched.contributors.contributorsScreenRoute
 import io.github.droidkaigi.confsched.contributors.contributorsScreens
 import io.github.droidkaigi.confsched.data.Repositories
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
+import io.github.droidkaigi.confsched.designsystem.theme.dotGothic16FontFamily
 import io.github.droidkaigi.confsched.droidkaigiui.NavHostWithSharedAxisX
 import io.github.droidkaigi.confsched.eventmap.eventMapScreenRoute
 import io.github.droidkaigi.confsched.eventmap.eventMapScreens
@@ -44,7 +46,13 @@ import io.github.droidkaigi.confsched.main.MainScreenTab.Timetable
 import io.github.droidkaigi.confsched.main.mainScreen
 import io.github.droidkaigi.confsched.main.mainScreenRoute
 import io.github.droidkaigi.confsched.model.AboutItem
+import io.github.droidkaigi.confsched.model.FontFamily.DotGothic16Regular
+import io.github.droidkaigi.confsched.model.FontFamily.SystemDefault
 import io.github.droidkaigi.confsched.model.Lang.JAPANESE
+import io.github.droidkaigi.confsched.model.Settings.DoesNotExists
+import io.github.droidkaigi.confsched.model.Settings.Exists
+import io.github.droidkaigi.confsched.model.Settings.Loading
+import io.github.droidkaigi.confsched.model.SettingsRepository
 import io.github.droidkaigi.confsched.model.TimetableItem
 import io.github.droidkaigi.confsched.model.compositionlocal.LocalRepositories
 import io.github.droidkaigi.confsched.model.defaultLang
@@ -90,9 +98,22 @@ fun kaigiAppController(
         LocalRepositories provides repositories.map
     ) {
         val windowSizeClass = calculateWindowSizeClass()
+
+        val settingsRepository = LocalRepositories.current[SettingsRepository::class] as SettingsRepository
+        val fontFamily = when (val settings = settingsRepository.settings()) {
+            DoesNotExists, Loading -> dotGothic16FontFamily()
+            is Exists -> {
+                when (settings.useFontFamily) {
+                    DotGothic16Regular -> dotGothic16FontFamily()
+                    SystemDefault -> null
+                }
+            }
+        }
+
         Logging.initialize()
         KaigiApp(
             windowSize = windowSizeClass,
+            fontFamily = fontFamily,
         )
     }
 }
@@ -100,9 +121,12 @@ fun kaigiAppController(
 @Composable
 fun KaigiApp(
     windowSize: WindowSizeClass,
+    fontFamily: FontFamily?,
     modifier: Modifier = Modifier,
 ) {
-    KaigiTheme {
+    KaigiTheme(
+        fontFamily = fontFamily,
+    ) {
         Surface(
             modifier = modifier.fillMaxSize(),
             color = MaterialTheme.colorScheme.background,

--- a/core/designsystem/src/iosMain/kotlin/io/github/droidkaigi/confsched/designsystem/theme/Type.ios.kt
+++ b/core/designsystem/src/iosMain/kotlin/io/github/droidkaigi/confsched/designsystem/theme/Type.ios.kt
@@ -9,7 +9,7 @@ import org.jetbrains.skia.Typeface
 
 @Composable
 actual fun dotGothic16FontFamily(): FontFamily {
-    val skTypeface = loadCustomFont("dot_gothic16_regular")
+    val skTypeface = loadCustomFont("DotGothic16")
 
     return try {
         FontFamily(Typeface(skTypeface))
@@ -18,10 +18,10 @@ actual fun dotGothic16FontFamily(): FontFamily {
     }
 }
 
-private fun loadCustomFont(name: String): Typeface {
+private fun loadCustomFont(familyName: String): Typeface {
     val fontMgr = FontMgr.default
 
-    return fontMgr.matchFamilyStyle(name, FontStyle.NORMAL)
+    return fontMgr.matchFamilyStyle(familyName, FontStyle.NORMAL)
         ?: fontMgr.matchFamilyStyle(null, FontStyle.NORMAL) // default system font.
         ?: Typeface.makeEmpty()
 }


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- A problem with custom fonts not being applied in Compose Multiplatform has been addressed.
- Also, fonts changed in the settings screen are now applied.

## Why was this happening?

- The log obtained by the following code included the name of a custom font in the font family.
- However, the custom font was not applied because the name specified was the font name, not the font family.

```kotlin
    for (i in 0 until fontMgr.familiesCount) {
        val familyName = fontMgr.getFamilyName(i)
        println("Debug: Font family [$i]: $familyName")
    }
```

```
Debug: Attempting to load font from path: src/commonMain/composeResources/font/dot_gothic16_regular.ttf
Debug: Font family [0]: Academy Engraved LET
omission (of middle part of a text).
Debug: Font family [29]: DotGothic16
```

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/1dfc966c-e2b2-4a61-9371-eedabbac554f" width="300" > | <img src="https://github.com/user-attachments/assets/14965a4f-dfe3-4504-84f1-c15f03b2d736" width="300" >