### PR TITLE
Fix the size of the shared profile card

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/ShareableCard.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/ShareableCard.kt
@@ -3,7 +3,6 @@ package io.github.droidkaigi.confsched.profilecard.component
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -68,9 +67,8 @@ internal fun ShareableCard(
         Box(
             contentAlignment = Alignment.Center,
             modifier = Modifier
-                .fillMaxWidth()
                 .background(LocalProfileCardTheme.current.primaryColor)
-                .padding(vertical = 50.dp),
+                .padding(vertical = 50.dp, horizontal = 120.dp),
         ) {
             backImage?.let {
                 Image(


### PR DESCRIPTION
## Issue
- close #850

## Overview (Required)
- The shared profile card size was not fixed; it depends on the device screen width. This PR fixes the size of the shared profile card.

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/7a53c7d9-80a3-4faa-9589-241fb07b49ca" width="300" /> | <img src="https://github.com/user-attachments/assets/5690f213-9de3-4a81-893e-e34d804157f9" width="300" />

