### PR TITLE
:recycle: Placeholders are now displayed on the speaker icon of the Timetable Items.

### DIFF
--- a/core/droidkaigiui/src/androidMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/SpeakerPainter.android.kt
+++ b/core/droidkaigiui/src/androidMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/SpeakerPainter.android.kt
@@ -10,6 +10,9 @@ import io.github.droidkaigi.confsched.droidkaigiui.rememberAsyncImagePainter
 
 @Composable
 actual fun speakerPainter(url: String): Painter {
+    // TODO Use DrawableResource
+    // https://github.com/DroidKaigi/conference-app-2024/pull/864/files#r1736437080
+    // https://github.com/coil-kt/coil/issues/2077
     return rememberAsyncImagePainter(
         model = ImageRequest.Builder(LocalContext.current)
             .data(url)

--- a/core/droidkaigiui/src/androidMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/SpeakerPainter.android.kt
+++ b/core/droidkaigiui/src/androidMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/SpeakerPainter.android.kt
@@ -1,0 +1,19 @@
+package io.github.droidkaigi.confsched.droidkaigiui.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalContext
+import coil3.request.ImageRequest
+import coil3.request.placeholder
+import io.github.droidkaigi.confsched.core.droidkaigiui.R
+import io.github.droidkaigi.confsched.droidkaigiui.rememberAsyncImagePainter
+
+@Composable
+actual fun speakerPainter(url: String): Painter {
+    return rememberAsyncImagePainter(
+        model = ImageRequest.Builder(LocalContext.current)
+            .data(url)
+            .placeholder(R.drawable.icon_place_hoolder)
+            .build()
+    )
+}

--- a/core/droidkaigiui/src/androidMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/SpeakerPainter.android.kt
+++ b/core/droidkaigiui/src/androidMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/SpeakerPainter.android.kt
@@ -14,6 +14,6 @@ actual fun speakerPainter(url: String): Painter {
         model = ImageRequest.Builder(LocalContext.current)
             .data(url)
             .placeholder(R.drawable.icon_place_hoolder)
-            .build()
+            .build(),
     )
 }

--- a/core/droidkaigiui/src/androidMain/res/drawable/icon_place_hoolder.xml
+++ b/core/droidkaigiui/src/androidMain/res/drawable/icon_place_hoolder.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#67FF8D" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM12,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z"/>
+    
+</vector>

--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/ImagePainter.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/ImagePainter.kt
@@ -9,3 +9,10 @@ fun rememberAsyncImagePainter(url: String): Painter {
         model = url,
     )
 }
+
+@Composable
+fun rememberAsyncImagePainter(model: Any): Painter {
+    return coil3.compose.rememberAsyncImagePainter(
+        model = model,
+    )
+}

