### PR TITLE
Allow non-square images to be used for profile by center-cropping them

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -73,6 +73,7 @@ import androidx.compose.ui.graphics.vector.VectorPainter
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
@@ -563,7 +564,9 @@ private fun ImagePickerWithError(
                 Image(
                     bitmap = image,
                     contentDescription = null,
+                    contentScale = ContentScale.Crop,
                     modifier = Modifier
+                        .fillMaxSize()
                         .clip(RoundedCornerShape(2.dp))
                         .align(Alignment.BottomStart),
                 )

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/FlipCardFront.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/FlipCardFront.kt
@@ -81,6 +81,7 @@ internal fun FlipCardFront(
             Image(
                 painter = profileImagePainter,
                 contentDescription = null,
+                contentScale = ContentScale.Crop,
                 modifier = Modifier
                     .clip(CircleShape)
                     .size(131.dp),

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/PhotoPickButton.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/PhotoPickButton.kt
@@ -1,20 +1,12 @@
 package io.github.droidkaigi.confsched.profilecard.component
 
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.preat.peekaboo.image.picker.SelectionMode
 import com.preat.peekaboo.image.picker.rememberImagePickerLauncher
-import com.preat.peekaboo.image.picker.toImageBitmap
 import kotlinx.coroutines.CoroutineScope
 
 @Composable
@@ -23,34 +15,7 @@ internal fun PhotoPickerButton(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    var isOpenDialog by remember { mutableStateOf(false) }
-
-    val imagePicker = rememberSingleImagePickerLauncher {
-        with(it.toImageBitmap()) {
-            if (height != width) {
-                // If the image is not square, throw an error.
-                // Ideally, we would like to crop the image, but this is currently on hold due to the difficulty of implementing it by KMP.
-                isOpenDialog = true
-            } else {
-                onSelectedImage(it)
-            }
-        }
-    }
-
-    if (isOpenDialog) {
-        AlertDialog(
-            onDismissRequest = { isOpenDialog = false },
-            title = { Text("Error") },
-            text = { Text("The image is not square.") },
-            confirmButton = {
-                Button(
-                    onClick = { isOpenDialog = false },
-                ) {
-                    Text("OK")
-                }
-            },
-        )
-    }
+    val imagePicker = rememberSingleImagePickerLauncher(onResult = onSelectedImage)
 
     OutlinedButton(
         onClick = imagePicker::launch,


### PR DESCRIPTION
## Issue
- close #840

## Overview (Required)
- Apply a `ContentScale.Crop` to the profile image of both the card and edit versions of the `ProfileCardScreen`
- Remove the "is image square?" check inside `PhotoPickButton`, as well as the dialog when it wasn't

## Links
- https://thoughtbot.com/blog/android-imageview-scaletype-a-visual-guide

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/f460cc66-ffa7-47de-8dd3-cc5573b193e3" width="300" > | <video src="https://github.com/user-attachments/assets/b46a7840-b2cf-4b8b-829f-e42916d57b5b" width="300" >







