### PR TITLE
:sparkles: Implement profile card share function for iOS.

### DIFF
--- a/app-ios/Sources/App/RootView.swift
+++ b/app-ios/Sources/App/RootView.swift
@@ -1,6 +1,7 @@
 import AboutFeature
 import ComposableArchitecture
 import ContributorFeature
+import CommonComponents
 import FavoriteFeature
 import LicenseList
 import ProfileCardFeature
@@ -190,7 +191,8 @@ public struct RootView: View {
         NavigationStack {
             ZStack(alignment: .bottom) {
                 KmpProfileCardComposeViewControllerWrapper { text, image in
-                    // TODO Implement a sharing function.
+                    let shareNavigator = ShareNavigator()
+                    shareNavigator.shareTextWithImage(text: text, image: image)
                 }
                 tabItems
             }

--- a/app-ios/Sources/CommonComponents/ShareNavigator.swift
+++ b/app-ios/Sources/CommonComponents/ShareNavigator.swift
@@ -1,0 +1,21 @@
+import UIKit
+
+public struct ShareNavigator {
+    public init() {}
+    
+    @MainActor
+    public func shareTextWithImage(text: String, image: UIImage) {
+        let items: [Any] = [text, image]
+        let activityViewController = UIActivityViewController(activityItems: items, applicationActivities: nil)
+        
+        DispatchQueue.main.async {
+            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+               let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }),
+               let rootViewController = keyWindow.rootViewController {
+                rootViewController.present(activityViewController, animated: true, completion: nil)
+            } else {
+                print("Unable to find the root view controller.")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- ProfileCardScreen created in Compose can now use the Share function in iOS.

## Links
- https://github.com/DroidKaigi/conference-app-2024/pull/825#discussion_r1732149241

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
