### PR TITLE
Bump target sdk version to 35

### DIFF
--- a/app-android/src/main/AndroidManifest.xml
+++ b/app-android/src/main/AndroidManifest.xml
@@ -34,11 +34,11 @@
 
         <activity
             android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
-            android:theme="@style/Theme.AppCompat.DayNight.DarkActionBar" />
+            android:theme="@style/Theme.KaigiApp.Licenses" />
 
         <activity
             android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
-            android:theme="@style/Theme.AppCompat.DayNight.DarkActionBar" />
+            android:theme="@style/Theme.KaigiApp.Licenses" />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app-android/src/main/res/values/themes.xml
+++ b/app-android/src/main/res/values/themes.xml
@@ -4,4 +4,8 @@
     <style name="Theme.KaigiApp" parent="android:Theme.Material.NoActionBar">
         <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
+
+    <style name="Theme.KaigiApp.Licenses" parent="Theme.AppCompat.DayNight.DarkActionBar">
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
 </resources>

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/AndroidGradleDsl.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/AndroidGradleDsl.kt
@@ -31,11 +31,11 @@ fun Project.setupAndroid() {
         namespace?.let {
             this.namespace = it
         }
-        compileSdkVersion(34)
+        compileSdkVersion(35)
 
         defaultConfig {
             minSdk = 24
-            targetSdk = 34
+            targetSdk = 35
         }
 
         compileOptions {


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Title says it all.
- The oss-licenses-plugin has disabled Edge-to-Edge because it cannot control insets padding.

## Links
- https://developer.android.com/about/versions/15/behavior-changes-all
- https://developer.android.com/about/versions/15/behavior-changes-15

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/f0fbfb59-551b-451f-887b-8747a642270f" width="300" /> | <img src="https://github.com/user-attachments/assets/73cdcbe4-7268-4ac6-85c4-21eaa2623881" width="300" />

No difference

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
