### PR TITLE
[Profile Card]Fixed profile input scroll direction

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -521,6 +521,7 @@ private fun InputFieldWithError(
     modifier: Modifier = Modifier,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     maxLines: Int = 1,
+    singleLine: Boolean = true,
 ) {
     Column(modifier = modifier) {
         val isError = errorMessage.isNotEmpty()
@@ -540,6 +541,7 @@ private fun InputFieldWithError(
             shape = RoundedCornerShape(4.dp),
             keyboardOptions = keyboardOptions,
             maxLines = maxLines,
+            singleLine = singleLine,
             modifier = Modifier
                 .indicatorLine(
                     enabled = false,


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
The TextField has a maximum of 1 line, but long text will wrap and scroll vertically.
If you want to apply a single line, it is more natural to have a horizontally scrollable input field.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/6946e9f9-0fa5-4d6e-8112-43f7d08636a7" width="300" > | <video src="https://github.com/user-attachments/assets/ee2e2dc1-23a8-49c0-9222-6942901a231a" width="300" >


