### PR TITLE
Add URL validation

### DIFF
--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/ProfileCardScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/ProfileCardScreenRobot.kt
@@ -14,6 +14,7 @@ import io.github.droidkaigi.confsched.profilecard.ProfileCardCardScreenTestTag
 import io.github.droidkaigi.confsched.profilecard.ProfileCardCreateButtonTestTag
 import io.github.droidkaigi.confsched.profilecard.ProfileCardEditButtonTestTag
 import io.github.droidkaigi.confsched.profilecard.ProfileCardEditScreenColumnTestTag
+import io.github.droidkaigi.confsched.profilecard.ProfileCardInputErrorTextTestTag
 import io.github.droidkaigi.confsched.profilecard.ProfileCardLinkTextFieldTestTag
 import io.github.droidkaigi.confsched.profilecard.ProfileCardNicknameTextFieldTestTag
 import io.github.droidkaigi.confsched.profilecard.ProfileCardOccupationTextFieldTestTag
@@ -138,6 +139,14 @@ class ProfileCardScreenRobot @Inject constructor(
         composeTestRule
             .onNode(hasTestTag(ProfileCardLinkTextFieldTestTag))
             .assertTextEquals(link)
+    }
+
+    fun checkLinkError(
+        link: String,
+    ) {
+        composeTestRule
+            .onNode(hasTestTag(ProfileCardInputErrorTextTestTag.plus(link)))
+            .assertIsDisplayed()
     }
 
     fun checkCardScreenDisplayed() {

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/ProfileCardScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/ProfileCardScreenRobot.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched.testing.robot
 import android.graphics.RenderNode
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasTestTag
@@ -147,6 +148,14 @@ class ProfileCardScreenRobot @Inject constructor(
         composeTestRule
             .onNode(hasTestTag(ProfileCardInputErrorTextTestTag.plus(link)))
             .assertIsDisplayed()
+    }
+
+    fun checkLinkNotError(
+        link: String,
+    ) {
+        composeTestRule
+            .onNode(hasTestTag(ProfileCardInputErrorTextTestTag.plus(link)))
+            .assertIsNotDisplayed()
     }
 
     fun checkCardScreenDisplayed() {

--- a/feature/profilecard/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenTest.kt
+++ b/feature/profilecard/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenTest.kt
@@ -49,20 +49,66 @@ class ProfileCardScreenTest(
                             checkEditScreenDisplayed()
                         }
                     }
-                    // FIXME Add a test to confirm that it is possible to transition to the Card screen after entering the required input fields, including images.
-                    // FIXME Currently, the test code does not allow the user to select and input an image from the Add Image button.
-                    describe("when url is invalid") {
-                        // This Url is invalid because it does not have a domain name like "https://not-valid-url.com".
-                        val invalidUrl = "https://not-valid-url"
+
+                    describe("when url protocol is invalid") {
+                        val url = "ttps://example.com"
                         doIt {
-                            inputLink(invalidUrl)
+                            inputLink("ttps://example.com")
                         }
                         itShould("show error message") {
                             captureScreenWithChecks {
-                                checkLinkError(invalidUrl)
+                                checkLinkError(url)
                             }
                         }
                     }
+
+                    describe("when url top level domain is missing") {
+                        val url = "https://example"
+                        doIt {
+                            inputLink(url)
+                        }
+                        itShould("show error message") {
+                            captureScreenWithChecks {
+                                checkLinkError(url)
+                            }
+                        }
+                    }
+                    describe("when url contains IDN domain name") {
+                        val url = "https://example.xn--com"
+                        doIt {
+                            inputLink(url)
+                        }
+                        itShould("not show error message") {
+                            captureScreenWithChecks {
+                                checkLinkNotError(url)
+                            }
+                        }
+                    }
+                    describe("when protocol is missing") {
+                        val url = "example.com/foobar"
+                        doIt {
+                            inputLink(url)
+                        }
+                        itShould("not show error message") {
+                            captureScreenWithChecks {
+                                checkLinkNotError(url)
+                            }
+                        }
+                    }
+                    describe("when url contains sub domain") {
+                        val url = "https://www.example.co.jp/foobar"
+                        doIt {
+                            inputLink(url)
+                        }
+                        itShould("not show error message") {
+                            captureScreenWithChecks {
+                                checkLinkNotError(url)
+                            }
+                        }
+                    }
+
+                    // FIXME Add a test to confirm that it is possible to transition to the Card screen after entering the required input fields, including images.
+                    // FIXME Currently, the test code does not allow the user to select and input an image from the Add Image button.
                 }
                 describe("when profile card is exists") {
                     doIt {

--- a/feature/profilecard/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenTest.kt
+++ b/feature/profilecard/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenTest.kt
@@ -51,6 +51,18 @@ class ProfileCardScreenTest(
                     }
                     // FIXME Add a test to confirm that it is possible to transition to the Card screen after entering the required input fields, including images.
                     // FIXME Currently, the test code does not allow the user to select and input an image from the Add Image button.
+                    describe("when url is invalid") {
+                        // This Url is invalid because it does not have a domain name like "https://not-valid-url.com".
+                        val invalidUrl = "https://not-valid-url"
+                        doIt {
+                            inputLink(invalidUrl)
+                        }
+                        itShould("show error message") {
+                            captureScreenWithChecks {
+                                checkLinkError(invalidUrl)
+                            }
+                        }
+                    }
                 }
                 describe("when profile card is exists") {
                     doIt {
@@ -63,7 +75,7 @@ class ProfileCardScreenTest(
                             checkProfileCardFrontDisplayed()
                         }
                     }
-                    describe("flip prifle card") {
+                    describe("flip profile card") {
                         doIt {
                             flipProfileCard()
                         }

--- a/feature/profilecard/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/profilecard/src/commonMain/composeResources/values-ja/strings.xml
@@ -12,6 +12,7 @@
     <string name="add_image">画像を追加</string>
     <string name="enter_validate_format">%1$sを入力してください</string>
     <string name="add_validate_format">%1$sを追加してください</string>
+    <string name="url_is_invalid">URLの形式が正しくありません</string>
     <string name="share">共有する</string>
     <string name="edit">編集する</string>
     <string name="share_description">DroidKaigiのプロフィールカードを作成しました！イベントでつながりましょう。#DroidKaigi</string>

--- a/feature/profilecard/src/commonMain/composeResources/values/strings.xml
+++ b/feature/profilecard/src/commonMain/composeResources/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="add_image">Add Image</string>
     <string name="enter_validate_format">Please enter a %1$s</string>
     <string name="add_validate_format">Please add %1$s</string>
+    <string name="url_is_invalid">The URL format is incorrect</string>
     <string name="share">Share</string>
     <string name="edit">Edit</string>
     <string name="share_description">Check out my DroidKaigi Profile Card! Let's connect at the event. #DroidKaigi</string>

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -82,6 +82,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.max
 import androidx.navigation.NavController
@@ -431,7 +432,10 @@ internal fun EditScreen(
                 link = it
                 onChangeLink(it)
             },
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Done,
+                keyboardType = KeyboardType.Uri,
+            ),
         )
 
         Column(
@@ -841,10 +845,9 @@ internal fun CardScreen(
                             text = stringResource(ProfileCardRes.string.edit),
                             modifier = Modifier.padding(8.dp),
                             style = MaterialTheme.typography.labelLarge,
-                            color = Color.Black
+                            color = Color.Black,
                         )
                     }
-
                 }
             }
         }

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -134,6 +134,7 @@ const val ProfileCardEditScreenColumnTestTag = "ProfileCardEditScreenColumnTestT
 const val ProfileCardNicknameTextFieldTestTag = "ProfileCardNicknameTextFieldTestTag"
 const val ProfileCardOccupationTextFieldTestTag = "ProfileCardOccupationTextFieldTestTag"
 const val ProfileCardLinkTextFieldTestTag = "ProfileCardLinkTextFieldTestTag"
