### PR TITLE
:wrench: The problem of flickering icons has been addressed by caching ImageRequests.

### DIFF
--- a/core/droidkaigiui/src/androidMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/SpeakerPainter.android.kt
+++ b/core/droidkaigiui/src/androidMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/SpeakerPainter.android.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched.droidkaigiui.component
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalContext
 import coil3.request.ImageRequest
@@ -10,13 +11,17 @@ import io.github.droidkaigi.confsched.droidkaigiui.rememberAsyncImagePainter
 
 @Composable
 actual fun speakerPainter(url: String): Painter {
-    // TODO Use DrawableResource
-    // https://github.com/DroidKaigi/conference-app-2024/pull/864/files#r1736437080
-    // https://github.com/coil-kt/coil/issues/2077
-    return rememberAsyncImagePainter(
-        model = ImageRequest.Builder(LocalContext.current)
+    val context = LocalContext.current
+
+    val imageRequest = remember(url, context) {
+        // TODO Use DrawableResource
+        // https://github.com/DroidKaigi/conference-app-2024/pull/864/files#r1736437080
+        // https://github.com/coil-kt/coil/issues/2077
+        ImageRequest.Builder(context)
             .data(url)
             .placeholder(R.drawable.icon_place_hoolder)
-            .build(),
-    )
+            .build()
+    }
+
+    return rememberAsyncImagePainter(model = imageRequest)
 }

--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/ImagePainter.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/ImagePainter.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched.droidkaigiui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.painter.Painter
 import coil3.request.ImageRequest
 
@@ -13,7 +14,9 @@ fun rememberAsyncImagePainter(url: String): Painter {
 
 @Composable
 fun rememberAsyncImagePainter(model: ImageRequest): Painter {
+    val requestModel = remember(model) { model }
+
     return coil3.compose.rememberAsyncImagePainter(
-        model = model,
+        model = requestModel
     )
 }

--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/ImagePainter.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/ImagePainter.kt
@@ -17,6 +17,6 @@ fun rememberAsyncImagePainter(model: ImageRequest): Painter {
     val requestModel = remember(model) { model }
 
     return coil3.compose.rememberAsyncImagePainter(
-        model = requestModel
+        model = requestModel,
     )
 }


### PR DESCRIPTION
## Issue
- close #912

## Overview (Required)
- Every time you scroll, a new ImageRequest instance was created using LocalContext.current.
- As a result, rememberAsyncImagePainter would create a new Painter each time, causing flickering when scrolling.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/f523f9f1-6a5e-49d7-916f-6fc8ef4069cc" width="300" > | <img src="https://github.com/user-attachments/assets/d30a232b-10af-47d3-8242-f23d7af2e516" width="300" >