### PR TITLE
Prevents opt-in needed warning

### DIFF
--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+
 plugins {
     id("droidkaigi.primitive.kmp")
     id("droidkaigi.primitive.kmp.android")
@@ -9,6 +11,7 @@ plugins {
 }
 
 android.namespace = "io.github.droidkaigi.confsched.core.designsystem"
+@OptIn(ExperimentalRoborazziApi::class)
 roborazzi.generateComposePreviewRobolectricTests.packages = listOf("io.github.droidkaigi.confsched.designsystem")
 
 kotlin {

--- a/feature/about/build.gradle.kts
+++ b/feature/about/build.gradle.kts
@@ -1,8 +1,11 @@
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+
 plugins {
     id("droidkaigi.convention.kmpfeature")
 }
 
 android.namespace = "io.github.droidkaigi.confsched.feature.about"
+@OptIn(ExperimentalRoborazziApi::class)
 roborazzi.generateComposePreviewRobolectricTests.packages = listOf("io.github.droidkaigi.confsched.about")
 kotlin {
     sourceSets {

--- a/feature/contributors/build.gradle.kts
+++ b/feature/contributors/build.gradle.kts
@@ -1,8 +1,11 @@
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+
 plugins {
     id("droidkaigi.convention.kmpfeature")
 }
 
 android.namespace = "io.github.droidkaigi.confsched.feature.contributors"
+@OptIn(ExperimentalRoborazziApi::class)
 roborazzi.generateComposePreviewRobolectricTests.packages = listOf("io.github.droidkaigi.confsched.contributors")
 kotlin {
     sourceSets {

--- a/feature/eventmap/build.gradle.kts
+++ b/feature/eventmap/build.gradle.kts
@@ -1,9 +1,12 @@
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+
 plugins {
     id("droidkaigi.convention.kmpfeature")
     id("droidkaigi.primitive.kmp.serialization")
 }
 
 android.namespace = "io.github.droidkaigi.confsched.feature.eventmap"
+@OptIn(ExperimentalRoborazziApi::class)
 roborazzi.generateComposePreviewRobolectricTests.packages = listOf("io.github.droidkaigi.confsched.eventmap")
 kotlin {
     sourceSets {

--- a/feature/favorites/build.gradle.kts
+++ b/feature/favorites/build.gradle.kts
@@ -1,8 +1,11 @@
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+
 plugins {
     id("droidkaigi.convention.kmpfeature")
 }
 
 android.namespace = "io.github.droidkaigi.confsched.feature.favorites"
+@OptIn(ExperimentalRoborazziApi::class)
 roborazzi.generateComposePreviewRobolectricTests.packages = listOf("io.github.droidkaigi.confsched.favorites")
 kotlin {
     sourceSets {

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -1,8 +1,11 @@
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+
 plugins {
     id("droidkaigi.convention.kmpfeature")
 }
 
 android.namespace = "io.github.droidkaigi.confsched.feature.main"
+@OptIn(ExperimentalRoborazziApi::class)
 roborazzi.generateComposePreviewRobolectricTests.packages = listOf("io.github.droidkaigi.confsched.main")
 
 kotlin {

--- a/feature/profilecard/build.gradle.kts
+++ b/feature/profilecard/build.gradle.kts
@@ -1,8 +1,11 @@
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+
 plugins {
     id("droidkaigi.convention.kmpfeature")
 }
 
 android.namespace = "io.github.droidkaigi.confsched.feature.profilecard"
+@OptIn(ExperimentalRoborazziApi::class)
 roborazzi.generateComposePreviewRobolectricTests.packages =
     listOf("io.github.droidkaigi.confsched.profilecard")
 kotlin {

--- a/feature/sessions/build.gradle.kts
+++ b/feature/sessions/build.gradle.kts
@@ -1,9 +1,12 @@
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+
 plugins {
     id("droidkaigi.convention.kmpfeature")
     id("droidkaigi.primitive.kmp.serialization")
 }
 
 android.namespace = "io.github.droidkaigi.confsched.feature.sessions"
+@OptIn(ExperimentalRoborazziApi::class)
 roborazzi.generateComposePreviewRobolectricTests.packages = listOf("io.github.droidkaigi.confsched.sessions")
 
 kotlin {

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -1,8 +1,11 @@
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+
 plugins {
     id("droidkaigi.convention.kmpfeature")
 }
 
 android.namespace = "io.github.droidkaigi.confsched.feature.settings"
+@OptIn(ExperimentalRoborazziApi::class)
 roborazzi.generateComposePreviewRobolectricTests.packages = listOf("io.github.droidkaigi.confsched.settings")
 kotlin {
     sourceSets {

--- a/feature/sponsors/build.gradle.kts
+++ b/feature/sponsors/build.gradle.kts
@@ -1,8 +1,11 @@
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+
 plugins {
     id("droidkaigi.convention.kmpfeature")
 }
 
 android.namespace = "io.github.droidkaigi.confsched.feature.sponsors"
+@OptIn(ExperimentalRoborazziApi::class)
 roborazzi.generateComposePreviewRobolectricTests.packages = listOf("io.github.droidkaigi.confsched.sponsors")
 kotlin {
     sourceSets {

--- a/feature/staff/build.gradle.kts
+++ b/feature/staff/build.gradle.kts
@@ -1,8 +1,11 @@
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+
 plugins {
     id("droidkaigi.convention.kmpfeature")
 }
 
 android.namespace = "io.github.droidkaigi.confsched.feature.staff"
+@OptIn(ExperimentalRoborazziApi::class)
 roborazzi.generateComposePreviewRobolectricTests.packages = listOf("io.github.droidkaigi.confsched.staff")
 kotlin {
     sourceSets {


### PR DESCRIPTION
## Issue
- close None

## Overview (Required)
Compiler warned "This declaration needs opt-in." in some build.gradle.kts files because they used `roborazzi.generateComposePreviewRobolectricTests.packages` without `OptIn(ExperimentalRoborazziApi::class)`.  
Output logs were so annoying that I prevented them all.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
