### PR TITLE
Resolved ComposablePreviewScanner library dependency

### DIFF
--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/DroidKaigiKmpPreviewTester.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/DroidKaigiKmpPreviewTester.kt
@@ -7,11 +7,11 @@ import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.captureRoboImage
 import io.github.droidkaigi.confsched.testing.rules.CoilRule
 import sergio.sastre.composable.preview.scanner.core.preview.ComposablePreview
+import sergio.sastre.composable.preview.scanner.jvm.JvmAnnotationInfo
 import sergio.sastre.composable.preview.scanner.jvm.JvmAnnotationScanner
-import sergio.sastre.composable.preview.scanner.jvm.JvmAnnotationScanner.DesktopPreviewInfo
 
 @OptIn(ExperimentalRoborazziApi::class)
-class DroidKaigiKmpPreviewTester : ComposePreviewTester<JvmAnnotationScanner.DesktopPreviewInfo> {
+class DroidKaigiKmpPreviewTester : ComposePreviewTester<JvmAnnotationInfo> {
     override fun options(): Options {
         return super.options().copy(
             testLifecycleOptions = JUnit4TestLifecycleOptions {
@@ -19,13 +19,13 @@ class DroidKaigiKmpPreviewTester : ComposePreviewTester<JvmAnnotationScanner.Des
             },
         )
     }
-    override fun previews(): List<ComposablePreview<DesktopPreviewInfo>> {
+    override fun previews(): List<ComposablePreview<JvmAnnotationInfo>> {
         return JvmAnnotationScanner("org.jetbrains.compose.ui.tooling.preview.Preview")
             .scanPackageTrees(*options().scanOptions.packages.toTypedArray())
             .getPreviews()
     }
 
-    override fun test(preview: ComposablePreview<JvmAnnotationScanner.DesktopPreviewInfo>) {
+    override fun test(preview: ComposablePreview<JvmAnnotationInfo>) {
         captureRoboImage("${preview.methodName}.png") {
             println(preview.methodName)
             preview()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ molecule = "1.4.2"
 kover = "0.7.6"
 androidxLifecycleProcess = "2.8.4"
 skie = "0.8.4"
-composablePreviewScanner = "0.1.3"
+composablePreviewScanner = "0.3.0"
 coil = "3.0.0-alpha10"
 peekaboo = "0.5.2"
 


### PR DESCRIPTION
## Issue
- close #830

## Overview (Required)
- Update ComposablePreviewScanner 0.3.0
- Modify ComposePreviewTester
  - I wrote this part based on that library, but it may not be entirely accurate
  - [Compose Multiplatform Support](https://github.com/user-attachments/assets/b68b9c3f-1ac6-4c68-a12e-70595431ce50)

## Links
- [Diff ComposablePreviewScanner v0.2.0](https://github.com/sergio-sastre/ComposablePreviewScanner/pull/23/files)
- ComposePreviewTester pom files
   - [0.1.3 pom file](https://jitpack.io/com/github/sergio-sastre/ComposablePreviewScanner/android/0.1.3/android-0.1.3.pom)
   - [0.3.0 pom file](https://jitpack.io/com/github/sergio-sastre/ComposablePreviewScanner/android/0.3.0/android-0.3.0.pom)

## Depdendencies (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/b68b9c3f-1ac6-4c68-a12e-70595431ce50" width="300" /> | <img src="https://github.com/user-attachments/assets/abbc2506-c1d4-440e-9554-01416b9cf929" width="300" />