### PR TITLE
Expand the tap area of the edit button In ProfileCardScreen

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextFieldDefaults.indicatorLine
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -806,14 +807,27 @@ internal fun CardScreen(
                         )
                     }
                     Spacer(Modifier.height(8.dp))
-                    Text(
-                        text = stringResource(ProfileCardRes.string.edit),
-                        style = MaterialTheme.typography.labelLarge,
-                        color = Color.Black,
+                    TextButton(
+                        onClick = {
+                            onClickEdit()
+                        },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Color.Transparent,
+                            disabledContainerColor = Color.Transparent,
+                        ),
                         modifier = Modifier
-                            .clickable { onClickEdit() }
+                            .padding(horizontal = 16.dp)
+                            .fillMaxWidth()
                             .testTag(ProfileCardEditButtonTestTag),
-                    )
+                    ) {
+                        Text(
+                            text = stringResource(ProfileCardRes.string.edit),
+                            modifier = Modifier.padding(8.dp),
+                            style = MaterialTheme.typography.labelLarge,
+                            color = Color.Black
+                        )
+                    }
+
                 }
             }
         }


### PR DESCRIPTION
## Issue
- close #801 

## Overview (Required)
- The edit button in ProfileCardScreen has a littele tap area. 
- The tap area  should be in the same size as the button for sharing one above.
- So, I try expanded the tap area.


- Please let me know if I am wrong below.
    - I thought it would be better to use TextButton for the edit button than to make Text clickable, so I did so.
    - Specify ButtonDefaults.buttonColors for colors, following the example of the Share button, etc.
        - I've already confirmed that the ripple will look and feel good, similar to the share button.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
- The top and bottom position of the view has changed before and after the modification because of the added margin between the Share button and the... Please check if this is a problem.

Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/aba476f6-cd70-4d72-af94-3bd6553504d9" width="300" /> | <img src="https://github.com/user-attachments/assets/8c829397-cfae-4e38-9817-4ef95f7dc7d2" width="300" />


## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="https://github.com/user-attachments/assets/dd7012bd-53d5-4c14-b47b-9bc863bc3d71" width="300" >