### PR TITLE
[iOS] Add borders to user icons

### DIFF
--- a/app-ios/Sources/CommonComponents/Timetable/CircularUserIcon.swift
+++ b/app-ios/Sources/CommonComponents/Timetable/CircularUserIcon.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import Theme
 
 private actor CircularUserIconInMemoryCache {
     static let shared = CircularUserIconInMemoryCache()
@@ -35,6 +36,10 @@ public struct CircularUserIcon: View {
             }
         }
         .clipShape(Circle())
+        .overlay(
+            Circle()
+                .stroke(AssetColors.Outline.outline.swiftUIColor, lineWidth: 1)
+        )
         .task {
             if let data = await CircularUserIconInMemoryCache.shared.data(urlString: urlString) {
                 iconData = data

--- a/app-ios/Sources/StaffFeature/StaffLabel.swift
+++ b/app-ios/Sources/StaffFeature/StaffLabel.swift
@@ -10,10 +10,6 @@ struct StaffLabel: View {
         HStack(alignment: .center, spacing: 12) {
             CircularUserIcon(urlString: icon.absoluteString)
                 .frame(width: 52, height: 52)
-                .overlay(
-                    Circle()
-                        .stroke(AssetColors.Outline.outline.swiftUIColor, lineWidth: 1)
-                )
 
             Text(name)
                 .textStyle(.bodyLarge)

--- a/app-ios/Sources/TimetableFeature/TimetableGridCard.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableGridCard.swift
@@ -44,15 +44,8 @@ public struct TimetableGridCard: View {
                 
                 ForEach(timetableItem.speakers, id: \.id) { speaker in
                     HStack(spacing: 8) {
-                        Group {
-                            AsyncImage(url: URL(string: speaker.iconUrl)) {
-                                $0.resizable()
-                            } placeholder: {
-                                Color.gray
-                            }
-                        }
-                        .frame(width: 32, height: 32)
-                        .clipShape(Circle())
+                        CircularUserIcon(urlString: speaker.iconUrl)
+                            .frame(width: 32, height: 32)
 
                         Text(speaker.name)
                             .textStyle(.titleSmall)


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- This PR adds gray borders to user icons

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/d25fcdad-a580-4ee0-803c-af046e17f6f8" width="300" /> | <img src="https://github.com/user-attachments/assets/cfbacb9d-8407-4bbe-b281-9a1e1dee69bb" width="300" />
<img src="https://github.com/user-attachments/assets/6360513f-f212-4a0d-90a2-e022c2b09927" width="300" /> | <img src="https://github.com/user-attachments/assets/27bd4667-e182-4c0d-b5fe-1ef7181d4992" width="300" />
<img src="https://github.com/user-attachments/assets/6ada0f42-c74a-405e-8757-292719193a00" width="300" /> | <img src="https://github.com/user-attachments/assets/0b25f168-15c7-4e22-8abe-966d9ebb43e5" width="300" />
<img src="https://github.com/user-attachments/assets/36319973-178e-49f3-a0bc-530710387b93" width="300" /> | <img src="https://github.com/user-attachments/assets/13b2ab89-db89-4085-b81e-011f31818c21" width="300" />



## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >