### PR TITLE
Fix duplicated language filter items

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenPresenter.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenPresenter.kt
@@ -96,7 +96,7 @@ fun searchScreenPresenter(
     val searchFilterLanguageUiState: SearchFilterUiState<Lang> by rememberUpdatedState(
         SearchFilterUiState(
             selectedItems = selectedLanguages,
-            selectableItems = sessions.languages.map { it.toLang() },
+            selectableItems = sessions.languages.map { it.toLang() }.distinct(),
             selectedValuesText = selectedLanguages.joinToString { it.tagName },
         ),
     )


### PR DESCRIPTION
## Issue
- close #842

## Overview (Required)
- Fixed a bug where `MIXED` was duplicated among Supported languages ​​items in the search filter
### Cause
The `MIXED` value was duplicated during the mapping process in `sessions.languages` due to `toLang()` being applied, where `ENGLISH` or `JAPANESE` with `isInterpretationTarget` set to true caused this issue.
```kotlin
// SearchScreenPresenter.kt 96 line
val searchFilterLanguageUiState: SearchFilterUiState<Lang> by rememberUpdatedState(
        SearchFilterUiState(
            selectedItems = selectedLanguages,
            selectableItems = sessions.languages.map { it.toLang() },
            selectedValuesText = selectedLanguages.joinToString { it.tagName },
        ),
    )

// TimetableLanguage.kt 15 line
fun toLang() = if (isInterpretationTarget) {
        Lang.MIXED
    } else {
        Lang.entries.firstOrNull { it.tagName == langOfSpeaker.take(2) } ?: Lang.MIXED
    }
```

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/a559135a-354f-4314-9c67-87ffbb7ee5d0" width="300" /> | <img src="https://github.com/user-attachments/assets/0fda606b-1a06-496d-9732-b16c20d33dbe" width="300" />

