### PR TITLE
feat: add ellipsis and maxLines state explicitly to Speaker text

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
@@ -254,6 +254,8 @@ private fun SingleSpeaker(
             text = speaker.name,
             style = textStyle,
             color = textColor,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
     }
 }


### PR DESCRIPTION
## Issue
- close #894

## Overview (Required)
- The number of rows of the Speaker name in the GridItem of the timetable was different from that in the figma, so it was clarified so that ellipsis is always done in one line.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After | figma
:--: | :--: | :--:
<img src="https://github.com/user-attachments/assets/911c3262-70f6-410e-96c5-ff5c7b4a30d3" width="300" /> | <img src="https://github.com/user-attachments/assets/45727db6-3c2f-43e4-a3f4-e2f9e517e0eb" width="300" /> | <img src="https://github.com/user-attachments/assets/60d29b2c-a0fc-49dc-9c2a-66c366fa538c" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
