### PR TITLE
:wrench: We have made some modifications to the profile card screen so that focus is handled appropriately.

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -445,8 +445,8 @@ internal fun EditScreen(
             keyboardActions = KeyboardActions(
                 onDone = {
                     focusManager.clearFocus()
-                }
-            )
+                },
+            ),
         )
 
         Column(

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -78,6 +79,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
@@ -231,6 +233,7 @@ internal fun ProfileCardScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val layoutDirection = LocalLayoutDirection.current
     val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current
 
     SnackbarMessageEffect(
         snackbarHostState = snackbarHostState,
@@ -256,6 +259,7 @@ internal fun ProfileCardScreen(
             .pointerInput(Unit) {
                 detectTapGestures {
                     keyboardController?.hide()
+                    focusManager.clearFocus()
                 }
             },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
@@ -387,6 +391,8 @@ internal fun EditScreen(
         }
     }
 
+    val focusManager = LocalFocusManager.current
+
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -436,6 +442,11 @@ internal fun EditScreen(
                 imeAction = ImeAction.Done,
                 keyboardType = KeyboardType.Uri,
             ),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    focusManager.clearFocus()
+                }
+            )
         )
 
         Column(
@@ -520,6 +531,7 @@ private fun InputFieldWithError(
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
     maxLines: Int = 1,
 ) {
     Column(modifier = modifier) {
@@ -539,6 +551,7 @@ private fun InputFieldWithError(
             isError = isError,
             shape = RoundedCornerShape(4.dp),
             keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
             maxLines = maxLines,
             modifier = Modifier
                 .indicatorLine(


### PR DESCRIPTION
## Issue
- close #920

## Overview (Required)
- I have made it so that the focus is cleared at the following times.
1. When you tap anywhere on the screen.
2. When you perform the Done action on the last item.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/1ded325f-7c34-4746-9a61-1adc08dba4be" width="300" > | <video src="https://github.com/user-attachments/assets/823dd9a5-efae-4a32-a594-1f40c1a6b0e2" width="300" >