### PR TITLE
Update style of links inside a ClickableLinkText to match the design

### DIFF
--- a/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/component/ClickableLinkText.kt
+++ b/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/component/ClickableLinkText.kt
@@ -19,9 +19,9 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import io.github.droidkaigi.confsched.designsystem.theme.RoomTheme
 
 private const val ClickableTextExpandAnimateDurationMillis = 300
 
@@ -58,9 +58,8 @@ private fun getAnnotatedString(
             val endIndex = startIndex + matchResult.value.length
             addStyle(
                 style = SpanStyle(
-                    color = MaterialTheme.colorScheme.primary,
+                    color = RoomTheme.Jellyfish.primaryColor,
                     textDecoration = TextDecoration.Underline,
-                    fontWeight = FontWeight.Bold,
                 ),
                 start = startIndex,
                 end = endIndex,

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -840,10 +840,9 @@ internal fun CardScreen(
                             text = stringResource(ProfileCardRes.string.edit),
                             modifier = Modifier.padding(8.dp),
                             style = MaterialTheme.typography.labelLarge,
-                            color = Color.Black
+                            color = Color.Black,
                         )
                     }
-
                 }
             }
         }


### PR DESCRIPTION
## Issue
- close #884

## Overview (Required)
- Change the weight and color of links embedded in a `ClickableLinkText`, e.g. on the "About DroidKaigi" screen

## Screenshot (Optional if screenshot test is present or unrelated to UI)

**Figma**

<img src="https://github.com/user-attachments/assets/6f93a79a-6e65-40c6-b8ab-4bbc4259d265" width="300" />

Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/308926e3-a74f-4e54-b10a-145a517a076b" width="300" /> | <img src="https://github.com/user-attachments/assets/c0efadf0-57d9-4d46-806c-92110027ee2e" width="300" />

