### PR TITLE
Fix bottom space from DayTab offsets in Timetable Screen

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableGrid.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableGrid.kt
@@ -139,7 +139,7 @@ fun TimetableGrid(
     val animatedScope = LocalAnimatedVisibilityScope.current
 
     Row(
-        modifier = Modifier
+        modifier = modifier
             .testTag(TimetableGridTestTag)
             .padding(
                 top = contentPadding.calculateTopPadding(),
@@ -171,7 +171,6 @@ fun TimetableGrid(
                 timetableState = timetableState,
                 timeLine = timeLine,
                 selectedDay = selectedDay,
-                modifier = modifier,
                 contentPadding = PaddingValues(
                     top = 16.dp + contentPadding.calculateTopPadding(),
                     bottom = 16.dp + 80.dp + contentPadding.calculateBottomPadding(),

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
@@ -93,9 +93,6 @@ internal fun TimetableList(
 
     LazyColumn(
         modifier = modifier.testTag(TimetableListTestTag)
-            .offset {
-                IntOffset(x = 0, y = nestedScrollStateHolder.uiState.dayTabOffsetY.toInt())
-            }
             .nestedScroll(nestedScrollConnection),
         state = scrollState,
         verticalArrangement = Arrangement.spacedBy(32.dp),

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableSheet.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableSheet.kt
@@ -1,7 +1,7 @@
 package io.github.droidkaigi.confsched.sessions.section
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
@@ -20,7 +20,9 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -29,6 +31,7 @@ import io.github.droidkaigi.confsched.model.DroidKaigi2024Day
 import io.github.droidkaigi.confsched.model.TimeLine
 import io.github.droidkaigi.confsched.model.TimetableItem
 import io.github.droidkaigi.confsched.sessions.component.TimetableDayTab
+import io.github.droidkaigi.confsched.sessions.component.TimetableNestedScrollStateHolder
 import io.github.droidkaigi.confsched.sessions.component.rememberTimetableNestedScrollStateHolder
 import io.github.droidkaigi.confsched.sessions.section.TimetableUiState.Empty
 import io.github.droidkaigi.confsched.sessions.section.TimetableUiState.GridTimetable
@@ -71,9 +74,8 @@ fun Timetable(
     Surface(
         modifier = modifier.padding(contentPadding.calculateTopPadding()),
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize(),
+        Box(
+            modifier = Modifier.fillMaxSize(),
         ) {
             TimetableDayTab(
                 selectedDay = selectedDay,
@@ -100,9 +102,7 @@ fun Timetable(
                         scrollState = scrollStates.getValue(selectedDay),
                         onTimetableItemClick = onTimetableItemClick,
                         onBookmarkClick = onFavoriteClick,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .weight(1f),
+                        modifier = timetableModifier(nestedScrollStateHolder),
                         contentPadding = PaddingValues(
                             bottom = contentPadding.calculateBottomPadding(),
                             start = contentPadding.calculateStartPadding(layoutDirection),
@@ -119,9 +119,7 @@ fun Timetable(
                         timeLine = uiState.timeLine,
                         selectedDay = selectedDay,
                         onTimetableItemClick = onTimetableItemClick,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .weight(1f),
+                        modifier = timetableModifier(nestedScrollStateHolder),
                         contentPadding = PaddingValues(
                             bottom = contentPadding.calculateBottomPadding(),
                             start = contentPadding.calculateStartPadding(layoutDirection),
@@ -159,4 +157,20 @@ private fun rememberGridTimetableStates(): Map<DroidKaigi2024Day, TimetableState
         rememberTimetableGridState()
     }
     return remember { timetableStateMap }
+}
+
+@Composable
+private fun timetableModifier(
+    nestedScrollStateHolder: TimetableNestedScrollStateHolder,
+): Modifier {
+    val density = LocalDensity.current
+
+    return Modifier
+        .padding(
+            top = with(density) {
+                (nestedScrollStateHolder.uiState.scrollConnectionMinOffset + nestedScrollStateHolder.uiState.dayTabOffsetY).toDp()
+            },
+        )
+        .fillMaxSize()
+        .background(Color.Transparent)
 }


### PR DESCRIPTION
## Issue
- close #914

## Overview (Required)
- In Timetable Screen,  remove bottom empty space due to `DateTab` offset.
- Replace **Column and offset** with **Box and Padding**.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)

### portrait
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/547da23c-8def-4563-b867-ce461712bf69" width="300" > | <video src="https://github.com/user-attachments/assets/fd22ca7d-d5f2-4fae-aeab-51cc43bc3fe5" width="300" >

### landscape

Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/2aaf0623-45bc-4d16-9441-f2e57d36838b" width="300" > | <video src="https://github.com/user-attachments/assets/b3151287-37b3-4153-ab2d-8d14d1b1e512" width="300" >
