### PR TITLE
[iOS] Fix timeline grid unexpected margin.

### DIFF
--- a/app-ios/Sources/TimetableFeature/TimetableGridCard.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableGridCard.swift
@@ -63,7 +63,8 @@ public struct TimetableGridCard: View {
             }
             .frame(maxWidth: .infinity)
             .padding(12)
-            .frame(width: 192 * CGFloat(cellCount) + CGFloat(12 * (cellCount - 1)), height: 153)
+            .frame(maxWidth: 192 * CGFloat(cellCount) + CGFloat(12 * (cellCount - 1)))
+            .frame(height: 153)
             .background(cellCount > 1 ? AssetColors.Surface.surfaceContainer.swiftUIColor : timetableItem.room.roomTheme.containerColor, in: RoundedRectangle(cornerRadius: 4))
             .overlay(RoundedRectangle(cornerRadius: 4).stroke(cellCount > 1 ? AssetColors.Surface.onSurface.swiftUIColor : timetableItem.room.roomTheme.primaryColor, lineWidth: 1))
         }

--- a/app-ios/Sources/TimetableFeature/TimetableListView.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableListView.swift
@@ -137,7 +137,7 @@ struct TimetableGridView: View {
                             Text(timeBlock.startsTimeString).foregroundStyle(AssetColors.Surface.onSurface.swiftUIColor).textStyle(.labelMedium)
                             Spacer()
                             
-                        }.frame(height: 153)
+                        }.frame(width: 40, height: 153)
                         
                         if (timeBlock.items.count == 1 && timeBlock.isTopLunch()) {
                             


### PR DESCRIPTION
## Issue

None.（※ I found a solution and improved it.）

## Overview (Required)

When displaying the Timeline screen as a grid, an unintended blank space occurred, causing the display of Jellyfish room to be cut off in the middle. We have made adjustments to resolve this situation.

- Adjust grid width about displaying timeline start.
- divide frame modifier maxWidth & height in TimetableGridCard.

## Link

- [Figma (about Timeline Grid)](https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=54849-10371&node-type=SECTION&t=gg56ROjbJ7k3uNLf-0)

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/778638a2-fb23-4e58-bf35-a5bf74bfbdd2" width="300" /> | <img src="https://github.com/user-attachments/assets/de71fc84-3262-4a71-b6d3-ffda80a3ed25" width="300" />

## Movie
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/3ed116df-8d57-4537-a20f-09f32298fc3d" width="300" > | <video src="https://github.com/user-attachments/assets/8541b9a9-35c1-4c67-8899-56693b1fbc45" width="300" >

## Appendix

I think it also looks good when displayed in landscape mode.

<video src="https://github.com/user-attachments/assets/bc9ce162-7eb8-4343-8064-498ccf43fc7b" width="480" >