### PR TITLE
[iOS] Localize calendars usage description

### DIFF
--- a/app-ios/App/App.xcodeproj/project.pbxproj
+++ b/app-ios/App/App.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		8C7DACB82BCBCCB0002C298A /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C7DACB22BCBCCB0002C298A /* App.swift */; };
 		8C7DACB92BCBCCB0002C298A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8C7DACB32BCBCCB0002C298A /* Assets.xcassets */; };
 		8C7DACC52BCBD18A002C298A /* App in Frameworks */ = {isa = PBXBuildFile; productRef = 8C7DACC42BCBD18A002C298A /* App */; };
+		9EA589E52C7F98E6007EE5EC /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 9EA589E42C7F98E6007EE5EC /* InfoPlist.xcstrings */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -29,6 +30,7 @@
 		8C7DACB52BCBCCB0002C298A /* App.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
 		8C7DACBB2BCBCDA0002C298A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		8C7DACC12BCBD0F1002C298A /* app-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "app-ios"; path = ..; sourceTree = "<group>"; };
+		9EA589E42C7F98E6007EE5EC /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		C412816C2C149FB500B458D1 /* DroidKaigi2024App-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "DroidKaigi2024App-Info.plist"; sourceTree = "<group>"; };
 		C495D60A2C075130003B324E /* App.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = App.xctestplan; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -93,6 +95,7 @@
 				8C7DACB52BCBCCB0002C298A /* App.entitlements */,
 				8C31F46A2BF6909A003F1BBA /* GoogleService-Info.plist */,
 				8C7DACBB2BCBCDA0002C298A /* PrivacyInfo.xcprivacy */,
+				9EA589E42C7F98E6007EE5EC /* InfoPlist.xcstrings */,
 			);
 			name = App;
 			sourceTree = "<group>";
@@ -150,6 +153,7 @@
 			knownRegions = (
 				en,
 				Base,
+				ja,
 			);
 			mainGroup = 8C772B0C2BCBCBCA00F2BADC;
 			productRefGroup = 8C772B162BCBCBCA00F2BADC /* Products */;
@@ -167,6 +171,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8C7DACB92BCBCCB0002C298A /* Assets.xcassets in Resources */,
+				9EA589E52C7F98E6007EE5EC /* InfoPlist.xcstrings in Resources */,
 				8C7074792C7791DF00FD4F39 /* ci_pre_xcodebuild.sh in Resources */,
 				8C7DACB72BCBCCB0002C298A /* Preview Assets.xcassets in Resources */,
 				8C31F46B2BF6909A003F1BBA /* GoogleService-Info.plist in Resources */,

--- a/app-ios/App/DroidKaigi2024App-Info.plist
+++ b/app-ios/App/DroidKaigi2024App-Info.plist
@@ -8,6 +8,6 @@
 		<string>ja</string>
 	</array>
 	<key>NSCalendarsUsageDescription</key>
-    <string>カレンダーにイベントを追加するためにカレンダーへのアクセスが必要です。</string>
+	<string>Use for adding events to your calendar</string>
 </dict>
 </plist>

--- a/app-ios/App/InfoPlist.xcstrings
+++ b/app-ios/App/InfoPlist.xcstrings
@@ -1,0 +1,41 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "CFBundleName" : {
+      "comment" : "Bundle name",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DroidKaigi2024App"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DroidKaigi2024App"
+          }
+        }
+      }
+    },
+    "NSCalendarsUsageDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use for adding events to your calendar"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カレンダーにイベントを追加するためにカレンダーへのアクセスが必要です。"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}


### PR DESCRIPTION
## Issue
- close #839

## Overview (Required)
- This PR adds localizations for the calendars usage description

## Links
- https://developer.apple.com/documentation/xcode/localizing-and-varying-text-with-a-string-catalog

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://github.com/user-attachments/assets/aa7af629-a1c0-4a52-a134-a419e020a1e5" width="300" /><br>(English)
<img src="" width="300" /> | <img src="https://github.com/user-attachments/assets/5aae5ac3-8858-4961-a003-82fdb8a33c68" width="300" /><br>(Japanese)

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >