### PR TITLE
In TimetableGridItem, Schedule icon align is misaligned when changing the font size on the device

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
@@ -160,8 +160,8 @@ fun TimetableGridItem(
             ) {
                 if (isShowingAllContent) {
                     Row(
-                        modifier = Modifier
-                            .weight(1f, fill = false),
+                        modifier = Modifier.weight(1f, fill = false),
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Icon(
                             modifier = Modifier.height(TimetableGridItemSizes.scheduleHeight),


### PR DESCRIPTION
## Issue
none

## Overview
- It is quite detailed...
- The schedule has icons and text surrounded by a Row, but the height of the icons is fixed, so if the font size on the device is changed, the height will not match and the alignment will be shifted.


## Screenshot (Optional if screenshot test is present or unrelated to UI)
Title | Before | After
:--: | :--: | :--:
small font | <img src="https://github.com/user-attachments/assets/1d4ca9ac-0564-4718-a6bc-f382425d3cf8" width="300" /> | <img src="https://github.com/user-attachments/assets/fe0df80a-6dcb-4304-8dcd-f8fd6d336ae0" width="300" />
medium font | <img src="https://github.com/user-attachments/assets/7f8c67ca-f5fd-4177-a8d8-9254a8e95edf" width="300" /> | <img src="https://github.com/user-attachments/assets/8debd736-9466-492a-bfba-7d58aa82cc54" width="300" />
large font | <img src="https://github.com/user-attachments/assets/d0495529-afcb-45ed-be67-7a13293dd1b2" width="300" /> | <img src="https://github.com/user-attachments/assets/4082e763-bf6c-4ef6-8c5a-7e7b1c9b95d9" width="300" />


