### PR TITLE
:recycle: [TimetableItemDetailScreenTest] Since there is a lack of VRT for assets, we have added VRT so that they can be tested.

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sessions/FakeSessionsApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sessions/FakeSessionsApiClient.kt
@@ -30,6 +30,24 @@ public class FakeSessionsApiClient : SessionsApiClient {
             }
         }
 
+        public data object OperationalBothAssetAvailable : Status() {
+            override suspend fun sessionsAllResponse(): SessionsAllResponse {
+                return SessionsAllResponse.bothAssetAvailableFake()
+            }
+        }
+
+        public data object OperationalOnlySlideAssetAvailable : Status() {
+            override suspend fun sessionsAllResponse(): SessionsAllResponse {
+                return SessionsAllResponse.onlySlideAssetAvailableFake()
+            }
+        }
+
+        public data object OperationalOnlyVideoAssetAvailable : Status() {
+            override suspend fun sessionsAllResponse(): SessionsAllResponse {
+                return SessionsAllResponse.onlyVideoAssetAvailableFake()
+            }
+        }
+
         public data object Error : Status() {
             override suspend fun sessionsAllResponse(): SessionsAllResponse {
                 throw IOException("Fake IO Exception")
@@ -213,6 +231,63 @@ public fun SessionsAllResponse.Companion.fake(): SessionsAllResponse {
         rooms = rooms,
         speakers = speakers,
         categories = categories,
+    )
+}
+
+public fun SessionsAllResponse.Companion.bothAssetAvailableFake(): SessionsAllResponse {
+    val baseFake = fake()
+    val sessions = baseFake.sessions.map { session ->
+        session.copy(
+            asset = SessionAssetResponse(
+                videoUrl = "https://2024.droidkaigi.jp/",
+                slideUrl = "https://2024.droidkaigi.jp/",
+            )
+        )
+    }
+
+    return SessionsAllResponse(
+        sessions = sessions,
+        rooms = baseFake.rooms,
+        speakers = baseFake.speakers,
+        categories = baseFake.categories,
+    )
+}
+
+public fun SessionsAllResponse.Companion.onlySlideAssetAvailableFake(): SessionsAllResponse {
+    val baseFake = fake()
+    val sessions = baseFake.sessions.map { session ->
+        session.copy(
+            asset = SessionAssetResponse(
+                videoUrl = null,
+                slideUrl = "https://2024.droidkaigi.jp/",
+            )
+        )
+    }
+
+    return SessionsAllResponse(
+        sessions = sessions,
+        rooms = baseFake.rooms,
+        speakers = baseFake.speakers,
+        categories = baseFake.categories,
+    )
+}
+
+public fun SessionsAllResponse.Companion.onlyVideoAssetAvailableFake(): SessionsAllResponse {
+    val baseFake = fake()
+    val sessions = baseFake.sessions.map { session ->
+        session.copy(
+            asset = SessionAssetResponse(
+                videoUrl = "https://2024.droidkaigi.jp/",
+                slideUrl = null,
+            )
+        )
+    }
+
+    return SessionsAllResponse(
+        sessions = sessions,
+        rooms = baseFake.rooms,
+        speakers = baseFake.speakers,
+        categories = baseFake.categories,
     )
 }
 

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sessions/FakeSessionsApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sessions/FakeSessionsApiClient.kt
@@ -238,7 +238,7 @@ public fun SessionsAllResponse.Companion.bothAssetAvailableFake(): SessionsAllRe
             asset = SessionAssetResponse(
                 videoUrl = "https://2024.droidkaigi.jp/",
                 slideUrl = "https://2024.droidkaigi.jp/",
-            )
+            ),
         )
     }
 
@@ -257,7 +257,7 @@ public fun SessionsAllResponse.Companion.onlySlideAssetAvailableFake(): Sessions
             asset = SessionAssetResponse(
                 videoUrl = null,
                 slideUrl = "https://2024.droidkaigi.jp/",
-            )
+            ),
         )
     }
 
@@ -276,7 +276,7 @@ public fun SessionsAllResponse.Companion.onlyVideoAssetAvailableFake(): Sessions
             asset = SessionAssetResponse(
                 videoUrl = "https://2024.droidkaigi.jp/",
                 slideUrl = null,
-            )
+            ),
         )
     }
 

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sessions/FakeSessionsApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sessions/FakeSessionsApiClient.kt
@@ -83,50 +83,105 @@ public class FakeSessionsApiClient : SessionsApiClient {
     }
 }
 
