### PR TITLE
:wrench: Remove todoCheks from EventMapScreenTest.

### DIFF
--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/EventMapScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/EventMapScreenRobot.kt
@@ -2,6 +2,8 @@ package io.github.droidkaigi.confsched.testing.robot
 
 import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
@@ -133,5 +135,11 @@ class EventMapScreenRobot @Inject constructor(
         composeTestRule
             .onNode(hasTestTag(EventMapTabImageTestTag))
             .assertContentDescriptionEquals("Map of ${floorLevel.floorName}")
+    }
+
+    fun checkErrorSnackbarDisplayed() {
+        composeTestRule
+            .onNode(hasText("Fake IO Exception"))
+            .isDisplayed()
     }
 }

--- a/feature/eventmap/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreenTest.kt
+++ b/feature/eventmap/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreenTest.kt
@@ -8,7 +8,6 @@ import io.github.droidkaigi.confsched.testing.execute
 import io.github.droidkaigi.confsched.testing.robot.EventMapScreenRobot
 import io.github.droidkaigi.confsched.testing.robot.EventMapServerRobot.ServerStatus
 import io.github.droidkaigi.confsched.testing.robot.runRobot
-import io.github.droidkaigi.confsched.testing.robot.todoChecks
 import io.github.droidkaigi.confsched.testing.rules.RobotTestRule
 import org.junit.Rule
 import org.junit.Test
@@ -124,7 +123,7 @@ class EventMapScreenTest(val behavior: DescribedBehavior<EventMapScreenRobot>) {
                         captureScreenWithChecks(
                             checks = {
                                 checkErrorSnackbarDisplayed()
-                            }
+                            },
                         )
                     }
                 }

--- a/feature/eventmap/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreenTest.kt
+++ b/feature/eventmap/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreenTest.kt
@@ -122,7 +122,9 @@ class EventMapScreenTest(val behavior: DescribedBehavior<EventMapScreenRobot>) {
                     }
                     itShould("show error message") {
                         captureScreenWithChecks(
-                            checks = todoChecks("This screen is still empty now. Please add some checks."),
+                            checks = {
+                                checkErrorSnackbarDisplayed()
+                            }
                         )
                     }
                 }


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- I searched the project for todoChecks and found todoCheks still in this location, so I added a test to address it.