### PR TITLE
Fixed “Create Card” button could not be tapped when the keyboard was displayed

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -74,10 +75,12 @@ import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.max
 import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavGraphBuilder
@@ -239,6 +242,10 @@ internal fun ProfileCardScreen(
         }
     }
 
+    val contentWindowInsetsBottom = max(
+        contentPadding.calculateBottomPadding(),
+        with(LocalDensity.current) { WindowInsets.ime.getBottom(this).toDp() },
+    )
     Scaffold(
         modifier = modifier
             .pointerInput(Unit) {
@@ -251,7 +258,7 @@ internal fun ProfileCardScreen(
             left = contentPadding.calculateLeftPadding(layoutDirection),
             top = contentPadding.calculateTopPadding(),
             right = contentPadding.calculateRightPadding(layoutDirection),
-            bottom = contentPadding.calculateBottomPadding()
+            bottom = contentWindowInsetsBottom
                 .plus(16.dp), // Adjusting Snackbar position
         ),
         topBar = {


### PR DESCRIPTION
## Issue
- close #852

## Overview (Required)
- Can't tap the “Create Card” button when the keyboard is displayed. Therefore, the keyboard must be closed once, which is a poor user experience.

## Links
- 

## Movie (Optional)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/38197155-4f05-4dff-bf74-6acf6829c725" width="300" > | <video src="https://github.com/user-attachments/assets/1ecd9be7-ba7c-4e7c-86d0-c84b708fd9e2" width="300" >