-public fun SessionsAllResponse.Companion.fake(): SessionsAllResponse {
-    val sessions = mutableListOf<SessionResponse>()
-    val speakers = listOf(
-        SpeakerResponse(fullName = "taka", id = "1", isTopSpeaker = true),
-        SpeakerResponse(fullName = "ry", id = "2", isTopSpeaker = true),
-    )
-    val rooms = listOf(
-        RoomResponse(name = LocaledResponse(ja = "Hedgehog ja", en = "Hedgehog"), id = 1, sort = 1),
-        RoomResponse(
-            name = LocaledResponse(ja = "Flamingo ja", en = "Flamingo"),
-            id = 2,
-            sort = 2,
+public fun SessionsAllResponse.Companion.fake(
+    sessions: List<SessionResponse> = SessionResponse.fakes(
+        rooms = RoomResponse.fakes(),
+        categories = CategoryResponse.fakes(),
+        asset = SessionAssetResponse.fake(),
+    ),
+    rooms: List<RoomResponse> = RoomResponse.fakes(),
+    speakers: List<SpeakerResponse> = SpeakerResponse.fakes(),
+    categories: List<CategoryResponse> = CategoryResponse.fakes(),
+): SessionsAllResponse = SessionsAllResponse(
+    sessions = sessions,
+    rooms = rooms,
+    speakers = speakers,
+    categories = categories,
+)
+
+public fun SessionsAllResponse.Companion.bothAssetAvailableFake(): SessionsAllResponse = SessionsAllResponse.fake(
+    sessions = SessionResponse.fakes(
+        asset = SessionAssetResponse(
+            videoUrl = "https://2024.droidkaigi.jp/",
+            slideUrl = "https://2024.droidkaigi.jp/",
         ),
-        RoomResponse(
-            name = LocaledResponse(ja = "Giraffe ja", en = "Giraffe"),
-            id = 3,
-            sort = 3,
-        ),
-        RoomResponse(name = LocaledResponse(ja = "Iguana ja", en = "Iguana"), id = 4, sort = 3),
     )
-    val categories = listOf(
-        CategoryResponse(
-            id = 1,
-            sort = 1,
-            title = LocaledResponse(ja = "Category1 ja", en = "Category1 en"),
-            items = listOf(
-                CategoryItemResponse(
-                    id = 1,
-                    name = LocaledResponse(ja = "App Architecture ja", en = "App Architecture en"),
-                    sort = 1,
-                ),
-                CategoryItemResponse(
-                    id = 2,
-                    name = LocaledResponse(ja = "Jetpack Compose ja", en = "Jetpack Compose en"),
-                    sort = 2,
-                ),
-                CategoryItemResponse(
-                    id = 3,
-                    name = LocaledResponse(ja = "Other ja", en = "Other en"),
-                    sort = 3,
-                ),
+)
+
+public fun SessionsAllResponse.Companion.onlySlideAssetAvailableFake(): SessionsAllResponse = SessionsAllResponse.fake(
+    sessions = SessionResponse.fakes(
+        asset = SessionAssetResponse(
+            videoUrl = null,
+            slideUrl = "https://2024.droidkaigi.jp/",
+        ),
+    )
+)
+
+public fun SessionsAllResponse.Companion.onlyVideoAssetAvailableFake(): SessionsAllResponse = SessionsAllResponse.fake(
+    sessions = SessionResponse.fakes(
+        asset = SessionAssetResponse(
+            videoUrl = "https://2024.droidkaigi.jp/",
+            slideUrl = null,
+        ),
+    )
+)
+
+private fun RoomResponse.Companion.fakes(): List<RoomResponse> = listOf(
+    RoomResponse(name = LocaledResponse(ja = "Hedgehog ja", en = "Hedgehog"), id = 1, sort = 1),
+    RoomResponse(
+        name = LocaledResponse(ja = "Flamingo ja", en = "Flamingo"),
+        id = 2,
+        sort = 2,
+    ),
+    RoomResponse(
+        name = LocaledResponse(ja = "Giraffe ja", en = "Giraffe"),
+        id = 3,
+        sort = 3,
+    ),
+    RoomResponse(name = LocaledResponse(ja = "Iguana ja", en = "Iguana"), id = 4, sort = 3),
+)
+
+private fun CategoryResponse.Companion.fakes(): List<CategoryResponse> = listOf(
+    CategoryResponse(
+        id = 1,
+        sort = 1,
+        title = LocaledResponse(ja = "Category1 ja", en = "Category1 en"),
+        items = listOf(
+            CategoryItemResponse(
+                id = 1,
+                name = LocaledResponse(ja = "App Architecture ja", en = "App Architecture en"),
+                sort = 1,
+            ),
+            CategoryItemResponse(
+                id = 2,
+                name = LocaledResponse(ja = "Jetpack Compose ja", en = "Jetpack Compose en"),
+                sort = 2,
+            ),
+            CategoryItemResponse(
+                id = 3,
+                name = LocaledResponse(ja = "Other ja", en = "Other en"),
+                sort = 3,
             ),
         ),
-    )
+    ),
+)
+
+private fun SessionAssetResponse.Companion.fake(): SessionAssetResponse = SessionAssetResponse(
+    videoUrl = null,
+    slideUrl = null,
+)
+
+private fun SpeakerResponse.Companion.fakes(): List<SpeakerResponse> = listOf(
+    SpeakerResponse(fullName = "taka", id = "1", isTopSpeaker = true),
+    SpeakerResponse(fullName = "ry", id = "2", isTopSpeaker = true),
+)
+
+private fun SessionResponse.Companion.fakes(
+    rooms: List<RoomResponse> = RoomResponse.fakes(),
+    categories: List<CategoryResponse> = CategoryResponse.fakes(),
+    asset: SessionAssetResponse = SessionAssetResponse.fake(),
+): List<SessionResponse> {
+    val sessions = mutableListOf<SessionResponse>()
 
     for (dayIndex in 0..2) {
         sessions.add(
@@ -148,7 +203,7 @@ public fun SessionsAllResponse.Companion.fake(): SessionsAllResponse {
                 language = "JAPANESE",
                 sessionCategoryItemId = 3,
                 interpretationTarget = false,
-                asset = SessionAssetResponse(videoUrl = null, slideUrl = null),
+                asset = asset,
                 message = null,
                 sessionType = "WELCOME_TALK",
                 levels = listOf("UNSPECIFIED"),
@@ -215,7 +270,7 @@ public fun SessionsAllResponse.Companion.fake(): SessionsAllResponse {
                     isPlenumSession = false,
                     targetAudience = "For App developer アプリ開発者向け",
                     interpretationTarget = false,
-                    asset = SessionAssetResponse(videoUrl = null, slideUrl = null),
+                    asset = asset,
                     levels = listOf("INTERMEDIATE"),
                 )
                 sessions.add(session)
@@ -223,69 +278,7 @@ public fun SessionsAllResponse.Companion.fake(): SessionsAllResponse {
         }
     }
 
-    return SessionsAllResponse(
-        sessions = sessions,
-        rooms = rooms,
-        speakers = speakers,
-        categories = categories,
-    )
-}
-
-public fun SessionsAllResponse.Companion.bothAssetAvailableFake(): SessionsAllResponse {
-    val baseFake = fake()
-    val sessions = baseFake.sessions.map { session ->
-        session.copy(
-            asset = SessionAssetResponse(
-                videoUrl = "https://2024.droidkaigi.jp/",
-                slideUrl = "https://2024.droidkaigi.jp/",
-            ),
-        )
-    }
-
-    return SessionsAllResponse(
-        sessions = sessions,
-        rooms = baseFake.rooms,
-        speakers = baseFake.speakers,
-        categories = baseFake.categories,
-    )
-}
-
-public fun SessionsAllResponse.Companion.onlySlideAssetAvailableFake(): SessionsAllResponse {
-    val baseFake = fake()
-    val sessions = baseFake.sessions.map { session ->
-        session.copy(
-            asset = SessionAssetResponse(
-                videoUrl = null,
-                slideUrl = "https://2024.droidkaigi.jp/",
-            ),
-        )
-    }
-
-    return SessionsAllResponse(
-        sessions = sessions,
-        rooms = baseFake.rooms,
-        speakers = baseFake.speakers,
-        categories = baseFake.categories,
-    )
-}
-
-public fun SessionsAllResponse.Companion.onlyVideoAssetAvailableFake(): SessionsAllResponse {
-    val baseFake = fake()
-    val sessions = baseFake.sessions.map { session ->
-        session.copy(
-            asset = SessionAssetResponse(
-                videoUrl = "https://2024.droidkaigi.jp/",
-                slideUrl = null,
-            ),
-        )
-    }
-
-    return SessionsAllResponse(
-        sessions = sessions,
-        rooms = baseFake.rooms,
-        speakers = baseFake.speakers,
-        categories = baseFake.categories,
-    )
+    return sessions
 }
 
 private fun Instant.toCustomIsoString(): String {

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sessions/FakeSessionsApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sessions/FakeSessionsApiClient.kt
@@ -215,10 +215,7 @@ public fun SessionsAllResponse.Companion.fake(): SessionsAllResponse {
                     isPlenumSession = false,
                     targetAudience = "For App developer アプリ開発者向け",
                     interpretationTarget = false,
-                    asset = SessionAssetResponse(
-                        videoUrl = "https://www.youtube.com/watch?v=hFdKCyJ-Z9A",
-                        slideUrl = "https://droidkaigi.jp/2021/",
-                    ),
+                    asset = SessionAssetResponse(videoUrl = null, slideUrl = null),
                     levels = listOf("INTERMEDIATE"),
                 )
                 sessions.add(session)

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sessions/FakeSessionsApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/sessions/FakeSessionsApiClient.kt
@@ -105,7 +105,7 @@ public fun SessionsAllResponse.Companion.bothAssetAvailableFake(): SessionsAllRe
             videoUrl = "https://2024.droidkaigi.jp/",
             slideUrl = "https://2024.droidkaigi.jp/",
         ),
-    )
+    ),
 )
 
 public fun SessionsAllResponse.Companion.onlySlideAssetAvailableFake(): SessionsAllResponse = SessionsAllResponse.fake(
@@ -114,7 +114,7 @@ public fun SessionsAllResponse.Companion.onlySlideAssetAvailableFake(): Sessions
             videoUrl = null,
             slideUrl = "https://2024.droidkaigi.jp/",
         ),
-    )
+    ),
 )
 
 public fun SessionsAllResponse.Companion.onlyVideoAssetAvailableFake(): SessionsAllResponse = SessionsAllResponse.fake(
@@ -123,7 +123,7 @@ public fun SessionsAllResponse.Companion.onlyVideoAssetAvailableFake(): Sessions
             videoUrl = "https://2024.droidkaigi.jp/",
             slideUrl = null,
         ),
-    )
+    ),
 )
 
 private fun RoomResponse.Companion.fakes(): List<RoomResponse> = listOf(

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/TimetableAsset.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/TimetableAsset.kt
@@ -5,5 +5,5 @@ public data class TimetableAsset(
     val slideUrl: String?,
 ) {
     val isAvailable: Boolean
-        get() = !videoUrl.isNullOrBlank() && !slideUrl.isNullOrBlank()
+        get() = videoUrl.isNullOrBlank().not() || slideUrl.isNullOrBlank().not()
 }

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/MiniRobots.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/MiniRobots.kt
@@ -10,6 +10,7 @@ import io.github.droidkaigi.confsched.data.eventmap.EventMapApiClient
 import io.github.droidkaigi.confsched.data.eventmap.FakeEventMapApiClient
 import io.github.droidkaigi.confsched.data.profilecard.ProfileCardDataStore
 import io.github.droidkaigi.confsched.data.sessions.FakeSessionsApiClient
+import io.github.droidkaigi.confsched.data.sessions.FakeSessionsApiClient.Status
 import io.github.droidkaigi.confsched.data.sessions.SessionsApiClient
 import io.github.droidkaigi.confsched.data.settings.SettingsDataStore
 import io.github.droidkaigi.confsched.data.sponsors.FakeSponsorsApiClient
@@ -28,6 +29,11 @@ import io.github.droidkaigi.confsched.testing.robot.SettingsDataStoreRobot.Setti
 import io.github.droidkaigi.confsched.testing.robot.SettingsDataStoreRobot.SettingsStatus.UseDotGothic16FontFamily
 import io.github.droidkaigi.confsched.testing.robot.SettingsDataStoreRobot.SettingsStatus.UseSystemDefaultFont
 import io.github.droidkaigi.confsched.testing.robot.SponsorsServerRobot.ServerStatus
+import io.github.droidkaigi.confsched.testing.robot.TimetableServerRobot.ServerStatus.Error
+import io.github.droidkaigi.confsched.testing.robot.TimetableServerRobot.ServerStatus.Operational
+import io.github.droidkaigi.confsched.testing.robot.TimetableServerRobot.ServerStatus.OperationalBothAssetAvailable
+import io.github.droidkaigi.confsched.testing.robot.TimetableServerRobot.ServerStatus.OperationalOnlySlideAssetAvailable
+import io.github.droidkaigi.confsched.testing.robot.TimetableServerRobot.ServerStatus.OperationalOnlyVideoAssetAvailable
 import io.github.droidkaigi.confsched.testing.rules.RobotTestRule
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.test.TestDispatcher
@@ -168,6 +174,9 @@ class DefaultDeviceSetupRobot @Inject constructor() : DeviceSetupRobot {
 interface TimetableServerRobot {
     enum class ServerStatus {
         Operational,
+        OperationalBothAssetAvailable,
+        OperationalOnlySlideAssetAvailable,
+        OperationalOnlyVideoAssetAvailable,
         Error,
     }
 
@@ -180,8 +189,11 @@ class DefaultTimetableServerRobot @Inject constructor(sessionsApiClient: Session
     override fun setupTimetableServer(serverStatus: TimetableServerRobot.ServerStatus) {
         fakeSessionsApiClient.setup(
             when (serverStatus) {
-                TimetableServerRobot.ServerStatus.Operational -> FakeSessionsApiClient.Status.Operational
-                TimetableServerRobot.ServerStatus.Error -> FakeSessionsApiClient.Status.Error
+                Operational -> Status.Operational
+                OperationalBothAssetAvailable -> Status.OperationalBothAssetAvailable
+                OperationalOnlySlideAssetAvailable -> Status.OperationalOnlySlideAssetAvailable
+                OperationalOnlyVideoAssetAvailable -> Status.OperationalOnlyVideoAssetAvailable
+                Error -> Status.Error
             },
         )
     }

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/TimetableItemDetailScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/TimetableItemDetailScreenRobot.kt
@@ -186,6 +186,13 @@ class TimetableItemDetailScreenRobot @Inject constructor(
         checkVideoAssetButtonDisplayed()
     }
 
+    fun checkAssetSectionDoesNotDisplayed() {
+        composeTestRule
+            .onAllNodes(hasTestTag(TimetableItemDetailContentArchiveSectionTestTag))
+            .onFirst()
+            .assertIsNotDisplayed()
+    }
+
     fun checkOnlySlideAssetButtonDisplayed() {
         checkSlideAssetButtonDisplayed()
         checkVideoAssetButtonDoesNotDisplayed()

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/TimetableItemDetailScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/TimetableItemDetailScreenRobot.kt
@@ -107,8 +107,8 @@ class TimetableItemDetailScreenRobot @Inject constructor(
             .onNode(hasTestTag(TimetableItemDetailScreenLazyColumnTestTag))
             .performScrollToNode(
                 hasTestTag(
-                    TimetableItemDetailContentTargetAudienceSectionBottomTestTag
-                )
+                    TimetableItemDetailContentTargetAudienceSectionBottomTestTag,
+                ),
             )
     }
 

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/TimetableItemDetailScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/TimetableItemDetailScreenRobot.kt
@@ -30,6 +30,7 @@ import io.github.droidkaigi.confsched.sessions.component.TargetAudienceSectionTe
 import io.github.droidkaigi.confsched.sessions.component.TimetableItemDetailContentArchiveSectionSlideButtonTestTag
 import io.github.droidkaigi.confsched.sessions.component.TimetableItemDetailContentArchiveSectionTestTag
 import io.github.droidkaigi.confsched.sessions.component.TimetableItemDetailContentArchiveSectionVideoButtonTestTag
+import io.github.droidkaigi.confsched.sessions.component.TimetableItemDetailContentTargetAudienceSectionBottomTestTag
 import io.github.droidkaigi.confsched.sessions.component.TimetableItemDetailHeadlineTestTag
 import io.github.droidkaigi.confsched.sessions.navigation.TimetableItemDetailDestination
 import javax.inject.Inject
@@ -99,6 +100,16 @@ class TimetableItemDetailScreenRobot @Inject constructor(
                     endY = visibleSize.height / 7F,
                 )
             }
+    }
+
+    fun scrollToBeforeAssetSection() {
+        composeTestRule
+            .onNode(hasTestTag(TimetableItemDetailScreenLazyColumnTestTag))
+            .performScrollToNode(
+                hasTestTag(
+                    TimetableItemDetailContentTargetAudienceSectionBottomTestTag
+                )
+            )
     }
 
     fun scrollToAssetSection() {

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/TimetableItemDetailScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/TimetableItemDetailScreenRobot.kt
@@ -1,7 +1,9 @@
 package io.github.droidkaigi.confsched.testing.robot
 
 import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasTestTag
@@ -11,6 +13,7 @@ import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToIndex
+import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeUp
 import com.github.takahirom.roborazzi.Dump
@@ -24,6 +27,9 @@ import io.github.droidkaigi.confsched.sessions.TimetableItemDetailScreenLazyColu
 import io.github.droidkaigi.confsched.sessions.component.DescriptionMoreButtonTestTag
 import io.github.droidkaigi.confsched.sessions.component.SummaryCardTextTag
 import io.github.droidkaigi.confsched.sessions.component.TargetAudienceSectionTestTag
+import io.github.droidkaigi.confsched.sessions.component.TimetableItemDetailContentArchiveSectionSlideButtonTestTag
+import io.github.droidkaigi.confsched.sessions.component.TimetableItemDetailContentArchiveSectionTestTag
+import io.github.droidkaigi.confsched.sessions.component.TimetableItemDetailContentArchiveSectionVideoButtonTestTag
 import io.github.droidkaigi.confsched.sessions.component.TimetableItemDetailHeadlineTestTag
 import io.github.droidkaigi.confsched.sessions.navigation.TimetableItemDetailDestination
 import javax.inject.Inject
@@ -93,6 +99,12 @@ class TimetableItemDetailScreenRobot @Inject constructor(
                     endY = visibleSize.height / 7F,
                 )
             }
+    }
+
+    fun scrollToAssetSection() {
+        composeTestRule
+            .onNode(hasTestTag(TimetableItemDetailScreenLazyColumnTestTag))
+            .performScrollToNode(hasTestTag(TimetableItemDetailContentArchiveSectionTestTag))
     }
 
     fun checkScreenCapture() {
@@ -167,6 +179,55 @@ class TimetableItemDetailScreenRobot @Inject constructor(
             .onNode(hasTestTag(DescriptionMoreButtonTestTag))
             .assertExists()
             .assertIsDisplayed()
+    }
+
+    fun checkBothAssetButtonDisplayed() {
+        checkSlideAssetButtonDisplayed()
+        checkVideoAssetButtonDisplayed()
+    }
+
+    fun checkOnlySlideAssetButtonDisplayed() {
+        checkSlideAssetButtonDisplayed()
+        checkVideoAssetButtonDoesNotDisplayed()
+    }
+
+    fun checkOnlyVideoAssetButtonDisplayed() {
+        checkSlideAssetButtonDoesNotDisplayed()
+        checkVideoAssetButtonDisplayed()
+    }
+
+    private fun checkSlideAssetButtonDisplayed() {
+        composeTestRule
+            .onAllNodes(hasTestTag(TimetableItemDetailContentArchiveSectionSlideButtonTestTag))
+            .onFirst()
+            .assertExists()
+            .assertIsDisplayed()
+            .assertHasClickAction()
+    }
+
+    private fun checkVideoAssetButtonDisplayed() {
+        composeTestRule
+            .onAllNodes(hasTestTag(TimetableItemDetailContentArchiveSectionVideoButtonTestTag))
+            .onFirst()
+            .assertExists()
+            .assertIsDisplayed()
+            .assertHasClickAction()
+    }
+
+    private fun checkSlideAssetButtonDoesNotDisplayed() {
+        composeTestRule
+            .onAllNodes(hasTestTag(TimetableItemDetailContentArchiveSectionSlideButtonTestTag))
+            .onFirst()
+            .assertIsNotDisplayed()
+            .assertDoesNotExist()
+    }
+
+    private fun checkVideoAssetButtonDoesNotDisplayed() {
+        composeTestRule
+            .onAllNodes(hasTestTag(TimetableItemDetailContentArchiveSectionVideoButtonTestTag))
+            .onFirst()
+            .assertIsNotDisplayed()
+            .assertDoesNotExist()
     }
 
     companion object {

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -840,10 +840,9 @@ internal fun CardScreen(
                             text = stringResource(ProfileCardRes.string.edit),
                             modifier = Modifier.padding(8.dp),
                             style = MaterialTheme.typography.labelLarge,
-                            color = Color.Black
+                            color = Color.Black,
                         )
                     }
-
                 }
             }
         }

