### PR TITLE
:wrench: Addressed an issue where the app would crash on the timetable screen when the font size on the device is increased.

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridTab.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridTab.kt
@@ -36,6 +36,7 @@ fun TimetableDayTab(
     onDaySelected: (day: DroidKaigi2024Day) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // TODO Refactor
     val density = LocalDensity.current
     val tabWidth = with(density) {
         // calculate width from sp
@@ -51,8 +52,10 @@ fun TimetableDayTab(
     }
     val paddingAroundTab =
         (tabWidth - indicatorWidths.reduce { acc, width -> acc + width }) / (indicatorWidths.size * 2)
+    val columnHorizontalPadding = 0.dp.coerceAtLeast(20.dp - paddingAroundTab)
+
     Column(
-        modifier = modifier.padding(horizontal = 20.dp - paddingAroundTab, vertical = 16.dp),
+        modifier = modifier.padding(horizontal = columnHorizontalPadding, vertical = 16.dp),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.Start,
     ) {


### PR DESCRIPTION
## Issue
- close #856

## Overview (Required)
- Prevented negative numbers from being included in the Horizontal padding.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/ad6e697c-e96c-4f47-9ee1-b41d1521398b" width="300" > | <img src="https://github.com/user-attachments/assets/d28472e0-2bd9-4474-b267-e0374ec28676" width="300" >