### PR TITLE
:wrench: [ShareableCardContent] Fixed so that profile photos are always output at a fixed size, regardless of the device's resolution, portrait or landscape orientation.

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -840,10 +840,9 @@ internal fun CardScreen(
                             text = stringResource(ProfileCardRes.string.edit),
                             modifier = Modifier.padding(8.dp),
                             style = MaterialTheme.typography.labelLarge,
-                            color = Color.Black
+                            color = Color.Black,
                         )
                     }
-
                 }
             }
         }

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/ShareableCard.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/ShareableCard.kt
@@ -106,7 +106,7 @@ private fun ShareableCardContent(
                 width = with(density) { widthPx.toDp() },
                 height = with(density) { heightPx.toDp() },
             )
-            .background(LocalProfileCardTheme.current.primaryColor)
+            .background(LocalProfileCardTheme.current.primaryColor),
     ) {
         Box(modifier = Modifier.padding(vertical = 30.dp)) {
             backImage?.let {

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/ShareableCard.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/ShareableCard.kt
@@ -92,10 +92,10 @@ private fun ShareableCardContent(
     val heightPx = 630
     val cardWidthPx = 300
     val cardHeightPx = 380
-    val offsetXBackPx = 140f
-    val offsetYBackPx = 75f
-    val offsetXFrontPx = -140f
-    val offsetYFrontPx = -75f
+    val offsetXBackPx = 148f
+    val offsetYBackPx = 76f
+    val offsetXFrontPx = -136f
+    val offsetYFrontPx = -61f
 
     val density = LocalDensity.current
 
@@ -134,7 +134,7 @@ private fun ShareableCardContent(
                             x = with(density) { offsetXFrontPx.toDp() },
                             y = with(density) { offsetYFrontPx.toDp() },
                         )
-                        .rotate(-10f)
+                        .rotate(-12.2f)
                         .size(
                             width = with(density) { cardWidthPx.toDp() },
                             height = with(density) { cardHeightPx.toDp() },

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/ShareableCard.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/ShareableCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -21,6 +22,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImagePainter
@@ -86,21 +88,41 @@ private fun ShareableCardContent(
     backImage: ImageBitmap?,
     modifier: Modifier = Modifier,
 ) {
-    Box(modifier = modifier) {
-        Box(
-            contentAlignment = Alignment.Center,
-            modifier = Modifier
-                .background(LocalProfileCardTheme.current.primaryColor)
-                .padding(vertical = 50.dp, horizontal = 120.dp),
-        ) {
+    val widthPx = 1200
+    val heightPx = 630
+    val cardWidthPx = 300
+    val cardHeightPx = 380
+    val offsetXBackPx = 140f
+    val offsetYBackPx = 75f
+    val offsetXFrontPx = -140f
+    val offsetYFrontPx = -75f
+
+    val density = LocalDensity.current
+
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .requiredSize(
+                width = with(density) { widthPx.toDp() },
+                height = with(density) { heightPx.toDp() },
+            )
+            .background(LocalProfileCardTheme.current.primaryColor)
+    ) {
+        Box(modifier = Modifier.padding(vertical = 30.dp)) {
             backImage?.let {
                 Image(
                     bitmap = it,
                     contentDescription = null,
                     modifier = Modifier
-                        .offset(x = 70.dp, y = 15.dp)
+                        .offset(
+                            x = with(density) { offsetXBackPx.toDp() },
+                            y = with(density) { offsetYBackPx.toDp() },
+                        )
                         .rotate(10f)
-                        .size(150.dp, 190.dp),
+                        .size(
+                            width = with(density) { cardWidthPx.toDp() },
+                            height = with(density) { cardHeightPx.toDp() },
+                        ),
                 )
             }
             frontImage?.let {
@@ -108,9 +130,15 @@ private fun ShareableCardContent(
                     bitmap = it,
                     contentDescription = null,
                     modifier = Modifier
-                        .offset(x = (-70).dp, y = (-15).dp)
+                        .offset(
+                            x = with(density) { offsetXFrontPx.toDp() },
+                            y = with(density) { offsetYFrontPx.toDp() },
+                        )
                         .rotate(-10f)
-                        .size(150.dp, 190.dp),
+                        .size(
+                            width = with(density) { cardWidthPx.toDp() },
+                            height = with(density) { cardHeightPx.toDp() },
+                        ),
                 )
             }
         }


### PR DESCRIPTION
## Issue
- close #890

## Overview (Required)
- Until now, the size of the image output by the profile card has varied depending on the resolution of the device each person is using.
- By incorporating this change to the repository, the image will be output at the size and position as designed, regardless of the resolution of the device or whether it is in portrait or landscape mode.

## Links
- https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=58136-36586&t=JyZS9Bhf38VcrbFM-4

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Small Phone | Pixel 7 Pro
:--: | :--:
<img src="https://github.com/user-attachments/assets/81533e6f-db0b-4f9b-84fc-77c8bdb59953" width="300" /> | <img src="https://github.com/user-attachments/assets/72d2120c-1c6a-4af3-8596-4a1db33b18b1" width="300" />

Pixel 2 | Pixel 3a
:--: | :--:
<img src="https://github.com/user-attachments/assets/693f9b28-781a-4888-a40b-1a708ea959b0" width="300" /> | <img src="https://github.com/user-attachments/assets/3f100431-ae21-41e6-a4c5-27ebadf4e6a4" width="300" />

Pixel 3 XL | Pixel 8 Pro
:--: | :--:
<img src="https://github.com/user-attachments/assets/d2f64db5-343f-4446-bde0-537e68e9e435" width="300" /> | <img src="https://github.com/user-attachments/assets/d605abba-660b-4fc0-9d82-7bece37e3216" width="300" />