+const val ProfileCardInputErrorTextTestTag = "ProfileCardInputErrorTextTestTag"
 const val ProfileCardSelectImageButtonTestTag = "ProfileCardSelectImageButtonTestTag"
 const val ProfileCardCreateButtonTestTag = "ProfileCardCreateButtonTestTag"
 const val ProfileCardCardScreenTestTag = "ProfileCardCardScreenTestTag"
@@ -558,7 +559,7 @@ private fun InputFieldWithError(
                     start = 16.dp,
                     top = 4.dp,
                     end = 16.dp,
-                ),
+                ).testTag(ProfileCardInputErrorTextTestTag.plus(value)),
         )
     }
 }

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
@@ -84,19 +84,20 @@ internal fun profileCardScreenPresenter(
     events: EventFlow<ProfileCardScreenEvent>,
     repository: ProfileCardRepository = localProfileCardRepository(),
 ): ProfileCardScreenState = providePresenterDefaults { userMessageStateHolder ->
-    val nicknameValidationErrorString = stringResource(
+    val emptyNicknameErrorString = stringResource(
         ProfileCardRes.string.enter_validate_format,
         stringResource(ProfileCardRes.string.nickname),
     )
-    val occupationValidationErrorString = stringResource(
+    val emptyOccupationErrorString = stringResource(
         ProfileCardRes.string.enter_validate_format,
         stringResource(ProfileCardRes.string.occupation),
     )
-    val linkValidationErrorString = stringResource(
+    val emptyLinkErrorString = stringResource(
         ProfileCardRes.string.enter_validate_format,
         stringResource(ProfileCardRes.string.link),
     )
     val imageValidationErrorString = stringResource(
+    val emptyImageErrorString = stringResource(
         ProfileCardRes.string.add_validate_format,
         stringResource(ProfileCardRes.string.image),
     )
@@ -148,13 +149,13 @@ internal fun profileCardScreenPresenter(
 
             is EditScreenEvent.OnChangeNickname -> {
                 cardError = cardError.copy(
-                    nicknameError = if (event.nickname.isEmpty()) nicknameValidationErrorString else "",
+                    nicknameError = if (event.nickname.isEmpty()) emptyNicknameErrorString else "",
                 )
             }
 
             is EditScreenEvent.OnChangeOccupation -> {
                 cardError = cardError.copy(
-                    occupationError = if (event.occupation.isEmpty()) occupationValidationErrorString else "",
+                    occupationError = if (event.occupation.isEmpty()) emptyOccupationErrorString else "",
                 )
             }
 
@@ -164,13 +165,13 @@ internal fun profileCardScreenPresenter(
                 // ex. https://www.example.com/hogefuga/foobar
                 val invalidFormat = event.link.matches(Regex("^https?://(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}(?:/\\S*)?\$")).not()
                 cardError = cardError.copy(
-                    linkError = if (event.link.isEmpty() || invalidFormat) linkValidationErrorString else "",
+                    linkError = if (event.link.isEmpty()) emptyLinkErrorString else "",
                 )
             }
 
             is EditScreenEvent.OnChangeImage -> {
                 cardError = cardError.copy(
-                    imageError = if (event.image.isEmpty()) imageValidationErrorString else "",
+                    imageError = if (event.image.isEmpty()) emptyImageErrorString else "",
                 )
             }
         }

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
@@ -163,10 +163,10 @@ internal fun profileCardScreenPresenter(
             }
 
             is EditScreenEvent.OnChangeLink -> {
-                // Only matches if the link is in this format "${http or https://}${domain}.${tld}/${sub directories}".
+                // Only matches if the link is in this format "${http or https + ://}${sub domain + .}${domain}.${tld}/${sub directories}".
                 // Protocol, sub domain and sub directories are optional.
                 // ex. https://www.example.com/hogefuga/foobar
-                val invalidFormat = event.link.matches(Regex("^(?:https?://)?(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}(?:/\\S*)?\$")).not()
+                val invalidFormat = event.link.matches(Regex("^(?:https?://)?(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]{2,}(?:/\\S*)?\$")).not()
                 cardError = cardError.copy(
                     linkError = if (event.link.isEmpty()) emptyLinkErrorString else if (invalidFormat) invalidLinkErrorString else "",
                 )

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
@@ -13,6 +13,7 @@ import conference_app_2024.feature.profilecard.generated.resources.image
 import conference_app_2024.feature.profilecard.generated.resources.link
 import conference_app_2024.feature.profilecard.generated.resources.nickname
 import conference_app_2024.feature.profilecard.generated.resources.occupation
+import conference_app_2024.feature.profilecard.generated.resources.url_is_invalid
 import io.github.droidkaigi.confsched.compose.EventEffect
 import io.github.droidkaigi.confsched.compose.EventFlow
 import io.github.droidkaigi.confsched.compose.SafeLaunchedEffect
@@ -96,7 +97,9 @@ internal fun profileCardScreenPresenter(
         ProfileCardRes.string.enter_validate_format,
         stringResource(ProfileCardRes.string.link),
     )
-    val imageValidationErrorString = stringResource(
+    val invalidLinkErrorString = stringResource(
+        ProfileCardRes.string.url_is_invalid,
+    )
     val emptyImageErrorString = stringResource(
         ProfileCardRes.string.add_validate_format,
         stringResource(ProfileCardRes.string.image),
@@ -165,7 +168,7 @@ internal fun profileCardScreenPresenter(
                 // ex. https://www.example.com/hogefuga/foobar
                 val invalidFormat = event.link.matches(Regex("^https?://(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}(?:/\\S*)?\$")).not()
                 cardError = cardError.copy(
-                    linkError = if (event.link.isEmpty()) emptyLinkErrorString else "",
+                    linkError = if (event.link.isEmpty()) emptyLinkErrorString else if (invalidFormat) invalidLinkErrorString else "",
                 )
             }
 

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
@@ -159,8 +159,12 @@ internal fun profileCardScreenPresenter(
             }
 
             is EditScreenEvent.OnChangeLink -> {
+                // Only matches if the link is in this format "${(http or https}://${domain}.${tld}/${sub directory}".
+                // Sub domain and sub directory are optional.
+                // ex. https://www.example.com/hogefuga/foobar
+                val invalidFormat = event.link.matches(Regex("^https?://(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}(?:/\\S*)?\$")).not()
                 cardError = cardError.copy(
-                    linkError = if (event.link.isEmpty()) linkValidationErrorString else "",
+                    linkError = if (event.link.isEmpty() || invalidFormat) linkValidationErrorString else "",
                 )
             }
 

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
@@ -163,10 +163,10 @@ internal fun profileCardScreenPresenter(
             }
 
             is EditScreenEvent.OnChangeLink -> {
-                // Only matches if the link is in this format "${(http or https}://${domain}.${tld}/${sub directory}".
-                // Sub domain and sub directory are optional.
+                // Only matches if the link is in this format "${http or https://}${domain}.${tld}/${sub directories}".
+                // Protocol, sub domain and sub directories are optional.
                 // ex. https://www.example.com/hogefuga/foobar
-                val invalidFormat = event.link.matches(Regex("^https?://(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}(?:/\\S*)?\$")).not()
+                val invalidFormat = event.link.matches(Regex("^(?:https?://)?(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}(?:/\\S*)?\$")).not()
                 cardError = cardError.copy(
                     linkError = if (event.link.isEmpty()) emptyLinkErrorString else if (invalidFormat) invalidLinkErrorString else "",
                 )


### PR DESCRIPTION
## Issue
- close #800

## Overview (Required)
- Add URL check if input value is valid format or not
  - valid URL example:
    - https://example.com/foobar/hogefuga
    - http://www.example.com
    - example.com/foobar
    - contains punycode like https://xn--wgv71a119e.jp/
  - invalid URL example:
    - invalid protocol 
      - ttps://example.com
    - missing top level domain
      - https://example/foobar
    - invalid characters
       - https://#$%.com
- Add some test to check regular expression works as expected
- Change keyboard type of link to Uri
- Rename error string variables.

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/3e190a11-3aa2-4dda-a786-8e4918c4cbc7" width="300" /> | <img src="https://github.com/user-attachments/assets/0ec06f40-9d94-4304-9bbc-9499c3e85d03" width="300" />
