### PR TITLE
In EditScreen, add keyboardOptions in InputFieldWithError

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -79,6 +80,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.max
 import androidx.navigation.NavController
@@ -403,6 +405,7 @@ internal fun EditScreen(
                 nickname = it
                 onChangeNickname(it)
             },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
         )
         InputFieldWithError(
             value = occupation,
@@ -413,6 +416,7 @@ internal fun EditScreen(
                 occupation = it
                 onChangeOccupation(it)
             },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
         )
         val linkLabel = stringResource(ProfileCardRes.string.link)
             .plus(stringResource(ProfileCardRes.string.link_example_text))
@@ -425,6 +429,7 @@ internal fun EditScreen(
                 link = it
                 onChangeLink(it)
             },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
         )
 
         Column(
@@ -505,6 +510,7 @@ private fun InputFieldWithError(
     textFieldTestTag: String,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     maxLines: Int = 1,
 ) {
     Column(modifier = modifier) {
@@ -523,6 +529,7 @@ private fun InputFieldWithError(
             onValueChange = onValueChange,
             isError = isError,
             shape = RoundedCornerShape(4.dp),
+            keyboardOptions = keyboardOptions,
             maxLines = maxLines,
             modifier = Modifier
                 .indicatorLine(


### PR DESCRIPTION
## Issue
none


## Overview
- The profile entry field is a singleLine, but it is possible to break lines using ImeAction. Therefore, ImeAction is set to Next or Done to prevent line breaks and allow smooth input.


## Links
- [Android developers - ImeAction](https://developer.android.com/reference/kotlin/androidx/compose/ui/text/input/ImeAction)


## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/12941026-dfd1-4a63-81cd-8ec6f1bdd494" width="300" > | <video src="https://github.com/user-attachments/assets/a58bbde4-23aa-4a3f-8e76-a3bc84d2e69a" width="300" >
