### PR TITLE
Modify to change the display message based on whether the search text is empty or not

### DIFF
--- a/feature/sessions/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/sessions/src/commonMain/composeResources/values-ja/strings.xml
@@ -29,6 +29,7 @@
     <string name="language_title">対応言語</string>
     <string name="category_title">カテゴリ</string>
     <string name="empty_search_result">「%1$s」と一致する検索結果がありません</string>
+    <string name="empty_search_result_no_input">一致する検索結果がありません</string>
     <string name="filter_chip_day">開催日</string>
     <string name="filter_chip_category">カテゴリ</string>
     <string name="filter_chip_session_type">セッション種別</string>

--- a/feature/sessions/src/commonMain/composeResources/values/strings.xml
+++ b/feature/sessions/src/commonMain/composeResources/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="location_title">Location</string>
     <string name="language_title">Supported Languages</string>
     <string name="category_title">Category</string>
-    <string name="empty_search_result">Nothing matched your search criteria "%1$s"</string>
+    <string name="empty_search_result">Nothing matched your search criteria</string>
     <string name="filter_chip_day">Day</string>
     <string name="filter_chip_category">Category</string>
     <string name="filter_chip_session_type">Session type</string>

--- a/feature/sessions/src/commonMain/composeResources/values/strings.xml
+++ b/feature/sessions/src/commonMain/composeResources/values/strings.xml
@@ -28,7 +28,8 @@
     <string name="location_title">Location</string>
     <string name="language_title">Supported Languages</string>
     <string name="category_title">Category</string>
-    <string name="empty_search_result">Nothing matched your search criteria</string>
+    <string name="empty_search_result">Nothing matched your search criteria "%1$s"</string>
+    <string name="empty_search_result_no_input">Nothing matched your search criteria</string>
     <string name="filter_chip_day">Day</string>
     <string name="filter_chip_category">Category</string>
     <string name="filter_chip_session_type">Session type</string>

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenPresenter.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenPresenter.kt
@@ -50,7 +50,7 @@ fun searchScreenPresenter(
     val sessions by rememberUpdatedState(sessionsRepository.timetable())
 
     var searchWord by rememberRetained { mutableStateOf("") }
-    var  hasSearched by rememberRetained { mutableStateOf(false) }
+    var hasSearched by rememberRetained { mutableStateOf(false) }
     val selectedDays = rememberRetained { mutableStateListOf<DroidKaigi2024Day>() }
     val selectedSessionTypes = rememberRetained { mutableStateListOf<TimetableSessionType>() }
     val selectedCategories = rememberRetained { mutableStateListOf<TimetableCategory>() }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenPresenter.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenPresenter.kt
@@ -50,6 +50,7 @@ fun searchScreenPresenter(
     val sessions by rememberUpdatedState(sessionsRepository.timetable())
 
     var searchWord by rememberRetained { mutableStateOf("") }
+    var  hasSearched by rememberRetained { mutableStateOf(false) }
     val selectedDays = rememberRetained { mutableStateListOf<DroidKaigi2024Day>() }
     val selectedSessionTypes = rememberRetained { mutableStateListOf<TimetableSessionType>() }
     val selectedCategories = rememberRetained { mutableStateListOf<TimetableCategory>() }
@@ -109,6 +110,7 @@ fun searchScreenPresenter(
 
             is UpdateSearchWord -> {
                 searchWord = event.word
+                hasSearched = true
             }
 
             is ClearSearchWord -> {
@@ -150,7 +152,7 @@ fun searchScreenPresenter(
     }
 
     when {
-        filters.isNotEmpty() && filteredSessions.isEmpty() -> {
+        (filters.isNotEmpty() || hasSearched) && filteredSessions.isEmpty() -> {
             SearchScreenUiState.Empty(
                 searchWord = searchWord,
                 searchFilterDayUiState = searchFilterDayUiState,

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/EmptySearchResultBody.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/EmptySearchResultBody.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import conference_app_2024.feature.sessions.generated.resources.Res
 import conference_app_2024.feature.sessions.generated.resources.empty_search_result
+import conference_app_2024.feature.sessions.generated.resources.empty_search_result_no_input
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -24,6 +25,12 @@ fun EmptySearchResultBody(
     searchWord: String,
     modifier: Modifier = Modifier,
 ) {
+    val message = if (searchWord.isEmpty()) {
+        stringResource(Res.string.empty_search_result_no_input)
+    } else {
+        stringResource(Res.string.empty_search_result, searchWord)
+    }
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -36,7 +43,7 @@ fun EmptySearchResultBody(
             contentDescription = null,
         )
         Text(
-            text = stringResource(Res.string.empty_search_result, searchWord),
+            text = message,
             style = MaterialTheme.typography.titleMedium,
             textAlign = TextAlign.Center,
         )


### PR DESCRIPTION
## Issue
- close #798

## Overview (Required)
- Added a message to the strings file to be displayed when there are no results and no search input.
- Modified to change the display message based on whether the search text is empty or not.

## Links
- https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=58871-8744&t=WGCdhOBgDfcbOcP9-4

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/3c572325-1bd8-49ad-8e73-a2a98a468678" width="300" /> | <img src="https://github.com/user-attachments/assets/2d6bf220-fbe6-40aa-a618-62b37f6ba1bf" width="300" />
<img src="https://github.com/user-attachments/assets/3b1fc215-32b2-453d-92bd-52bc298cbfa4" width="300"/> | <img src="https://github.com/user-attachments/assets/ab239c48-bc03-42a4-a4e5-ca5f66545c09" width="300"/>

When there is input
<img src="https://github.com/user-attachments/assets/054c78a9-dbdf-4dd5-a19d-8e9f36d1c654" width="300"/>
