### PR TITLE
:wrench: [IosComposeKaigiTest] A syntax error occurred due to insufficient arguments, so I fixed it.

### DIFF
--- a/app-ios-shared/src/iosTest/kotlin/io/github/droidkaigi/confsched/shared/IosComposeKaigiTest.kt
+++ b/app-ios-shared/src/iosTest/kotlin/io/github/droidkaigi/confsched/shared/IosComposeKaigiTest.kt
@@ -58,7 +58,8 @@ class IosComposeKaigiTest {
                                 height = 812F
                             ),
                             density = LocalDensity.current,
-                        )
+                        ),
+                        fontFamily = null,
                     )
                 }
             }


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- The test code was broken due to the omission of an argument, so I fixed it.

## Links
- The test code was not modified when this was done.
- https://github.com/DroidKaigi/conference-app-2024/pull/836/files#diff-95ce4543f147fdb230f67281fa29911d85e7cfcb7571a32629c0c722dc547bbaR124
