### PR TITLE
[iOS] Update layout of timetable grid cells with multiple speakers

### DIFF
--- a/app-ios/Sources/TimetableFeature/TimetableGridCard.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableGridCard.swift
@@ -42,7 +42,14 @@ public struct TimetableGridCard: View {
                 
                 Spacer()
                 
-                ForEach(timetableItem.speakers, id: \.id) { speaker in
+                if timetableItem.speakers.count > 1 {
+                    HStack(spacing: 4) {
+                        ForEach(timetableItem.speakers, id: \.id) { speaker in
+                            CircularUserIcon(urlString: speaker.iconUrl)
+                                .frame(width: 32, height: 32)
+                        }
+                    }
+                } else if let speaker = timetableItem.speakers.first {
                     HStack(spacing: 8) {
                         CircularUserIcon(urlString: speaker.iconUrl)
                             .frame(width: 32, height: 32)


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- This PR updates the layout of the timetable grid cells with multiple speakers to match the Android app implementation:

<img src="https://github.com/user-attachments/assets/c97748e8-feee-44c6-8f0a-3e63443a991f" width=300>

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/9c3ddd34-9d5a-49f4-b398-508edb309df8" width="300" /> | <img src="https://github.com/user-attachments/assets/10b88568-592d-4b7e-9d1d-c175f30d139e" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
