### PR TITLE
:wrench: [iOS・Compose Multiplatform] The issue where the bottom navigation overlapped with the Create Profile button and made it difficult to press has been fixed.

### DIFF
--- a/feature/profilecard/src/iosMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardViewController.kt
+++ b/feature/profilecard/src/iosMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardViewController.kt
@@ -1,5 +1,7 @@
 package io.github.droidkaigi.confsched.profilecard
 
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched.compose.EventFlow
 import io.github.droidkaigi.confsched.data.Repositories
 import io.github.droidkaigi.confsched.droidkaigiui.composeViewController
@@ -22,6 +24,10 @@ fun profileCardViewController(
                 imageBitmap.toUiImage() ?: UIImage(),
             )
         },
+        // FIXME This is a workaround. For permanent support, we will get the inset value etc. from the iOS side and respond.
+        contentPadding = PaddingValues(
+            bottom = 30.dp,
+        )
     )
 }
 

--- a/feature/profilecard/src/iosMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardViewController.kt
+++ b/feature/profilecard/src/iosMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardViewController.kt
@@ -26,7 +26,7 @@ fun profileCardViewController(
         },
         // FIXME This is a workaround. For permanent support, we will get the inset value etc. from the iOS side and respond.
         contentPadding = PaddingValues(
-            bottom = 30.dp, // Hight of bottom tab bar
+            bottom = 30.dp, // Height of bottom tab bar
         ),
     )
 }

--- a/feature/profilecard/src/iosMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardViewController.kt
+++ b/feature/profilecard/src/iosMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardViewController.kt
@@ -27,7 +27,7 @@ fun profileCardViewController(
         // FIXME This is a workaround. For permanent support, we will get the inset value etc. from the iOS side and respond.
         contentPadding = PaddingValues(
             bottom = 30.dp,
-        )
+        ),
     )
 }
 

--- a/feature/profilecard/src/iosMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardViewController.kt
+++ b/feature/profilecard/src/iosMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardViewController.kt
@@ -26,7 +26,7 @@ fun profileCardViewController(
         },
         // FIXME This is a workaround. For permanent support, we will get the inset value etc. from the iOS side and respond.
         contentPadding = PaddingValues(
-            bottom = 30.dp,
+            bottom = 30.dp, // Hight of bottom tab bar
         ),
     )
 }


### PR DESCRIPTION
## Issue
- close #905

## Overview (Required)
- I simply added 30.dp to the bottom.
- As I mentioned in the comments, I think it would be better to get the inset from the iOS side as a permanent measure and set the padding in ProfileCardScreen based on that.

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before iPad mini | After iPad mini
:--: | :--:
<img src="https://github.com/user-attachments/assets/ff97fd68-05d0-4b99-8855-17d5d2c6be32" width="300" /> | <img src="https://github.com/user-attachments/assets/af8d14b6-a91e-4222-a51a-100a84f56d13" width="300" />

Before iPhone 15 | After iPhone 15 
:--: | :--:
<img src="https://github.com/user-attachments/assets/aa118242-0445-4e47-9566-122cca8bdaac" width="300" /> | <img src="https://github.com/user-attachments/assets/d8387bf6-ba23-4d09-94cf-0b261115957d" width="300" />

Before iPhone SE 3rd gen | After iPhone SE 3rd gen 
:--: | :--:
<img src="https://github.com/user-attachments/assets/0255e64d-a6d3-4f40-a863-97665bb59e07" width="300" /> | <img src="https://github.com/user-attachments/assets/d85bff5f-06f2-48f6-b8ce-a0aba41802c4" width="300" />