### PR TITLE
Fix: concurrency strict warnings in EventKitClient

### DIFF
--- a/app-ios/Sources/EventKitClient/EventKitClient.swift
+++ b/app-ios/Sources/EventKitClient/EventKitClient.swift
@@ -1,6 +1,5 @@
 import ComposableArchitecture
 import Foundation
-@preconcurrency import EventKit
 
 extension DependencyValues {
     public var eventKitClient: EventKitClient {
@@ -11,7 +10,6 @@ extension DependencyValues {
 
 @DependencyClient
 public struct EventKitClient: Sendable {
-    static let eventStore: EKEventStore = .init()
     public var requestAccessIfNeeded: @Sendable () async throws -> Bool
     public var addEvent: @Sendable (_ title: String, _ startDate: Date, _ endDate: Date) throws -> Void
 }

--- a/app-ios/Sources/EventKitClient/LiveKey.swift
+++ b/app-ios/Sources/EventKitClient/LiveKey.swift
@@ -1,32 +1,39 @@
 import Dependencies
-import EventKit
+@preconcurrency import EventKit
 import UIKit
 
 extension EventKitClient: DependencyKey {
-    public static let liveValue: Self = Self {
-        switch EKEventStore.authorizationStatus(for: .event) {
-        case .denied, .restricted:
-            Task.detached { @MainActor in
-                _ = await UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
-            }
-        case .authorized, .fullAccess, .writeOnly:
-            return true
-        case .notDetermined:
-            break
-        @unknown default:
-            break
-        }
-        return try await eventStore.requestWriteOnlyAccessToEvents()
-    } addEvent: { title, startDate, endDate in
-        guard let defaultCalendar = eventStore.defaultCalendarForNewEvents else {
-            return
-        }
-        let event = EKEvent(eventStore: eventStore)
-        event.title = title
-        event.startDate = startDate
-        event.endDate = endDate
-        event.calendar = defaultCalendar
+    public static var liveValue: Self {
+        let eventStore = EKEventStore()
 
-        try eventStore.save(event, span: .thisEvent)
+        return Self(
+            requestAccessIfNeeded: {
+                switch EKEventStore.authorizationStatus(for: .event) {
+                case .denied, .restricted:
+                    Task.detached { @MainActor in
+                        _ = await UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+                    }
+                case .authorized, .fullAccess, .writeOnly:
+                        return true
+                    case .notDetermined:
+                        break
+                @unknown default:
+                    break
+                }
+                return try await eventStore.requestWriteOnlyAccessToEvents()
+            },
+            addEvent: { title, startDate, endDate in
+                guard let defaultCalendar = eventStore.defaultCalendarForNewEvents else {
+                    return
+                }
+                let event = EKEvent(eventStore: eventStore)
+                event.title = title
+                event.startDate = startDate
+                event.endDate = endDate
+                event.calendar = defaultCalendar
+
+                try eventStore.save(event, span: .thisEvent)
+            }
+        )
     }
 }

--- a/app-ios/Sources/EventKitClient/LiveKey.swift
+++ b/app-ios/Sources/EventKitClient/LiveKey.swift
@@ -11,7 +11,9 @@ extension EventKitClient: DependencyKey {
                 switch EKEventStore.authorizationStatus(for: .event) {
                 case .denied, .restricted:
                     Task.detached { @MainActor in
-                        _ = await UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+                        _ = await UIApplication.shared.open(
+                            .init(string: UIApplication.openSettingsURLString)!
+                        )
                     }
                 case .authorized, .fullAccess, .writeOnly:
                         return true


### PR DESCRIPTION
## Issue
- in progress #431

## Overview (Required)
- This addresses the issue where making EKEventStore a static let triggers the following warning:
  - ```Static property eventStore is not concurrency-safe because it is not either conforming to Sendable or isolated to a global actor; this is an error in Swift 6.```

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
![スクリーンショット 2024-08-31 12 05 16](https://github.com/user-attachments/assets/d713fe27-619e-4557-abcf-8403e92d4d56) | ![スクリーンショット 2024-08-31 13 41 49](https://github.com/user-attachments/assets/c2fe46f8-5a25-4a3a-a3a8-ee7e21e29edc)

## Movie (Optional)
Before | After
:--: | :--:

<video src="" width="300" > | <video src="" width="300" >