--- a/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreenTest.kt
+++ b/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreenTest.kt
@@ -175,7 +175,7 @@ class TimetableItemDetailScreenTest(private val testCase: DescribedBehavior<Time
                             setupScreenContent()
                             scrollToAssetSection()
                         }
-                        itShould("both assets are displayed") {
+                        itShould("display both assets") {
                             captureScreenWithChecks {
                                 checkBothAssetButtonDisplayed()
                             }

--- a/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreenTest.kt
+++ b/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreenTest.kt
@@ -191,7 +191,7 @@ class TimetableItemDetailScreenTest(private val testCase: DescribedBehavior<Time
                             setupScreenContent()
                             scrollToAssetSection()
                         }
-                        itShould("only slide assets are displayed") {
+                        itShould("display only slide assets") {
                             captureScreenWithChecks {
                                 checkOnlySlideAssetButtonDisplayed()
                             }

--- a/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreenTest.kt
+++ b/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreenTest.kt
@@ -105,7 +105,7 @@ class TimetableItemDetailScreenTest(private val testCase: DescribedBehavior<Time
                             doIt {
                                 scrollLazyColumnByIndex(2)
                             }
-                            itShould("both assets does not displayed") {
+                            itShould("not display both assets") {
                                 captureScreenWithChecks {
                                     checkAssetSectionDoesNotDisplayed()
                                 }

--- a/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreenTest.kt
+++ b/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreenTest.kt
@@ -103,7 +103,7 @@ class TimetableItemDetailScreenTest(private val testCase: DescribedBehavior<Time
                         }
                         describe("when scroll to bottom") {
                             doIt {
-                                scrollLazyColumnByIndex(2)
+                                scrollToBeforeAssetSection()
                             }
                             itShould("not display both assets") {
                                 captureScreenWithChecks {

--- a/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreenTest.kt
+++ b/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreenTest.kt
@@ -207,7 +207,7 @@ class TimetableItemDetailScreenTest(private val testCase: DescribedBehavior<Time
                             setupScreenContent()
                             scrollToAssetSection()
                         }
-                        itShould("only video assets are displayed") {
+                        itShould("only display video assets") {
                             captureScreenWithChecks {
                                 checkOnlyVideoAssetButtonDisplayed()
                             }

--- a/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreenTest.kt
+++ b/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreenTest.kt
@@ -156,6 +156,54 @@ class TimetableItemDetailScreenTest(private val testCase: DescribedBehavior<Time
                         }
                     }
                 }
+                describe("when server is operational available both asset") {
+                    doIt {
+                        setupTimetableServer(ServerStatus.OperationalBothAssetAvailable)
+                    }
+                    describe("when launch") {
+                        doIt {
+                            setupScreenContent()
+                            scrollToAssetSection()
+                        }
+                        itShould("both assets are displayed") {
+                            captureScreenWithChecks {
+                                checkBothAssetButtonDisplayed()
+                            }
+                        }
+                    }
+                }
+                describe("when server is operational available only slide asset") {
+                    doIt {
+                        setupTimetableServer(ServerStatus.OperationalOnlySlideAssetAvailable)
+                    }
+                    describe("when launch") {
+                        doIt {
+                            setupScreenContent()
+                            scrollToAssetSection()
+                        }
+                        itShould("only slide assets are displayed") {
+                            captureScreenWithChecks {
+                                checkOnlySlideAssetButtonDisplayed()
+                            }
+                        }
+                    }
+                }
+                describe("when server is operational available only video asset") {
+                    doIt {
+                        setupTimetableServer(ServerStatus.OperationalOnlyVideoAssetAvailable)
+                    }
+                    describe("when launch") {
+                        doIt {
+                            setupScreenContent()
+                            scrollToAssetSection()
+                        }
+                        itShould("only video assets are displayed") {
+                            captureScreenWithChecks {
+                                checkOnlyVideoAssetButtonDisplayed()
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreenTest.kt
+++ b/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreenTest.kt
@@ -101,6 +101,16 @@ class TimetableItemDetailScreenTest(private val testCase: DescribedBehavior<Time
                                 )
                             }
                         }
+                        describe("when scroll to bottom") {
+                            doIt {
+                                scrollLazyColumnByIndex(2)
+                            }
+                            itShould("both assets does not displayed") {
+                                captureScreenWithChecks {
+                                    checkAssetSectionDoesNotDisplayed()
+                                }
+                            }
+                        }
                     }
                     describe("when the description is lengthy") {
                         doIt {

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailContent.kt
@@ -52,6 +52,9 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 
 const val TargetAudienceSectionTestTag = "TargetAudienceSectionTestTag"
 const val DescriptionMoreButtonTestTag = "DescriptionMoreButtonTestTag"
+const val TimetableItemDetailContentArchiveSectionTestTag = "TimetableItemDetailContentArchiveSectionTestTag"
+const val TimetableItemDetailContentArchiveSectionSlideButtonTestTag = "TimetableItemDetailContentArchiveSectionSlideButtonTestTag"
+const val TimetableItemDetailContentArchiveSectionVideoButtonTestTag = "TimetableItemDetailContentArchiveSectionVideoButtonTestTag"
 
 @Composable
 fun TimetableItemDetailContent(
@@ -171,7 +174,10 @@ private fun ArchiveSection(
     modifier: Modifier = Modifier,
     onWatchVideoClick: (url: String) -> Unit,
 ) {
-    Column(modifier = modifier.padding(8.dp)) {
+    Column(modifier = modifier
+        .padding(8.dp)
+        .testTag(TimetableItemDetailContentArchiveSectionTestTag)
+    ) {
         Text(
             text = stringResource(SessionsRes.string.archive),
             style = MaterialTheme.typography.titleLarge,
@@ -183,7 +189,9 @@ private fun ArchiveSection(
         ) {
             timetableItem.asset.slideUrl?.let { slideUrl ->
                 Button(
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier
+                        .weight(1f)
+                        .testTag(TimetableItemDetailContentArchiveSectionSlideButtonTestTag),
                     onClick = { onViewSlideClick(slideUrl) },
                     colors = ButtonDefaults.buttonColors().copy(
                         containerColor = LocalRoomTheme.current.primaryColor,
@@ -194,7 +202,7 @@ private fun ArchiveSection(
                         contentDescription = stringResource(SessionsRes.string.slide),
                     )
                     Text(
-                        text = "スライド",
+                        text = stringResource(SessionsRes.string.slide),
                         style = MaterialTheme.typography.labelLarge,
                     )
                 }
@@ -202,7 +210,9 @@ private fun ArchiveSection(
             timetableItem.asset.videoUrl?.let { videoUrl ->
                 Spacer(modifier = Modifier.width(8.dp))
                 Button(
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier
+                        .weight(1f)
+                        .testTag(TimetableItemDetailContentArchiveSectionVideoButtonTestTag),
                     onClick = { onWatchVideoClick(videoUrl) },
                     colors = ButtonDefaults.buttonColors().copy(
                         containerColor = LocalRoomTheme.current.primaryColor,
@@ -213,7 +223,7 @@ private fun ArchiveSection(
                         contentDescription = stringResource(SessionsRes.string.video),
                     )
                     Text(
-                        text = "動画",
+                        text = stringResource(SessionsRes.string.video),
                         style = MaterialTheme.typography.labelLarge,
                     )
                 }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailContent.kt
@@ -55,6 +55,7 @@ const val DescriptionMoreButtonTestTag = "DescriptionMoreButtonTestTag"
 const val TimetableItemDetailContentArchiveSectionTestTag = "TimetableItemDetailContentArchiveSectionTestTag"
 const val TimetableItemDetailContentArchiveSectionSlideButtonTestTag = "TimetableItemDetailContentArchiveSectionSlideButtonTestTag"
 const val TimetableItemDetailContentArchiveSectionVideoButtonTestTag = "TimetableItemDetailContentArchiveSectionVideoButtonTestTag"
+const val TimetableItemDetailContentTargetAudienceSectionBottomTestTag = "TimetableItemDetailContentTargetAudienceSectionBottomTestTag"
 
 @Composable
 fun TimetableItemDetailContent(
@@ -163,7 +164,7 @@ private fun TargetAudienceSection(
             text = timetableItem.targetAudience,
             style = MaterialTheme.typography.bodyLarge,
         )
-        Spacer(Modifier.height(8.dp))
+        Spacer(Modifier.height(8.dp).testTag(TimetableItemDetailContentTargetAudienceSectionBottomTestTag))
     }
 }
 

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailContent.kt
@@ -174,9 +174,10 @@ private fun ArchiveSection(
     modifier: Modifier = Modifier,
     onWatchVideoClick: (url: String) -> Unit,
 ) {
-    Column(modifier = modifier
-        .padding(8.dp)
-        .testTag(TimetableItemDetailContentArchiveSectionTestTag)
+    Column(
+        modifier = modifier
+            .padding(8.dp)
+            .testTag(TimetableItemDetailContentArchiveSectionTestTag),
     ) {
         Text(
             text = stringResource(SessionsRes.string.archive),


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- The asset section will not be displayed until after DroidKaigi2024 has ended.
- However, there is currently no test for that part.
- So, I added a test to check that it displays properly after the event is over.
- In the process, I realized that the asset section would not be displayed unless both the slides and the video were present, so I also fixed that part.