### PR TITLE
:recycle: Add a loading display to the EventMap screen.

### DIFF
--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
@@ -77,7 +77,7 @@ sealed interface EventMapUiState {
     val userMessageStateHolder: UserMessageStateHolder
 
     data class Loading(
-        override val userMessageStateHolder: UserMessageStateHolder
+        override val userMessageStateHolder: UserMessageStateHolder,
     ) : EventMapUiState
     data class Exists(
         override val userMessageStateHolder: UserMessageStateHolder,

--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched.eventmap
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -18,6 +20,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -70,10 +73,17 @@ fun NavController.navigateEventMapScreen() {
     }
 }
 
-data class EventMapUiState(
-    val eventMap: PersistentList<EventMapEvent>,
-    val userMessageStateHolder: UserMessageStateHolder,
-)
+sealed interface EventMapUiState {
+    val userMessageStateHolder: UserMessageStateHolder
+
+    data class Loading(
+        override val userMessageStateHolder: UserMessageStateHolder
+    ) : EventMapUiState
+    data class Exists(
+        override val userMessageStateHolder: UserMessageStateHolder,
+        val eventMap: PersistentList<EventMapEvent>,
+    ) : EventMapUiState
+}
 
 @Composable
 fun EventMapScreen(
@@ -131,7 +141,7 @@ fun EventMapScreen(
         ),
     ) { padding ->
         EventMap(
-            eventMapEvents = uiState.eventMap,
+            uiState = uiState,
             onEventMapItemClick = onEventMapItemClick,
             contentPadding = PaddingValues(bottom = padding.calculateBottomPadding()),
             modifier = Modifier
@@ -144,7 +154,7 @@ fun EventMapScreen(
 
 @Composable
 private fun EventMap(
-    eventMapEvents: PersistentList<EventMapEvent>,
+    uiState: EventMapUiState,
     onEventMapItemClick: (url: String) -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
@@ -158,21 +168,35 @@ private fun EventMap(
             EventMapTab()
             Spacer(Modifier.height(26.dp))
         }
-        itemsIndexed(eventMapEvents) { index, eventMapEvent ->
-            EventMapItem(
-                eventMapEvent = eventMapEvent,
-                onClick = onEventMapItemClick,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .testTag(EventMapItemTestTag.plus(eventMapEvent.roomName.enTitle)),
-            )
-            if (eventMapEvents.lastIndex != index) {
-                Spacer(Modifier.height(24.dp))
-                HorizontalDivider(
-                    thickness = 1.dp,
-                    color = MaterialTheme.colorScheme.outlineVariant,
-                )
-                Spacer(Modifier.height(24.dp))
+        when (uiState) {
+            is EventMapUiState.Exists -> {
+                itemsIndexed(uiState.eventMap) { index, eventMapEvent ->
+                    EventMapItem(
+                        eventMapEvent = eventMapEvent,
+                        onClick = onEventMapItemClick,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag(EventMapItemTestTag.plus(eventMapEvent.roomName.enTitle)),
+                    )
+                    if (uiState.eventMap.lastIndex != index) {
+                        Spacer(Modifier.height(24.dp))
+                        HorizontalDivider(
+                            thickness = 1.dp,
+                            color = MaterialTheme.colorScheme.outlineVariant,
+                        )
+                        Spacer(Modifier.height(24.dp))
+                    }
+                }
+            }
+            is EventMapUiState.Loading -> {
+                item {
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = Modifier.padding(contentPadding).fillMaxWidth(),
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
             }
         }
         item {
@@ -185,7 +209,10 @@ private fun EventMap(
 @Preview
 fun PreviewEventMapScreen() {
     EventMapScreen(
-        uiState = EventMapUiState(persistentListOf(), rememberUserMessageStateHolder()),
+        uiState = EventMapUiState.Exists(
+            userMessageStateHolder = rememberUserMessageStateHolder(),
+            eventMap = persistentListOf(),
+        ),
         snackbarHostState = SnackbarHostState(),
         onEventMapItemClick = {},
     )

--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreenPresenter.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreenPresenter.kt
@@ -19,7 +19,9 @@ fun eventMapScreenPresenter(
     val eventMap by rememberUpdatedState(eventMapRepository.eventMapEvents())
     EventEffect(events) { event ->
     }
-    EventMapUiState(
+
+    if (eventMap.isEmpty()) return@providePresenterDefaults EventMapUiState.Loading(userMessageStateHolder)
+    EventMapUiState.Exists(
         eventMap = eventMap,
         userMessageStateHolder = userMessageStateHolder,
     )


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- It would be easier for users to understand that loading is in progress even when communication is slow if there is a loading indicator during loading.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/8f820a94-923f-472e-b0df-2ff4c1fc2e17" width="300" > | <video src="https://github.com/user-attachments/assets/1839c2ef-82fa-4fc0-ae3d-5872d1c1af6b" width="300" >