### PR TITLE
:wrench: [ShareableCard] The image used when sharing profile cards has been changed to match the one used in Figma.

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -840,10 +840,9 @@ internal fun CardScreen(
                             text = stringResource(ProfileCardRes.string.edit),
                             modifier = Modifier.padding(8.dp),
                             style = MaterialTheme.typography.labelLarge,
-                            color = Color.Black
+                            color = Color.Black,
                         )
                     }
-
                 }
             }
         }

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/ShareableCard.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/ShareableCard.kt
@@ -98,7 +98,7 @@ private fun ShareableCardContent(
                     bitmap = it,
                     contentDescription = null,
                     modifier = Modifier
-                        .offset(x = 70.dp, y = 15.dp)
+                        .offset(x = 70.dp, y = 35.dp)
                         .rotate(10f)
                         .size(150.dp, 190.dp),
                 )
@@ -108,7 +108,7 @@ private fun ShareableCardContent(
                     bitmap = it,
                     contentDescription = null,
                     modifier = Modifier
-                        .offset(x = (-70).dp, y = (-15).dp)
+                        .offset(x = (-70).dp, y = (-35).dp)
                         .rotate(-10f)
                         .size(150.dp, 190.dp),
                 )


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- The image when sharing is slightly different from the one in Figma, so I made some adjustments.

## Links
- https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=58136-36586&t=ylgkTmFHRoWS9rw9-4

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/77126a71-2323-4cd0-8177-3a42293654bd" width="300" /> | <img src="https://github.com/user-attachments/assets/fa13d126-f35d-4afe-8840-b27c586e1d72" width="300" />