### PR TITLE
fix: timetableGridItem title maxLine3 while keeping the existing layout

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
@@ -184,6 +184,8 @@ fun TimetableGridItem(
                         style = titleTextStyle,
                         maxLines = 3,
                         overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier
+                            .padding(bottom = TimetableGridItemSizes.titleToSpeakerSpace),
                     )
                 },
                 measurePolicy = { measurables, constraints ->
@@ -482,6 +484,7 @@ object TimetableGridItemSizes {
     val padding = 12.dp
     val scheduleToTitleSpace = 6.dp
     val scheduleHeight = 16.dp
+    val titleToSpeakerSpace = 4.dp
     val errorHeight = 16.dp
     val speakerHeight = 32.dp
     val minTitleFontSize = 10.sp

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
@@ -190,7 +190,7 @@ fun TimetableGridItem(
                     if (isShowingAllContent && measurables.size > 1) {
                         // Layout if `isShowingAllContent` is `true`
                         val scheduleRowHeight = measurables[0].minIntrinsicHeight(constraints.maxWidth)
-                        val remainingHeight = constraints.maxHeight - scheduleRowHeight
+                        val remainingHeight = constraints.maxHeight - scheduleRowHeight - TimetableGridItemSizes.scheduleToTitleSpace.roundToPx()
 
                         // Measure title text
                         val titlePlaceable = measurables[measurables.lastIndex].measure(
@@ -205,7 +205,7 @@ fun TimetableGridItem(
                             // Place schedule text line at the top
                             schedulePlaceable.placeRelative(0, 0)
                             // Title text placed below the schedule
-                            titlePlaceable.placeRelative(0, scheduleRowHeight)
+                            titlePlaceable.placeRelative(0, scheduleRowHeight + TimetableGridItemSizes.scheduleToTitleSpace.roundToPx())
                         }
                     } else {
                         // Layout if only title is displayed

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
@@ -591,3 +591,23 @@ fun PreviewTimetableGridItemWelcomeTalk() {
         }
     }
 }
+
+@Preview
+@Composable
+fun PreviewTimetableGridItemMoreLongTitleItem() {
+    KaigiTheme {
+        Surface {
+            TimetableGridItem(
+                timetableItem = Session.fake().let {
+                    val longTitle = it.title.copy(
+                        jaTitle = it.title.jaTitle.repeat(10),
+                        enTitle = it.title.enTitle.repeat(10),
+                    )
+                    it.copy(title = longTitle, speakers = persistentListOf(it.speakers.first()))
+                },
+                onTimetableItemClick = {},
+                gridItemHeightPx = 500,
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Issue
- close #902 

## Overview (Required)
- This PR fixes the timelineText component to ensure it is limited to a maximum of three lines while preserving the existing layout.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/5d01efd0-3444-442e-b40e-2261ff690125" width="300" /><img src="https://github.com/user-attachments/assets/df35b922-7115-4962-8d8b-531c2a9ea9db" width="300" /> | <img src="https://github.com/user-attachments/assets/6186f949-c179-4b45-85ae-502e57943ef0" width="300" /><img src="https://github.com/user-attachments/assets/d23f17db-16f8-400d-8add-af733c15735e" width="300" />