--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/ImagePainter.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/ImagePainter.kt
@@ -2,6 +2,7 @@ package io.github.droidkaigi.confsched.droidkaigiui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.painter.Painter
+import coil3.request.ImageRequest
 
 @Composable
 fun rememberAsyncImagePainter(url: String): Painter {
@@ -11,7 +12,7 @@ fun rememberAsyncImagePainter(url: String): Painter {
 }
 
 @Composable
-fun rememberAsyncImagePainter(model: Any): Painter {
+fun rememberAsyncImagePainter(model: ImageRequest): Painter {
     return coil3.compose.rememberAsyncImagePainter(
         model = model,
     )

--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/SpeakerPainter.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/SpeakerPainter.kt
@@ -1,0 +1,7 @@
+package io.github.droidkaigi.confsched.droidkaigiui.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.painter.Painter
+
+@Composable
+expect fun speakerPainter(url: String): Painter

--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/TimetableItemCard.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/TimetableItemCard.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.Icons.Filled
 import androidx.compose.material.icons.Icons.Outlined
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.Icon
@@ -36,6 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
@@ -55,6 +57,7 @@ import io.github.droidkaigi.confsched.designsystem.theme.ProvideRoomTheme
 import io.github.droidkaigi.confsched.designsystem.theme.primaryFixed
 import io.github.droidkaigi.confsched.droidkaigiui.DroidKaigiUiRes
 import io.github.droidkaigi.confsched.droidkaigiui.animation.LocalFavoriteAnimationScope
+import io.github.droidkaigi.confsched.droidkaigiui.previewOverride
 import io.github.droidkaigi.confsched.model.TimetableItem
 import io.github.droidkaigi.confsched.model.TimetableItem.Session
 import org.jetbrains.compose.resources.stringResource
@@ -135,7 +138,9 @@ fun TimetableItemCard(
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
                             // TODO: Fixed image loading again but its still slow. Maybe we need smaller images?
-                            val painter = speakerPainter(speaker.iconUrl)
+                            val painter = previewOverride(previewPainter = { rememberVectorPainter(image = Icons.Default.Person) }) {
+                                speakerPainter(speaker.iconUrl)
+                            }
                             Image(
                                 painter = painter,
                                 modifier = Modifier

--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/TimetableItemCard.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/TimetableItemCard.kt
@@ -55,7 +55,6 @@ import io.github.droidkaigi.confsched.designsystem.theme.ProvideRoomTheme
 import io.github.droidkaigi.confsched.designsystem.theme.primaryFixed
 import io.github.droidkaigi.confsched.droidkaigiui.DroidKaigiUiRes
 import io.github.droidkaigi.confsched.droidkaigiui.animation.LocalFavoriteAnimationScope
-import io.github.droidkaigi.confsched.droidkaigiui.rememberAsyncImagePainter
 import io.github.droidkaigi.confsched.model.TimetableItem
 import io.github.droidkaigi.confsched.model.TimetableItem.Session
 import org.jetbrains.compose.resources.stringResource
@@ -136,7 +135,7 @@ fun TimetableItemCard(
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
                             // TODO: Fixed image loading again but its still slow. Maybe we need smaller images?
-                            val painter = rememberAsyncImagePainter(speaker.iconUrl)
+                            val painter = speakerPainter(speaker.iconUrl)
                             Image(
                                 painter = painter,
                                 modifier = Modifier

--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/TimetableItemCard.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/TimetableItemCard.kt
@@ -138,7 +138,11 @@ fun TimetableItemCard(
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
                             // TODO: Fixed image loading again but its still slow. Maybe we need smaller images?
-                            val painter = previewOverride(previewPainter = { rememberVectorPainter(image = Icons.Default.Person) }) {
+                            val painter = previewOverride(
+                                previewPainter = {
+                                    rememberVectorPainter(image = Icons.Default.Person)
+                                },
+                            ) {
                                 speakerPainter(speaker.iconUrl)
                             }
                             Image(

--- a/core/droidkaigiui/src/iosMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/SpeakerPainter.ios.kt
+++ b/core/droidkaigiui/src/iosMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/SpeakerPainter.ios.kt
@@ -1,0 +1,10 @@
+package io.github.droidkaigi.confsched.droidkaigiui.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.painter.Painter
+import io.github.droidkaigi.confsched.droidkaigiui.rememberAsyncImagePainter
+
+@Composable
+actual fun speakerPainter(url: String): Painter {
+    return rememberAsyncImagePainter(url)
+}

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
@@ -45,9 +45,9 @@ import conference_app_2024.feature.sessions.generated.resources.content_descript
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.designsystem.theme.LocalRoomTheme
 import io.github.droidkaigi.confsched.designsystem.theme.ProvideRoomTheme
+import io.github.droidkaigi.confsched.droidkaigiui.component.speakerPainter
 import io.github.droidkaigi.confsched.droidkaigiui.icon
 import io.github.droidkaigi.confsched.droidkaigiui.previewOverride
-import io.github.droidkaigi.confsched.droidkaigiui.rememberAsyncImagePainter
 import io.github.droidkaigi.confsched.model.MultiLangText
 import io.github.droidkaigi.confsched.model.RoomType.RoomH
 import io.github.droidkaigi.confsched.model.TimetableAsset
@@ -279,7 +279,7 @@ private fun SpeakerIcon(
 ) {
     Image(
         painter = previewOverride(previewPainter = { rememberVectorPainter(image = Icons.Default.Person) }) {
-            rememberAsyncImagePainter(iconUrl)
+            speakerPainter(iconUrl)
         },
         contentDescription = stringResource(SessionsRes.string.content_description_user_icon),
         modifier = modifier
@@ -287,6 +287,7 @@ private fun SpeakerIcon(
                 BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
                 CircleShape,
             )
+            .width(TimetableGridItemSizes.speakerHeight)
             .height(TimetableGridItemSizes.speakerHeight)
             .layout { measurable, constraints ->
                 // To keep circle shape, it needs to match the vertical size when pinching in

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
@@ -6,9 +6,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -31,6 +33,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
@@ -277,28 +280,42 @@ private fun SpeakerIcon(
     iconUrl: String,
     modifier: Modifier = Modifier,
 ) {
-    Image(
-        painter = previewOverride(previewPainter = { rememberVectorPainter(image = Icons.Default.Person) }) {
-            speakerPainter(iconUrl)
-        },
-        contentDescription = stringResource(SessionsRes.string.content_description_user_icon),
+    Box(
         modifier = modifier
             .border(
                 BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
                 CircleShape,
             )
-            .width(TimetableGridItemSizes.speakerHeight)
-            .height(TimetableGridItemSizes.speakerHeight)
+            .clip(CircleShape)
             .layout { measurable, constraints ->
                 // To keep circle shape, it needs to match the vertical size when pinching in
-                val placeable = measurable.measure(constraints)
-                val size = placeable.height
+                val size = constraints.maxWidth.coerceAtMost(constraints.maxHeight)
+                val placeable = measurable.measure(
+                    constraints.copy(
+                        minWidth = size,
+                        maxWidth = size,
+                        minHeight = size,
+                        maxHeight = size,
+                    ),
+                )
                 layout(size, size) {
                     placeable.placeRelative(0, 0)
                 }
-            }
-            .clip(CircleShape),
-    )
+            },
+    ) {
+        Image(
+            painter = previewOverride(
+                previewPainter = {
+                    rememberVectorPainter(image = Icons.Default.Person)
+                },
+            ) {
+                speakerPainter(iconUrl)
+            },
+            contentDescription = stringResource(SessionsRes.string.content_description_user_icon),
+            contentScale = ContentScale.Fit,
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
 }
 
 /**


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- Currently, nothing is displayed on the icon until the speaker's icon has finished loading.
- So I am adding this because I think it would be better to have a placeholder displayed.

## Movie (Optional)
Before List | After List
:--: | :--:
<video src="https://github.com/user-attachments/assets/28f78da2-c214-4dfa-a3d0-fd90e644ff0a" width="300" > | <video src="https://github.com/user-attachments/assets/95621072-369a-4d03-a148-f82d51246705" width="300" >

Before Grid | After Grid
:--: | :--:
<video src="https://github.com/user-attachments/assets/f92519b0-5aff-42ec-a609-265537e57199" width="300" > | <video src="https://github.com/user-attachments/assets/3ad2c907-e1d0-4e5d-b807-5dd340243da6" width="300" >

Before Grid Pinch-In&Out | After Grid Pinch-In&Out
:--: | :--:
<video src="https://github.com/user-attachments/assets/2be1db7f-759c-448c-8af8-b6c68f36dcc0" width="300" > | <video src="https://github.com/user-attachments/assets/cc2dd572-1ce1-4332-b571-efa75e934f79" width="300" >