### PR TITLE
[iOS] Fix timetable list spacing

### DIFF
--- a/app-ios/Sources/TimetableFeature/TimetableListView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableListView.swift
@@ -90,7 +90,7 @@ struct TimetableListView: View {
 
     var body: some View {
         ScrollView{
-            LazyVStack {
+            LazyVStack(spacing: 0) {
                 ForEach(store.timetableItems, id: \.self) { item in
                     TimeGroupMiniList(contents: item, onItemTap: { item in
                         store.send(.view(.timetableItemTapped(item)))
@@ -179,14 +179,14 @@ struct TimeGroupMiniList: View {
     let onFavoriteTap: (TimetableItemWithFavorite) -> Void
     
     var body: some View {
-        HStack {
+        HStack(spacing: 16) {
             VStack {
                 Text(contents.startsTimeString).textStyle(.titleMedium)
                 Text("|").font(.system(size: 8))
                 Text(contents.endsTimeString).textStyle(.titleMedium)
                 Spacer()
-            }.padding(10).foregroundStyle(AssetColors.Surface.onSurface.swiftUIColor)
-            VStack {
+            }.foregroundStyle(AssetColors.Surface.onSurface.swiftUIColor)
+            VStack(spacing: 12) {
                 ForEach(contents.items, id: \.self) { item in
                     TimetableCard(
                         timetableItem: item.timetableItem,
@@ -199,8 +199,7 @@ struct TimeGroupMiniList: View {
                         })
                 }
             }
-        }.background(Color.clear)
-            
+        }.padding(16).background(Color.clear)
     }
 }
 


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- This PR fixes the timetable list spacing to follow the design

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/a5274e78-d943-45a6-8af9-96413ed1894e" width="300" /> | <img src="https://github.com/user-attachments/assets/507c5ab0-91b4-4173-a34b-8f07af04a7e8" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
