### PR TITLE
Use same color for icon with text on AboutScreen items

### DIFF
--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutContentColumn.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutContentColumn.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutContentColumn.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutContentColumn.kt
@@ -58,8 +58,7 @@ fun AboutContentColumn(
                     .padding(
                         horizontal = 12.dp,
                     ),
-                // TODO: Migrate this to theme's color
-                tint = Color.Green,
+                tint = MaterialTheme.colorScheme.primaryFixed,
             )
             Text(
                 text = label,


### PR DESCRIPTION
## Issue
- close #728 

## Overview (Required)
- the color of item's icons on AboutScreen differs from text color
- use same color for it

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/f39b5d78-f937-4104-be0c-75399231cb32" width="300" /> | <img src="https://github.com/user-attachments/assets/283bbb19-b88d-46a5-9f02-7fa3a1f75280" width="300" />


