### PR TITLE
:wrench: This addresses the case where the image of the ProfileCard used for sharing on SNS etc. is corrupted in some cases.

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/CaptureableCardBack.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/CaptureableCardBack.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -18,6 +19,8 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.graphics.rememberGraphicsLayer
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
 import coil3.compose.AsyncImagePainter
@@ -58,19 +61,26 @@ internal fun BackgroundCapturableCardBack(
                 }
             },
     ) {
-        FlipCardBack(
-            uiState,
-            qrCodeImagePainter,
-            modifier = Modifier
-                .size(width = 300.dp, height = 380.dp)
-                .border(
-                    3.dp,
-                    Color.Black,
-                    RoundedCornerShape(8.dp),
-                )
-                .graphicsLayer {
-                    rotationY = 180f
-                },
-        )
+        CompositionLocalProvider(
+            LocalDensity provides Density(
+                density = 1f,
+                fontScale = 1f,
+            )
+        ) {
+            FlipCardBack(
+                uiState,
+                qrCodeImagePainter,
+                modifier = Modifier
+                    .size(width = 300.dp, height = 380.dp)
+                    .border(
+                        3.dp,
+                        Color.Black,
+                        RoundedCornerShape(8.dp),
+                    )
+                    .graphicsLayer {
+                        rotationY = 180f
+                    },
+            )
+        }
     }
 }

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/CaptureableCardBack.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/CaptureableCardBack.kt
@@ -65,7 +65,7 @@ internal fun BackgroundCapturableCardBack(
             LocalDensity provides Density(
                 density = 1f,
                 fontScale = 1f,
-            )
+            ),
         ) {
             FlipCardBack(
                 uiState,

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/CaptureableCardFront.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/CaptureableCardFront.kt
@@ -63,7 +63,7 @@ internal fun BackgroundCapturableCardFront(
             LocalDensity provides Density(
                 density = 1f,
                 fontScale = 1f,
-            )
+            ),
         ) {
             FlipCardFront(
                 uiState,

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/CaptureableCardFront.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/CaptureableCardFront.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -16,6 +17,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.graphics.rememberGraphicsLayer
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
 import coil3.compose.AsyncImagePainter
@@ -56,16 +59,23 @@ internal fun BackgroundCapturableCardFront(
                 }
             },
     ) {
-        FlipCardFront(
-            uiState,
-            profileImagePainter,
-            modifier = Modifier
-                .size(width = 300.dp, height = 380.dp)
-                .border(
-                    3.dp,
-                    Color.Black,
-                    RoundedCornerShape(8.dp),
-                ),
-        )
+        CompositionLocalProvider(
+            LocalDensity provides Density(
+                density = 1f,
+                fontScale = 1f,
+            )
+        ) {
+            FlipCardFront(
+                uiState,
+                profileImagePainter,
+                modifier = Modifier
+                    .size(width = 300.dp, height = 380.dp)
+                    .border(
+                        3.dp,
+                        Color.Black,
+                        RoundedCornerShape(8.dp),
+                    ),
+            )
+        }
     }
 }

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/ShareableCard.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/ShareableCard.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImagePainter
 import com.preat.peekaboo.image.picker.toImageBitmap
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
@@ -96,6 +95,7 @@ private fun ShareableCardContent(
     val offsetYBackPx = 76f
     val offsetXFrontPx = -136f
     val offsetYFrontPx = -61f
+    val verticalPaddingPx = 30f
 
     val density = LocalDensity.current
 
@@ -108,7 +108,7 @@ private fun ShareableCardContent(
             )
             .background(LocalProfileCardTheme.current.primaryColor),
     ) {
-        Box(modifier = Modifier.padding(vertical = 30.dp)) {
+        Box(modifier = Modifier.padding(vertical = with(density) { verticalPaddingPx.toDp() })) {
             backImage?.let {
                 Image(
                     bitmap = it,


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- Using the CompositionLocalProvider, we fixed the Density and FontScale for FlipCards used for shooting.
- Until this was fixed, the text size would fluctuate as reported in the issue and as shown in the screenshot, and in some cases the cards would be displayed squashed.
- With this fix, the appearance should now be consistent on all devices.

## Links
- https://github.com/DroidKaigi/conference-app-2024/issues/890#issuecomment-2322770976

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before Portrait Minimum SmallPhone | After Portrait Minimum SmallPhone
:--: | :--:
<img src="https://github.com/user-attachments/assets/d78e6a23-4a2d-4b38-b60d-e66b515206c5" width="300" /> | <img src="https://github.com/user-attachments/assets/c45d43c1-fc93-461a-a07e-c0ad2b43aa0a" width="300" />

Before Landscape Minimum SmallPhone | After Landscape Minimum SmallPhone
:--: | :--:
<img src="https://github.com/user-attachments/assets/6db7d6d9-e4a1-4496-bc35-dd3656dd5b84" width="300" /> | <img src="https://github.com/user-attachments/assets/0366d9ba-f888-44e2-af48-b16b879a9b83" width="300" />

Before Portrait Max SmallPhone | After Portrait Max SmallPhone
:--: | :--:
<img src="https://github.com/user-attachments/assets/66de5191-d4c8-4e52-a31b-04d2ec54c3c4" width="300" /> | <img src="https://github.com/user-attachments/assets/c1187526-f6ba-43a1-8bf8-4907f43398a0" width="300" />

Before Landscape Max SmallPhone | After Landscape Max SmallPhone
:--: | :--:
<img src="https://github.com/user-attachments/assets/835eebd8-8d93-480f-9b49-efe2f5dea5c9" width="300" /> | <img src="https://github.com/user-attachments/assets/d86ff61a-05e5-42f8-9cde-8e03da87507f" width="300" />

---

Before Portrait Minimum Pixel 7 Pro | After Portrait Minimum Pixel 7 Pro
:--: | :--:
<img src="https://github.com/user-attachments/assets/70f8acb0-b394-4b2e-9537-b191e1f75747" width="300" /> | <img src="https://github.com/user-attachments/assets/f2ef2021-c66b-4ea4-b35f-fb8e589227cb" width="300" />

Before Landscape Minimum Pixel 7 Pro | After Landscape Minimum Pixel 7 Pro
:--: | :--:
<img src="https://github.com/user-attachments/assets/65853c75-c1b2-492a-888f-92dda23b2e1b" width="300" /> | <img src="https://github.com/user-attachments/assets/604eeebe-ba06-4241-96bb-293046c41efa" width="300" />

Before Portrait Max Pixel 7 Pro | After Portrait Max Pixel 7 Pro
:--: | :--:
<img src="https://github.com/user-attachments/assets/bdab72a7-dc69-4c6e-a551-d85674a2f66f" width="300" /> | <img src="https://github.com/user-attachments/assets/7031e8be-4fc0-4dd6-aa70-1251e4cc0038" width="300" />

Before Landscape Max Pixel 7 Pro | After Landscape Max Pixel 7 Pro
:--: | :--:
<img src="https://github.com/user-attachments/assets/334186e9-9369-4b01-8fbf-ad9d9fc06960" width="300" /> | <img src="https://github.com/user-attachments/assets/9fb57f83-d5e7-4909-a562-6e6f209ab678" width="300" />

