### PR TITLE
:memo: Limit the number of lines that can be entered on the profile card edit screen to one line.

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -497,6 +497,7 @@ private fun InputFieldWithError(
     errorMessage: String,
     textFieldTestTag: String,
     onValueChange: (String) -> Unit,
+    maxLines: Int = 1,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
@@ -515,6 +516,7 @@ private fun InputFieldWithError(
             onValueChange = onValueChange,
             isError = isError,
             shape = RoundedCornerShape(4.dp),
+            maxLines = maxLines,
             modifier = Modifier
                 .indicatorLine(
                     enabled = false,

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -497,8 +497,8 @@ private fun InputFieldWithError(
     errorMessage: String,
     textFieldTestTag: String,
     onValueChange: (String) -> Unit,
-    maxLines: Int = 1,
     modifier: Modifier = Modifier,
+    maxLines: Int = 1,
 ) {
     Column(modifier = modifier) {
         val isError = errorMessage.isNotEmpty()


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- Only the first line is displayed on CardScreen.
- It is not necessary to be able to enter two lines.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/6f889c70-d015-4119-b184-a4f4d94f4995" width="300" > | <video src="https://github.com/user-attachments/assets/e2b7800f-d046-4556-a0c2-ee7685c0f842" width="300" >