### PR TITLE
[iOS] Run SwiftLint properly

### DIFF
--- a/app-ios/.swiftlint.yml
+++ b/app-ios/.swiftlint.yml
@@ -9,9 +9,9 @@ opt_in_rules:
 
 included:
   - App/DroidKaigi2024
-  - Modules/Package.swift
-  - Modules/Sources
-  - Modules/Tests
+  - Package.swift
+  - Sources
+  - Tests
 
 identifier_name:
   min_length: 2


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- This PR fixes invalid included paths in the configuration to run SwiftLint properly:

```
Error: No lintable files found at paths: ''
```

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
