### PR TITLE
Introduce auto sizing for all app bar title components

### DIFF
--- a/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/component/AutoSizeText.kt
+++ b/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/component/AutoSizeText.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFontFamilyResolver
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.Paragraph
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
@@ -34,7 +35,7 @@ fun AutoSizeText(
     color: Color = Color.Unspecified,
 ) {
     BoxWithConstraints(
-        modifier = modifier,
+        modifier = modifier.semantics(mergeDescendants = true) {},
         contentAlignment = when (textAlign) {
             TextAlign.Left, TextAlign.Start -> Alignment.CenterStart
             TextAlign.Center -> Alignment.Center

--- a/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/component/AutoSizeText.kt
+++ b/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/component/AutoSizeText.kt
@@ -109,7 +109,7 @@ private fun BoxWithConstraintsScope.calculateFontSize(
     }
 
     // After the binary search, the right pointer is the largest size
-    // that still works without overflowing the box'
+    // that still works without overflowing the box
     return hi.asTextUnit(type)
 }
 

--- a/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/component/AutoSizeText.kt
+++ b/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/component/AutoSizeText.kt
@@ -1,0 +1,94 @@
+package io.github.droidkaigi.confsched.designsystem.component
+
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.BoxWithConstraintsScope
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFontFamilyResolver
+import androidx.compose.ui.text.Paragraph
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.TextUnit
+import kotlin.math.ceil
+
+/**
+ * A [Text] component that automatically downsizes its font size to fit its content,
+ * with the upper bound being defined by the font size of its [style].
+ */
+@Composable
+fun AutoSizeText(
+    text: String,
+    modifier: Modifier = Modifier,
+    textAlign: TextAlign = TextAlign.Unspecified,
+    maxLines: Int = Int.MAX_VALUE,
+    style: TextStyle = LocalTextStyle.current,
+    color: Color = Color.Unspecified,
+) {
+    BoxWithConstraints(
+        modifier = modifier,
+        contentAlignment = when (textAlign) {
+            TextAlign.Left, TextAlign.Start -> Alignment.CenterStart
+            TextAlign.Center -> Alignment.Center
+            TextAlign.Right, TextAlign.End -> Alignment.CenterEnd
+            TextAlign.Justify -> Alignment.Center
+            else -> Alignment.CenterStart
+        },
+    ) {
+        Text(
+            text = text,
+            color = color,
+            fontSize = calculateFontSize(text, style, color, textAlign, maxLines),
+            style = style,
+            maxLines = maxLines,
+            textAlign = textAlign,
+        )
+    }
+}
+
+@Composable
+private fun BoxWithConstraintsScope.calculateFontSize(
+    text: String,
+    style: TextStyle,
+    color: Color,
+    textAlign: TextAlign,
+    maxLines: Int,
+): TextUnit = with(LocalDensity.current) {
+    // Upper bound of the font size, will decrease in the `while` loop below
+    var targetFontSize = style.fontSize
+
+    // Calculate the text layout using the current `targetFontSize`
+    val calculateParagraph = @Composable {
+        val finalStyle = style.merge(
+            TextStyle(
+                color = color,
+                fontSize = targetFontSize,
+                textAlign = textAlign,
+            ),
+        )
+
+        Paragraph(
+            text = text,
+            style = finalStyle,
+            maxLines = maxLines,
+            constraints = Constraints(maxWidth = ceil(maxWidth.toPx()).toInt()),
+            density = this,
+            fontFamilyResolver = LocalFontFamilyResolver.current,
+        )
+    }
+
+    var paragraph = calculateParagraph()
+
+    // Keep decreasing the font size until the text fits in the box without exceeding the max lines
+    while (paragraph.didExceedMaxLines || maxHeight < paragraph.height.toDp() || maxWidth < paragraph.minIntrinsicWidth.toDp()) {
+        targetFontSize *= 0.95
+        paragraph = calculateParagraph()
+    }
+
+    targetFontSize
+}

--- a/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/component/AutoSizeText.kt
+++ b/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/component/AutoSizeText.kt
@@ -96,7 +96,7 @@ private fun BoxWithConstraintsScope.rememberFontSize(
         // If the original text size fits already without overflowing,
         // then there is no need to do anything
         if (!style.fontSize.hasOverflowWhenPlaced()) {
-            style.fontSize
+            return@remember style.fontSize
         }
 
         // Otherwise, find the biggest font size that still fits using binary search

--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/AnimatedLargeTopAppBar.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/AnimatedLargeTopAppBar.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarColors
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -29,6 +28,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import io.github.droidkaigi.confsched.designsystem.component.AutoSizeText
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -68,7 +68,7 @@ fun AnimatedLargeTopAppBar(
                 // No animation required as it is erased with alpha
                 exit = ExitTransition.None,
             ) {
-                Text(
+                AutoSizeText(
                     text = title,
                     modifier = Modifier.then(
                         when (isCenterTitle) {
@@ -82,6 +82,7 @@ fun AnimatedLargeTopAppBar(
                         },
                     ),
                     textAlign = TextAlign.Center,
+                    maxLines = 1,
                 )
             }
         },

--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/AnimatedMediumTopAppBar.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/AnimatedMediumTopAppBar.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MediumTopAppBar
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarColors
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -29,6 +28,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import io.github.droidkaigi.confsched.designsystem.component.AutoSizeText
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -68,7 +68,7 @@ fun AnimatedMediumTopAppBar(
                 // No animation required as it is erased with alpha
                 exit = ExitTransition.None,
             ) {
-                Text(
+                AutoSizeText(
                     text = title,
                     modifier = Modifier.then(
                         when (isCenterTitle) {
@@ -77,11 +77,13 @@ fun AnimatedMediumTopAppBar(
                                     .padding(end = navigationIconWidthDp.dp)
                                     .fillMaxWidth()
                             }
+
                             false -> Modifier
                             null -> Modifier.alpha(0f)
                         },
                     ),
                     textAlign = TextAlign.Center,
+                    maxLines = 1,
                 )
             }
         },

--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/AnimatedTextTopAppBar.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/AnimatedTextTopAppBar.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarColors
 import androidx.compose.material3.TopAppBarDefaults
@@ -17,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.style.TextAlign
+import io.github.droidkaigi.confsched.designsystem.component.AutoSizeText
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -38,7 +38,7 @@ fun AnimatedTextTopAppBar(
     TopAppBar(
         title = {
             Box(modifier = Modifier.fillMaxWidth()) {
-                Text(
+                AutoSizeText(
                     text = title,
                     color = textColor,
                     modifier = Modifier
@@ -47,10 +47,11 @@ fun AnimatedTextTopAppBar(
                             alpha = 1f - transitionFraction
                         },
                     textAlign = TextAlign.Start,
+                    maxLines = 1,
                     style = MaterialTheme.typography.headlineSmall,
                 )
 
-                Text(
+                AutoSizeText(
                     text = title,
                     color = textColor,
                     modifier = Modifier
@@ -60,6 +61,7 @@ fun AnimatedTextTopAppBar(
                             alpha = transitionFraction
                         },
                     textAlign = TextAlign.Center,
+                    maxLines = 1,
                     style = MaterialTheme.typography.titleMedium,
                 )
             }

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/TimetableScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/TimetableScreenRobot.kt
@@ -27,11 +27,13 @@ import io.github.droidkaigi.confsched.model.DroidKaigi2024Day
 import io.github.droidkaigi.confsched.model.TimetableItem
 import io.github.droidkaigi.confsched.sessions.TimetableScreen
 import io.github.droidkaigi.confsched.sessions.TimetableScreenTestTag
+import io.github.droidkaigi.confsched.sessions.TimetableTitleTestTag
 import io.github.droidkaigi.confsched.sessions.TimetableUiTypeChangeButtonTestTag
 import io.github.droidkaigi.confsched.sessions.component.TimetableGridItemTestTag
 import io.github.droidkaigi.confsched.sessions.section.TimetableGridTestTag
 import io.github.droidkaigi.confsched.sessions.section.TimetableListTestTag
 import io.github.droidkaigi.confsched.sessions.section.TimetableTabTestTag
+import io.github.droidkaigi.confsched.testing.utils.assertLineCount
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
@@ -41,9 +43,11 @@ class TimetableScreenRobot @Inject constructor(
     private val screenRobot: DefaultScreenRobot,
     private val timetableServerRobot: DefaultTimetableServerRobot,
     private val deviceSetupRobot: DefaultDeviceSetupRobot,
+    fontScaleRobot: DefaultFontScaleRobot,
 ) : ScreenRobot by screenRobot,
     TimetableServerRobot by timetableServerRobot,
-    DeviceSetupRobot by deviceSetupRobot {
+    DeviceSetupRobot by deviceSetupRobot,
+    FontScaleRobot by fontScaleRobot {
     val clickedItems = mutableSetOf<TimetableItem>()
 
     fun setupTimetableScreenContent(customTime: LocalDateTime? = null) {
@@ -66,6 +70,12 @@ class TimetableScreenRobot @Inject constructor(
             }
         }
         waitUntilIdle()
+    }
+
+    fun checkTitleDisplayedInSingleLine() {
+        composeTestRule
+            .onNode(hasTestTag(TimetableTitleTestTag))
+            .assertLineCount(1)
     }
 
     fun clickFirstSession() {

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/utils/Matchers.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/utils/Matchers.kt
@@ -1,12 +1,15 @@
 package io.github.droidkaigi.confsched.testing.utils
 
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SemanticsNodeInteractionCollection
+import androidx.compose.ui.text.TextLayoutResult
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 
 fun hasTestTag(
     testTag: String,
@@ -62,6 +65,22 @@ fun SemanticsNodeInteraction.assertTextDoesNotContain(
             assertFalse(
                 "Node text contains unexpected substring: $substring",
                 textContent?.contains(substring) ?: false,
+            )
+        }
+}
+
+fun SemanticsNodeInteraction.assertLineCount(expectedCount: Int) {
+    fetchSemanticsNode()
+        .let { node ->
+            val results = mutableListOf<TextLayoutResult>()
+            node.config.getOrNull(SemanticsActions.GetTextLayoutResult)
+                ?.action
+                ?.invoke(results)
+            val result = results.firstOrNull()
+
+            assertTrue(
+                "Node has unexpected line count (expected $expectedCount, but was ${result?.lineCount})",
+                result?.lineCount == expectedCount,
             )
         }
 }

--- a/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
+++ b/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
@@ -128,6 +128,18 @@ class TimetableScreenTest(private val testCase: DescribedBehavior<TimetableScree
                         }
                     }
                 }
+                describe("when font scale is large") {
+                    doIt {
+                        setFontScale(3f)
+                        setupTimetableServer(ServerStatus.Operational)
+                        setupTimetableScreenContent()
+                    }
+                    itShould("show title in a single line") {
+                        captureScreenWithChecks(checks = {
+                            checkTitleDisplayedInSingleLine()
+                        })
+                    }
+                }
                 listOf(
                     InitialTabTestSpec(
                         date = LocalDate(2024, 9, 11),

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
@@ -65,6 +65,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 const val timetableScreenRoute = "timetable"
+const val TimetableTitleTestTag = "TimetableTitle"
 const val TimetableUiTypeChangeButtonTestTag = "TimetableUiTypeChangeButton"
 fun NavGraphBuilder.nestedSessionScreens(
     onSearchClick: () -> Unit,
@@ -158,7 +159,7 @@ private fun TimetableScreen(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         AutoSizeText(
-                            modifier = Modifier.weight(1f),
+                            modifier = Modifier.testTag(TimetableTitleTestTag).weight(1f),
                             text = stringResource(SessionsRes.string.timetable),
                             style = MaterialTheme.typography.headlineSmall,
                             maxLines = 1,

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
@@ -18,10 +18,10 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -31,9 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
@@ -47,6 +45,7 @@ import conference_app_2024.feature.sessions.generated.resources.timeline_view
 import conference_app_2024.feature.sessions.generated.resources.timetable
 import io.github.droidkaigi.confsched.compose.EventFlow
 import io.github.droidkaigi.confsched.compose.rememberEventFlow
+import io.github.droidkaigi.confsched.designsystem.component.AutoSizeText
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.droidkaigiui.SnackbarMessageEffect
 import io.github.droidkaigi.confsched.droidkaigiui.UserMessageStateHolder
@@ -158,12 +157,11 @@ private fun TimetableScreen(
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Text(
+                        AutoSizeText(
+                            modifier = Modifier.weight(1f),
                             text = stringResource(SessionsRes.string.timetable),
-                            fontSize = 24.sp,
-                            lineHeight = 32.sp,
-                            fontWeight = FontWeight.W400,
-                            modifier = Modifier.weight(1F),
+                            style = MaterialTheme.typography.headlineSmall,
+                            maxLines = 1,
                         )
                         IconButton(
                             onClick = dropUnlessResumed(block = onSearchClick),


### PR DESCRIPTION
## Issue
- close #757

## Overview (Required)
- Introduce `AutoSizeText`, a component that automatically finds the correct size to fit a text into a box
  - The maximum font size is defined by the `style` of the text, but it will shrink if necessary
  - It uses a binary search to find the biggest size that fits in a given number of lines
- Apply it to all titles in every top app bar of the app
  - The custom app bar of `TimetableScreen`
  - `AnimatedTextTopAppBar` (fix for the main tabs on the home screen)
  - `AnimatedMediumTopAppBar` (fix for contributor, sponsor, staff, settings screens)

## Movie (Optional)

### Before
Tabs (Large Font) | Tabs (Normal Font) | Contributor Screen
:--: | :--: | :--:
<video src="https://github.com/user-attachments/assets/37fd5583-1ea1-42f7-8382-0ff4f128804a" width="300" > | <video src="https://github.com/user-attachments/assets/fc0de7c7-07b0-4d41-bbc5-34f07dee4358" width="300" > | <video src="https://github.com/user-attachments/assets/16b4b211-dc82-490e-9de7-27f9e446d235" width="300" >


### After
Tabs (Large Font) | Tabs (Normal Font) | Contributor Screen
:--: | :--: | :--:
<video src="https://github.com/user-attachments/assets/2e1e6747-5b1d-4dbc-9d93-85f2aa2ef089" width="300" > | <video src="https://github.com/user-attachments/assets/d726ddba-436f-4c42-8aa9-6461f2de7d9b" width="300" > | <video src="https://github.com/user-attachments/assets/b94f0f7c-f757-476d-855a-8a5d517d0fdb" width="300" >




