### PR TITLE
Remove deprecated option in configuration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,6 @@ android.nonTransitiveRClass=true
 
 # kotlin
 kotlin.code.style=official
-kotlin.native.binary.memoryModel=experimental
 kotlin.native.ignoreDisabledTargets=true
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.stability.nowarn=true


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- This PR removes a deprecated option in 'gradle.properties' to resolve the following build warning:

```
w: -memory-model and memoryModel switches are deprecated and will be removed in a future release.
```

## Links
- https://kotlinlang.org/docs/whatsnew1720.html#configuration-and-setup

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
