### PR TITLE
Fix profile card screen padding

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -410,19 +410,22 @@ internal fun EditScreen(
         Column(
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
-            Label(label = stringResource(ProfileCardRes.string.image))
-            ImagePickerWithError(
-                image = image,
-                onSelectedImage = {
-                    imageByteArray = it
-                    onChangeImage(it.toBase64())
-                },
-                errorMessage = profileCardError.imageError,
-                onClearImage = {
-                    imageByteArray = null
-                    onChangeImage("")
-                },
-            )
+            Column {
+                Label(label = stringResource(ProfileCardRes.string.image))
+                Spacer(modifier = Modifier.height(12.dp))
+                ImagePickerWithError(
+                    image = image,
+                    onSelectedImage = {
+                        imageByteArray = it
+                        onChangeImage(it.toBase64())
+                    },
+                    errorMessage = profileCardError.imageError,
+                    onClearImage = {
+                        imageByteArray = null
+                        onChangeImage("")
+                    },
+                )
+            }
 
             Text(stringResource(ProfileCardRes.string.select_theme))
 

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -408,6 +408,7 @@ internal fun EditScreen(
         )
 
         Column(
+            modifier = Modifier.padding(bottom = 20.dp),
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
             Column {
@@ -448,10 +449,11 @@ internal fun EditScreen(
                 },
                 enabled = isValidInputs,
                 modifier = Modifier.fillMaxWidth()
+                    .padding(top = 12.dp)
                     .testTag(ProfileCardCreateButtonTestTag),
             ) {
                 Text(
-                    modifier = Modifier.padding(8.dp),
+                    modifier = Modifier.padding(10.dp),
                     text = stringResource(ProfileCardRes.string.create_card),
                 )
             }


### PR DESCRIPTION
## Issue
- close #771

## Overview (Required)
- Adjusted the padding between the `image` label and `add image` button.
- Adjusted the outside padding of the create card button.
- Adjusted the inside padding of the create card button.

## Links
[Figma](https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=55588-8264&t=5GQGixyoAVmum0oZ-0)

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/a7fb4bbd-ff30-4e7b-a795-d352d9793ce9" width="300" /> | <img src="https://github.com/user-attachments/assets/66d70727-146d-477e-af5b-5a7d4eec5c1e" width="300" />



