### PR TITLE
:bug: fix text style in edit screen.

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -454,7 +454,10 @@ internal fun EditScreen(
                 )
             }
 
-            Text(stringResource(ProfileCardRes.string.select_theme))
+            Text(
+                text = stringResource(ProfileCardRes.string.select_theme),
+                style = MaterialTheme.typography.titleMedium,
+            )
 
             CardTypePiker(
                 selectedCardType = selectedCardType,


### PR DESCRIPTION
## Issue
- close #898

## Overview (Required)
- Add the text style `titleMedium`.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After | Figma
:--: | :--: | :--:
<img src="https://github.com/user-attachments/assets/20424266-5991-4a69-b8d5-9f4f82262bf1" width="300" /> | <img src="https://github.com/user-attachments/assets/c615673d-68f9-4585-9029-15f03a51e4cb" width="300" /> | <img src="https://github.com/user-attachments/assets/45d6268f-6f66-4cbd-a789-9b00d9b5f8de" width="300" />