### PR TITLE
:wastebasket: Delete methods that are no longer used.

### DIFF
--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/RoomIcon.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/RoomIcon.kt
@@ -1,6 +1,5 @@
 package io.github.droidkaigi.confsched.model
 
-// TODO There should be similar definitions in several places, and they will be merged later if necessary.
 enum class RoomIcon {
     Square,
     Circle,

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/TimetableRoom.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/TimetableRoom.kt
@@ -17,37 +17,6 @@ data class TimetableRoom(
     }
 
     fun getThemeKey(): String = name.enTitle.lowercase()
-
-    // TODO: Names are updated but the shapes need to be checked
-    fun getShape(): Shapes {
-        return when (name.enTitle) {
-            "Flamingo" -> {
-                Shapes.SQUARE
-            }
-            "Giraffe" -> {
-                Shapes.CIRCLE
-            }
-            "Hedgehog" -> {
-                Shapes.SHARP_DIAMOND
-            }
-            "Iguana" -> {
-                Shapes.DIAMOND
-            }
-            "Jellyfish" -> {
-                Shapes.DIAMOND
-            }
-            else -> {
-                Shapes.SQUARE
-            }
-        }
-    }
-
-    enum class Shapes {
-        SQUARE,
-        CIRCLE,
-        SHARP_DIAMOND,
-        DIAMOND,
-    }
 }
 
 val TimetableRoom.nameAndFloor: String


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- Since RoomIcon.kt is used for room icons, this method is no longer needed.
- It is no longer referenced from anywhere now.