### PR TITLE
Remove unnecessary `retroactive` attribute

### DIFF
--- a/app-ios/Sources/FavoriteFeature/FavoriteView.swift
+++ b/app-ios/Sources/FavoriteFeature/FavoriteView.swift
@@ -83,13 +83,7 @@ public struct FavoriteView: View {
     }
 }
 
-#if hasFeature(RetroactiveAttribute)
-extension DroidKaigi2024Day: @retroactive Selectable {}
-#else
-extension DroidKaigi2024Day: Selectable {}
-#endif
-
-extension DroidKaigi2024Day {
+extension DroidKaigi2024Day: Model.Selectable {
     public var id: Self {
         self
     }

--- a/app-ios/Sources/SearchFeature/SearchView.swift
+++ b/app-ios/Sources/SearchFeature/SearchView.swift
@@ -183,13 +183,7 @@ public struct SearchView: View {
     }
 }
 
-#if hasFeature(RetroactiveAttribute)
-extension DroidKaigi2024Day: @retroactive Selectable {}
-#else
-extension DroidKaigi2024Day: Selectable {}
-#endif
-
-extension DroidKaigi2024Day {
+extension DroidKaigi2024Day: Model.Selectable {
     public var id: Self {
         self
     }
@@ -212,13 +206,7 @@ extension DroidKaigi2024Day {
     }
 }
 
-#if hasFeature(RetroactiveAttribute)
-extension TimetableSessionType: @retroactive Selectable {}
-#else
-extension TimetableSessionType: Selectable {}
-#endif
-
-extension TimetableSessionType {
+extension TimetableSessionType: Model.Selectable {
     public var id: Self {
         self
     }
@@ -228,13 +216,7 @@ extension TimetableSessionType {
     }
 }
 
-#if hasFeature(RetroactiveAttribute)
-extension Lang: @retroactive Selectable {}
-#else
-extension Lang: Selectable {}
-#endif
-
-extension Lang {
+extension Lang: Model.Selectable {
     public var id: Self {
         self
     }

--- a/app-ios/Sources/Theme/ColorAsset+Sendable.swift
+++ b/app-ios/Sources/Theme/ColorAsset+Sendable.swift
@@ -1,5 +1,1 @@
-#if hasFeature(RetroactiveAttribute)
-extension ColorAsset: @retroactive @unchecked Sendable {}
-#else
 extension ColorAsset: @unchecked Sendable {}
-#endif

--- a/app-ios/Sources/Theme/FontConvertible+Sendable.swift
+++ b/app-ios/Sources/Theme/FontConvertible+Sendable.swift
@@ -1,5 +1,1 @@
-#if hasFeature(RetroactiveAttribute)
-extension FontConvertible: @retroactive @unchecked Sendable {}
-#else
 extension FontConvertible: @unchecked Sendable {}
-#endif


### PR DESCRIPTION
## Issue

## Overview (Required)
- The `@retroactive` attribute was necessary in Xcode 16, so it was applied using a macro branching process. However, the proposal [SE-0364](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0364-retroactive-conformance-warning.md#source-compatibility) describes a method that does not require macro branching and switches to that fully qualified method.
- Additionally, the `ColorAsset` and `FontConvertible` types did not need the `@retroactive` attribute, so the attribute and macros were removed.
  - These types were created by SwiftGen in the `Theme` module, and the extensions were declared in the same `Theme` module.
    - The `@retroactive` attribute is necessary when changes are made from external modules, so it was not meaningful in this context.


## Links
- [SE-0364](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0364-retroactive-conformance-warning.md#source-compatibility)

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
