### PR TITLE
:recycle: Cards can be flipped by swiping as in EventMap.

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/FlipCard.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/FlipCard.kt
@@ -4,6 +4,9 @@ import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -26,6 +29,8 @@ import io.github.droidkaigi.confsched.profilecard.hologramaticEffect
 import kotlinx.coroutines.delay
 
 const val ProfileCardFlipCardTestTag = "ProfileCardFlipCardTestTag"
+
+private const val ChangeFlipCardDeltaThreshold = 20f
 
 @Composable
 internal fun FlipCard(
@@ -50,7 +55,18 @@ internal fun FlipCard(
         modifier = modifier
             .testTag(ProfileCardFlipCardTestTag)
             .size(width = 300.dp, height = 380.dp)
-            .clickable { isFlipped = !isFlipped }
+            .clickable { isFlipped = isFlipped.not() }
+            .draggable(
+                orientation = Orientation.Horizontal,
+                state = rememberDraggableState { delta ->
+                    if (isFlipped && delta > ChangeFlipCardDeltaThreshold) {
+                        isFlipped = false
+                    }
+                    if (isFlipped.not() && delta < -ChangeFlipCardDeltaThreshold) {
+                        isFlipped = true
+                    }
+                },
+            )
             .graphicsLayer {
                 rotationY = rotation
                 cameraDistance = 12f * density


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- I thought it would be useful to be able to swipe to flip cards on the profile card screen as well.

## Links
- https://github.com/DroidKaigi/conference-app-2024/blob/7799642fa0612ba250798675ccb51357768c8a44/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/component/EventMapTab.kt#L49-L59

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/8289eac2-0d33-4a6a-bcfe-29883ae9de69" width="300" > | <video src="https://github.com/user-attachments/assets/a28180ae-e407-499f-8175-24d43cbd3b62" width="300" >