### PR TITLE
Conform `Sendable` to TimetableDetailReducer.Action.

### DIFF
--- a/app-ios/Sources/TimetableDetailFeature/TimetableDetailReducer.swift
+++ b/app-ios/Sources/TimetableDetailFeature/TimetableDetailReducer.swift
@@ -28,7 +28,7 @@ public struct TimetableDetailReducer: Sendable {
         @Presents var confirmationDialog: ConfirmationDialogState<ConfirmationDialog>?
     }
 
-    public enum Action: BindableAction {
+    public enum Action: BindableAction, Sendable {
         case binding(BindingAction<State>)
         case view(View)
         case confirmationDialog(PresentationAction<ConfirmationDialog>)
@@ -36,7 +36,7 @@ public struct TimetableDetailReducer: Sendable {
         case requestEventAccessResponse(Result<Bool, any Error>)
         case addEventResponse(Result<Void, any Error>)
 
-        public enum View {
+        public enum View: Sendable{
             case favoriteButtonTapped
             case calendarButtonTapped
             case slideButtonTapped(URL)
@@ -46,7 +46,7 @@ public struct TimetableDetailReducer: Sendable {
     }
     
     @CasePathable
-    public enum ConfirmationDialog {
+    public enum ConfirmationDialog: Sendable {
         case addEvent
     }
     


### PR DESCRIPTION
## Issue
- In progress #431

## Overview (Required)
- Responded to according to the following warning
  - `Passing argument of non-sendable type 'TimetableDetailReducer.Action' into main actor-isolated context may introduce data races`

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/c5c541c4-8633-44fb-b485-a7b64bd9b253" width="300" /> | <img src="https://github.com/user-attachments/assets/5d2199ba-8cc8-40c4-94c3-6b8a04510716" width="300" />





## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
