### PR TITLE
Crop image to square

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched/KaigiApp.kt
@@ -72,6 +72,8 @@ import io.github.droidkaigi.confsched.model.AboutItem
 import io.github.droidkaigi.confsched.model.Lang.JAPANESE
 import io.github.droidkaigi.confsched.model.TimetableItem
 import io.github.droidkaigi.confsched.model.defaultLang
+import io.github.droidkaigi.confsched.profilecard.cropImageScreenRoute
+import io.github.droidkaigi.confsched.profilecard.cropImageScreens
 import io.github.droidkaigi.confsched.profilecard.navigateProfileCardScreen
 import io.github.droidkaigi.confsched.profilecard.profileCardScreen
 import io.github.droidkaigi.confsched.profilecard.profileCardScreenRoute
@@ -189,6 +191,10 @@ private fun KaigiNavHost(
                     onTimetableItemClick = navController::navigateToTimetableItemDetailScreen,
                     contentPadding = PaddingValues(),
                 )
+
+                cropImageScreens(
+                    onNavigationIconClick = navController::popBackStack,
+                )
             }
         }
     }
@@ -267,6 +273,7 @@ private fun NavGraphBuilder.mainScreen(
             profileCardScreen(
                 contentPadding = contentPadding,
                 onClickShareProfileCard = externalNavController::onShareProfileCardClick,
+                onNavigateToCropImage = { navController.navigate(cropImageScreenRoute) },
             )
         },
     )

--- a/app-android/src/main/java/io/github/droidkaigi/confsched/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched/KaigiApp.kt
@@ -194,6 +194,7 @@ private fun KaigiNavHost(
 
                 cropImageScreens(
                     onNavigationIconClick = navController::popBackStack,
+                    onConfirm = navController::popBackStack,
                 )
             }
         }

--- a/app-ios-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/shared/IosComposeKaigiApp.kt
+++ b/app-ios-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/shared/IosComposeKaigiApp.kt
@@ -22,8 +22,8 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import co.touchlab.kermit.Logger
-import conference_app_2024.app_ios_shared.generated.resources.permission_required
 import conference_app_2024.app_ios_shared.generated.resources.open_settings
+import conference_app_2024.app_ios_shared.generated.resources.permission_required
 import io.github.droidkaigi.confsched.about.aboutScreen
 import io.github.droidkaigi.confsched.about.aboutScreenRoute
 import io.github.droidkaigi.confsched.about.navigateAboutScreen
@@ -64,6 +64,8 @@ import io.github.droidkaigi.confsched.model.SettingsRepository
 import io.github.droidkaigi.confsched.model.TimetableItem
 import io.github.droidkaigi.confsched.model.compositionlocal.LocalRepositories
 import io.github.droidkaigi.confsched.model.defaultLang
+import io.github.droidkaigi.confsched.profilecard.cropImageScreenRoute
+import io.github.droidkaigi.confsched.profilecard.cropImageScreens
 import io.github.droidkaigi.confsched.profilecard.navigateProfileCardScreen
 import io.github.droidkaigi.confsched.profilecard.profileCardScreen
 import io.github.droidkaigi.confsched.profilecard.profileCardScreenRoute
@@ -251,6 +253,11 @@ private fun KaigiNavHost(
             onTimetableItemClick = navController::navigateToTimetableItemDetailScreen,
             contentPadding = PaddingValues(),
         )
+
+        cropImageScreens(
+            onNavigationIconClick = navController::popBackStack,
+            onConfirm = navController::popBackStack,
+        )
     }
 }
 
@@ -327,6 +334,7 @@ private fun NavGraphBuilder.mainScreen(
             profileCardScreen(
                 contentPadding = contentPadding,
                 onClickShareProfileCard = externalNavController::onShareProfileCardClick,
+                onNavigateToCropImage = { navController.navigate(cropImageScreenRoute) },
             )
         },
     )

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/DefaultProfileCardRepository.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched/data/profilecard/DefaultProfileCardRepository.kt
@@ -6,7 +6,9 @@ import androidx.compose.runtime.remember
 import io.github.droidkaigi.confsched.compose.safeCollectAsRetainedState
 import io.github.droidkaigi.confsched.model.ProfileCard
 import io.github.droidkaigi.confsched.model.ProfileCardRepository
+import io.github.droidkaigi.confsched.model.ProfileImage
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.ExperimentalResourceApi
@@ -32,7 +34,10 @@ public class DefaultProfileCardRepository(
     }
 
     @OptIn(ExperimentalResourceApi::class)
-    override suspend fun loadQrCodeImageByteArray(link: String, centerLogoRes: DrawableResource): ByteArray {
+    override suspend fun loadQrCodeImageByteArray(
+        link: String,
+        centerLogoRes: DrawableResource,
+    ): ByteArray {
         return withContext(ioDispatcher) {
             val logoImage = getDrawableResourceBytes(
                 environment = getSystemResourceEnvironment(),
@@ -43,5 +48,36 @@ public class DefaultProfileCardRepository(
                 .build(link)
                 .renderToBytes()
         }
+    }
+
+    private val profileImageInEditStateFlow = MutableStateFlow<ProfileImage?>(null)
+    private val profileImageCandidateStateFlow = MutableStateFlow<ProfileImage?>(null)
+
+    @Composable
+    override fun profileImageInEdit(): ProfileImage? {
+        val profileImage by profileImageInEditStateFlow.safeCollectAsRetainedState()
+        return profileImage
+    }
+
+    override fun setProfileImageInEdit(profileImage: ProfileImage) {
+        profileImageInEditStateFlow.value = profileImage
+    }
+
+    override fun clearProfileImageInEdit() {
+        profileImageInEditStateFlow.value = null
+    }
+
+    @Composable
+    override fun profileImageCandidate(): ProfileImage? {
+        val profileImageCandidate by profileImageCandidateStateFlow.safeCollectAsRetainedState()
+        return profileImageCandidate
+    }
+
+    override fun setProfileImageCandidate(profileImage: ProfileImage) {
+        profileImageCandidateStateFlow.value = profileImage
+    }
+
+    override fun clearProfileImageCache() {
+        profileImageCandidateStateFlow.value = null
     }
 }

--- a/core/model/src/androidMain/kotlin/io/github/droidkaigi/confsched/model/ProfileImage.kt
+++ b/core/model/src/androidMain/kotlin/io/github/droidkaigi/confsched/model/ProfileImage.kt
@@ -1,0 +1,16 @@
+package io.github.droidkaigi.confsched.model
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import androidx.compose.ui.unit.IntRect
+import java.io.ByteArrayOutputStream
+
+actual fun ByteArray.crop(rect: IntRect): ByteArray {
+    val bitmap = BitmapFactory.decodeByteArray(this, 0, size)
+    val cropped = Bitmap.createBitmap(bitmap, rect.left, rect.top, rect.width, rect.height)
+
+    return ByteArrayOutputStream(cropped.byteCount).use { stream ->
+        cropped.compress(Bitmap.CompressFormat.PNG, 100, stream)
+        stream.toByteArray()
+    }
+}

--- a/core/model/src/androidMain/kotlin/io/github/droidkaigi/confsched/model/ProfileImage.kt
+++ b/core/model/src/androidMain/kotlin/io/github/droidkaigi/confsched/model/ProfileImage.kt
@@ -3,14 +3,23 @@ package io.github.droidkaigi.confsched.model
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
 import java.io.ByteArrayOutputStream
 
+actual val ByteArray.imageSize: IntSize
+    get() = this.asBitmap().let {
+        IntSize(width = it.width, height = it.height)
+    }
+
 actual fun ByteArray.crop(rect: IntRect): ByteArray {
-    val bitmap = BitmapFactory.decodeByteArray(this, 0, size)
-    val cropped = Bitmap.createBitmap(bitmap, rect.left, rect.top, rect.width, rect.height)
+    val cropped = Bitmap.createBitmap(this.asBitmap(), rect.left, rect.top, rect.width, rect.height)
 
     return ByteArrayOutputStream(cropped.byteCount).use { stream ->
         cropped.compress(Bitmap.CompressFormat.PNG, 100, stream)
         stream.toByteArray()
     }
+}
+
+private fun ByteArray.asBitmap(): Bitmap {
+    return BitmapFactory.decodeByteArray(this, 0, size)
 }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/ProfileCardRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/ProfileCardRepository.kt
@@ -9,6 +9,16 @@ interface ProfileCardRepository {
     fun profileCard(): ProfileCard
     suspend fun save(profileCard: ProfileCard.Exists)
     suspend fun loadQrCodeImageByteArray(link: String, centerLogoRes: DrawableResource): ByteArray
+
+    @Composable
+    fun profileImageInEdit(): ProfileImage?
+    fun setProfileImageInEdit(profileImage: ProfileImage)
+    fun clearProfileImageInEdit()
+
+    @Composable
+    fun profileImageCandidate(): ProfileImage?
+    fun setProfileImageCandidate(profileImage: ProfileImage)
+    fun clearProfileImageCache()
 }
 
 @Composable

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/ProfileImage.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/ProfileImage.kt
@@ -1,10 +1,14 @@
 package io.github.droidkaigi.confsched.model
 
 import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
 
 data class ProfileImage(
     val bytes: ByteArray,
 ) {
+    val size: IntSize
+        get() = bytes.imageSize
+
     fun crop(rect: IntRect): ProfileImage {
         return copy(
             bytes = bytes.crop(rect),
@@ -25,4 +29,5 @@ data class ProfileImage(
     }
 }
 
+expect val ByteArray.imageSize: IntSize
 expect fun ByteArray.crop(rect: IntRect): ByteArray

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/ProfileImage.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/ProfileImage.kt
@@ -6,8 +6,9 @@ data class ProfileImage(
     val bytes: ByteArray,
 ) {
     fun crop(rect: IntRect): ProfileImage {
-        // TODO
-        return this
+        return copy(
+            bytes = bytes.crop(rect),
+        )
     }
 
     override fun equals(other: Any?): Boolean {
@@ -23,3 +24,5 @@ data class ProfileImage(
         return bytes.contentHashCode()
     }
 }
+
+expect fun ByteArray.crop(rect: IntRect): ByteArray

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/ProfileImage.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/ProfileImage.kt
@@ -1,0 +1,25 @@
+package io.github.droidkaigi.confsched.model
+
+import androidx.compose.ui.unit.IntRect
+
+data class ProfileImage(
+    val bytes: ByteArray,
+) {
+    fun crop(rect: IntRect): ProfileImage {
+        // TODO
+        return this
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as ProfileImage
+
+        return bytes.contentEquals(other.bytes)
+    }
+
+    override fun hashCode(): Int {
+        return bytes.contentHashCode()
+    }
+}

--- a/core/model/src/iosMain/kotlin/io/github/droidkaigi/confsched/model/ProfileImage.kt
+++ b/core/model/src/iosMain/kotlin/io/github/droidkaigi/confsched/model/ProfileImage.kt
@@ -1,9 +1,17 @@
 package io.github.droidkaigi.confsched.model
 
 import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
 import org.jetbrains.skia.Bitmap
 import org.jetbrains.skia.EncodedImageFormat
 import org.jetbrains.skia.Image
+
+actual val ByteArray.imageSize: IntSize
+    get() = Bitmap.makeFromImage(
+        Image.makeFromEncoded(this),
+    ).let {
+        IntSize(width = it.width, height = it.height)
+    }
 
 actual fun ByteArray.crop(rect: IntRect): ByteArray {
     val image = Image.makeFromEncoded(this)

--- a/core/model/src/iosMain/kotlin/io/github/droidkaigi/confsched/model/ProfileImage.kt
+++ b/core/model/src/iosMain/kotlin/io/github/droidkaigi/confsched/model/ProfileImage.kt
@@ -1,0 +1,22 @@
+package io.github.droidkaigi.confsched.model
+
+import androidx.compose.ui.unit.IntRect
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.EncodedImageFormat
+import org.jetbrains.skia.Image
+
+actual fun ByteArray.crop(rect: IntRect): ByteArray {
+    val image = Image.makeFromEncoded(this)
+
+    val bitmap = Bitmap()
+    val imageInfo = image.imageInfo.withWidthHeight(
+        width = rect.width,
+        height = rect.height,
+    )
+    bitmap.allocPixels(imageInfo)
+    image.readPixels(dst = bitmap, srcX = rect.left, srcY = rect.top)
+
+    val data = Image.makeFromBitmap(bitmap)
+        .encodeToData(format = EncodedImageFormat.PNG, quality = 100)
+    return requireNotNull(data).bytes
+}

--- a/feature/profilecard/src/androidMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/SingleImagePickerLauncher.kt
+++ b/feature/profilecard/src/androidMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/SingleImagePickerLauncher.kt
@@ -1,0 +1,23 @@
+package io.github.droidkaigi.confsched.profilecard.component
+
+import androidx.compose.runtime.Composable
+import com.preat.peekaboo.image.picker.ImagePickerLauncher
+import com.preat.peekaboo.image.picker.toImageBitmap
+import kotlinx.coroutines.CoroutineScope
+
+@Composable
+internal actual fun rememberCroppingImagePickerLauncher(
+    scope: CoroutineScope,
+    onCropImage: (ByteArray) -> Unit,
+    onSelectedImage: (ByteArray) -> Unit,
+): ImagePickerLauncher {
+    return rememberSingleImagePickerLauncher(scope) {
+        val imageBitmap = it.toImageBitmap()
+
+        if (imageBitmap.height != imageBitmap.width) {
+            onCropImage(it)
+        } else {
+            onSelectedImage(it)
+        }
+    }
+}

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/CropImageScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/CropImageScreen.kt
@@ -1,0 +1,84 @@
+package io.github.droidkaigi.confsched.profilecard
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons.AutoMirrored.Filled
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.dropUnlessResumed
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.preat.peekaboo.image.picker.toImageBitmap
+import io.github.droidkaigi.confsched.compose.EventFlow
+import io.github.droidkaigi.confsched.compose.rememberEventFlow
+import io.github.droidkaigi.confsched.model.ProfileImage
+
+const val cropImageScreenRoute = "cropImage"
+
+fun NavGraphBuilder.cropImageScreens(
+    onNavigationIconClick: () -> Unit,
+) {
+    composable(
+        cropImageScreenRoute,
+    ) {
+        CropImageScreen(
+            onNavigationIconClick = dropUnlessResumed(block = onNavigationIconClick),
+        )
+    }
+}
+
+internal data class CropImageScreenState(
+    val profileImage: ProfileImage?,
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun CropImageScreen(
+    onNavigationIconClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    eventEmitter: EventFlow<CropImageScreenEvent> = rememberEventFlow(),
+    uiState: CropImageScreenState = cropImageScreenPresenter(eventEmitter),
+) {
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text("Crop Image")
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onNavigationIconClick,
+                    ) {
+                        Icon(
+                            imageVector = Filled.ArrowBack,
+                            contentDescription = null,
+                        )
+                    }
+                },
+            )
+        },
+    ) { contentPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(contentPadding),
+        ) {
+            uiState.profileImage?.let {
+                Image(
+                    bitmap = it.bytes.toImageBitmap(),
+                    contentDescription = null,
+                )
+            }
+        }
+    }
+}

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/CropImageScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/CropImageScreen.kt
@@ -1,11 +1,18 @@
 package io.github.droidkaigi.confsched.profilecard
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons.AutoMirrored.Filled
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -13,7 +20,23 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.toRect
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.roundToIntRect
+import androidx.compose.ui.unit.toSize
 import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
@@ -21,32 +44,49 @@ import com.preat.peekaboo.image.picker.toImageBitmap
 import io.github.droidkaigi.confsched.compose.EventFlow
 import io.github.droidkaigi.confsched.compose.rememberEventFlow
 import io.github.droidkaigi.confsched.model.ProfileImage
+import io.github.droidkaigi.confsched.profilecard.component.ImageCropAreaSelector
+import kotlin.math.max
 
 const val cropImageScreenRoute = "cropImage"
 
 fun NavGraphBuilder.cropImageScreens(
     onNavigationIconClick: () -> Unit,
+    onConfirm: () -> Unit,
 ) {
     composable(
         cropImageScreenRoute,
     ) {
         CropImageScreen(
             onNavigationIconClick = dropUnlessResumed(block = onNavigationIconClick),
+            onConfirm = onConfirm,
         )
     }
 }
 
-internal data class CropImageScreenState(
-    val profileImage: ProfileImage?,
-)
+internal sealed interface CropImageScreenState {
+    data object Init : CropImageScreenState
+
+    data class Select(
+        val profileImage: ProfileImage,
+        val isProcessing: Boolean,
+    ) : CropImageScreenState
+
+    data class Confirm(
+        val profileImage: ProfileImage,
+    ) : CropImageScreenState
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun CropImageScreen(
     onNavigationIconClick: () -> Unit,
+    onConfirm: () -> Unit,
     modifier: Modifier = Modifier,
     eventEmitter: EventFlow<CropImageScreenEvent> = rememberEventFlow(),
-    uiState: CropImageScreenState = cropImageScreenPresenter(eventEmitter),
+    uiState: CropImageScreenState = cropImageScreenPresenter(
+        onConfirm = onConfirm,
+        events = eventEmitter,
+    ),
 ) {
     Scaffold(
         modifier = modifier.fillMaxSize(),
@@ -68,16 +108,220 @@ internal fun CropImageScreen(
             )
         },
     ) { contentPadding ->
+        when (uiState) {
+            is CropImageScreenState.Init -> Unit
+            is CropImageScreenState.Select -> {
+                Box(
+                    modifier = modifier.padding(contentPadding),
+                ) {
+                    SelectScreen(
+                        profileImage = uiState.profileImage,
+                        isCropButtonEnabled = !uiState.isProcessing,
+                        onCrop = { cropRect ->
+                            eventEmitter.tryEmit(
+                                CropImageScreenEvent.Crop(
+                                    rect = cropRect,
+                                ),
+                            )
+                        },
+                    )
+
+                    if (uiState.isProcessing) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.align(Alignment.Center),
+                        )
+                    }
+                }
+            }
+
+            is CropImageScreenState.Confirm -> {
+                ConfirmScreen(
+                    profileImage = uiState.profileImage,
+                    onConfirm = {
+                        eventEmitter.tryEmit(CropImageScreenEvent.Confirm)
+                    },
+                    onCancel = {
+                        eventEmitter.tryEmit(CropImageScreenEvent.Cancel)
+                    },
+                    modifier = modifier.padding(contentPadding),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SelectScreen(
+    profileImage: ProfileImage,
+    isCropButtonEnabled: Boolean,
+    onCrop: (cropRect: IntRect) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val cropRectRatio = 0.6f
+    var transformCalculator: TransformCalculator? by remember { mutableStateOf(null) }
+    var scale: Float by remember { mutableFloatStateOf(1f) }
+    var offset: Offset by remember { mutableStateOf(Offset.Zero) }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(bottom = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        BoxWithConstraints(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            contentAlignment = Alignment.Center,
+        ) {
+            val density = LocalDensity.current
+            val calculator = remember(profileImage, maxWidth, maxHeight, density) {
+                val imageSize = profileImage.size.toSize()
+                val layoutSize = with(density) {
+                    Size(
+                        width = maxWidth.toPx(),
+                        height = maxHeight.toPx(),
+                    )
+                }
+
+                TransformCalculator(
+                    cropRectRatio = cropRectRatio,
+                    layoutSize = layoutSize,
+                    imageSize = imageSize,
+                ).also { calculator ->
+                    scale = max(calculator.minScale, 1f)
+                    transformCalculator = calculator
+                }
+            }
+
+            ImageCropAreaSelector(
+                profileImage = profileImage,
+                transformCalculator = calculator,
+                scale = { scale },
+                offset = { offset },
+                onTransform = { newScale, newOffset ->
+                    scale = newScale
+                    offset = newOffset
+                },
+            )
+        }
+
+        Button(
+            onClick = {
+                val calculator = requireNotNull(transformCalculator)
+                val cropRect = calculator.calculateCropRectInImage(
+                    scale = scale,
+                    offset = offset,
+                )
+                onCrop(cropRect.roundToIntRect())
+            },
+            enabled = isCropButtonEnabled,
+        ) {
+            Text("Crop")
+        }
+    }
+}
+
+internal class TransformCalculator(
+    cropRectRatio: Float,
+    layoutSize: Size,
+    private val imageSize: Size,
+) {
+    private val imageLayoutRatio: Float =
+        if (imageSize.width / imageSize.height >= layoutSize.width / layoutSize.height) {
+            layoutSize.width / imageSize.width
+        } else {
+            layoutSize.height / imageSize.height
+        }
+
+    val cropRectLength: Float = if (layoutSize.width <= layoutSize.height) {
+        layoutSize.width * cropRectRatio
+    } else {
+        layoutSize.height * cropRectRatio
+    }
+
+    val minScale: Float = if (imageSize.width <= imageSize.height) {
+        cropRectLength / (imageSize.width * imageLayoutRatio)
+    } else {
+        cropRectLength / (imageSize.height * imageLayoutRatio)
+    }
+
+    fun calculateNext(
+        oldScale: Float,
+        oldOffset: Offset,
+        zoom: Float,
+        pan: Offset,
+    ): Pair<Float, Offset> {
+        val tempOffset = oldOffset - pan / oldScale
+        val newScale = (oldScale * zoom).coerceAtLeast(minScale)
+
+        val minOffsetX =
+            (cropRectLength / newScale - imageSize.width * imageLayoutRatio) / 2
+        val minOffsetY =
+            (cropRectLength / newScale - imageSize.height * imageLayoutRatio) / 2
+
+        val newOffset = Offset(
+            x = tempOffset.x.coerceIn(minOffsetX, -minOffsetX),
+            y = tempOffset.y.coerceIn(minOffsetY, -minOffsetY),
+        )
+
+        return newScale to newOffset
+    }
+
+    fun calculateCropRectInImage(
+        scale: Float,
+        offset: Offset,
+    ): Rect {
+        val cropRect = Rect(
+            offset = offset * scale - Offset(cropRectLength, cropRectLength) / 2f,
+            size = Size(cropRectLength, cropRectLength),
+        )
+        return Rect(
+            offset = cropRect.topLeft / (scale * imageLayoutRatio) + imageSize.toRect().center,
+            size = cropRect.size / (scale * imageLayoutRatio),
+        )
+    }
+}
+
+@Composable
+private fun ConfirmScreen(
+    profileImage: ProfileImage,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(bottom = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
         Box(
             modifier = Modifier
-                .fillMaxSize()
-                .padding(contentPadding),
+                .fillMaxWidth()
+                .weight(1f),
+            contentAlignment = Alignment.Center,
         ) {
-            uiState.profileImage?.let {
-                Image(
-                    bitmap = it.bytes.toImageBitmap(),
-                    contentDescription = null,
-                )
+            Image(
+                modifier = Modifier.fillMaxSize(),
+                bitmap = profileImage.bytes.toImageBitmap(),
+                contentDescription = null,
+                contentScale = ContentScale.Fit,
+            )
+        }
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(24.dp),
+        ) {
+            Button(
+                onClick = onConfirm,
+            ) {
+                Text("Confirm")
+            }
+            Button(
+                onClick = onCancel,
+            ) {
+                Text("Cancel")
             }
         }
     }

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/CropImageScreenPresenter.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/CropImageScreenPresenter.kt
@@ -2,37 +2,81 @@ package io.github.droidkaigi.confsched.profilecard
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.IntRect
 import io.github.droidkaigi.confsched.compose.SafeLaunchedEffect
 import io.github.droidkaigi.confsched.droidkaigiui.providePresenterDefaults
 import io.github.droidkaigi.confsched.model.ProfileCardRepository
 import io.github.droidkaigi.confsched.model.ProfileImage
 import io.github.droidkaigi.confsched.model.localProfileCardRepository
-import io.github.droidkaigi.confsched.profilecard.CropImageScreenEvent.Crop
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
 
 internal sealed interface CropImageScreenEvent {
     data class Crop(val rect: IntRect) : CropImageScreenEvent
+    data object Confirm : CropImageScreenEvent
+    data object Cancel : CropImageScreenEvent
 }
 
 @Composable
 internal fun cropImageScreenPresenter(
+    onConfirm: () -> Unit,
     events: Flow<CropImageScreenEvent>,
     repository: ProfileCardRepository = localProfileCardRepository(),
 ): CropImageScreenState = providePresenterDefaults { _ ->
-    val profileImage: ProfileImage? by rememberUpdatedState(repository.profileImageCandidate())
+    val profileImageCandidate: ProfileImage? by rememberUpdatedState(repository.profileImageCandidate())
+    var croppedProfileImage: ProfileImage? by remember { mutableStateOf(null) }
+    var isProcessing: Boolean by remember { mutableStateOf(false) }
 
     SafeLaunchedEffect(Unit) {
         events.collect { event ->
             when (event) {
-                is Crop -> {
-                    // TODO
+                is CropImageScreenEvent.Crop -> {
+                    isProcessing = true
+
+                    withContext(Dispatchers.Default) {
+                        croppedProfileImage = requireNotNull(profileImageCandidate).crop(event.rect)
+                    }
+
+                    isProcessing = false
+                }
+
+                is CropImageScreenEvent.Confirm -> {
+                    val result = requireNotNull(croppedProfileImage)
+                    repository.setProfileImageInEdit(result)
+
+                    onConfirm()
+                }
+
+                is CropImageScreenEvent.Cancel -> {
+                    croppedProfileImage = null
                 }
             }
         }
     }
-    CropImageScreenState(
-        profileImage = profileImage,
-    )
+
+    val candidate = profileImageCandidate
+    val cropped = croppedProfileImage
+    when {
+        candidate == null -> {
+            CropImageScreenState.Init
+        }
+
+        cropped == null -> {
+            CropImageScreenState.Select(
+                profileImage = candidate,
+                isProcessing = isProcessing,
+            )
+        }
+
+        else -> {
+            CropImageScreenState.Confirm(
+                profileImage = cropped,
+            )
+        }
+    }
 }

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/CropImageScreenPresenter.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/CropImageScreenPresenter.kt
@@ -1,0 +1,38 @@
+package io.github.droidkaigi.confsched.profilecard
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.unit.IntRect
+import io.github.droidkaigi.confsched.compose.SafeLaunchedEffect
+import io.github.droidkaigi.confsched.droidkaigiui.providePresenterDefaults
+import io.github.droidkaigi.confsched.model.ProfileCardRepository
+import io.github.droidkaigi.confsched.model.ProfileImage
+import io.github.droidkaigi.confsched.model.localProfileCardRepository
+import io.github.droidkaigi.confsched.profilecard.CropImageScreenEvent.Crop
+import kotlinx.coroutines.flow.Flow
+
+internal sealed interface CropImageScreenEvent {
+    data class Crop(val rect: IntRect) : CropImageScreenEvent
+}
+
+@Composable
+internal fun cropImageScreenPresenter(
+    events: Flow<CropImageScreenEvent>,
+    repository: ProfileCardRepository = localProfileCardRepository(),
+): CropImageScreenState = providePresenterDefaults { _ ->
+    val profileImage: ProfileImage? by rememberUpdatedState(repository.profileImageCandidate())
+
+    SafeLaunchedEffect(Unit) {
+        events.collect { event ->
+            when (event) {
+                is Crop -> {
+                    // TODO
+                }
+            }
+        }
+    }
+    CropImageScreenState(
+        profileImage = profileImage,
+    )
+}

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -393,13 +393,11 @@ internal fun EditScreen(
     var nickname by remember { mutableStateOf(uiState.nickname) }
     var occupation by remember { mutableStateOf(uiState.occupation) }
     var link by remember { mutableStateOf(uiState.link) }
-    var imageByteArray: ByteArray? by remember { mutableStateOf(uiState.image?.decodeBase64Bytes()) }
-    val image by remember { derivedStateOf { imageByteArray?.toImageBitmap() } }
     var selectedCardType by remember { mutableStateOf(uiState.cardType) }
 
-    val isValidInputs by remember {
+    val isValidInputs by remember(uiState.image) {
         derivedStateOf {
-            nickname.isNotEmpty() && occupation.isNotEmpty() && link.isNotEmpty() && image != null
+            nickname.isNotEmpty() && occupation.isNotEmpty() && link.isNotEmpty() && uiState.image != null
         }
     }
 
@@ -469,14 +467,12 @@ internal fun EditScreen(
                 Label(label = stringResource(ProfileCardRes.string.image))
                 Spacer(modifier = Modifier.height(12.dp))
                 ImagePickerWithError(
-                    image = image,
+                    image = uiState.image?.decodeBase64Bytes()?.toImageBitmap(),
                     onSelectedImage = {
-                        imageByteArray = it
                         onChangeImage(it.toBase64())
                     },
                     errorMessage = profileCardError.imageError,
                     onClearImage = {
-                        imageByteArray = null
                         onChangeImage("")
                     },
                     onCropImage = {
@@ -502,7 +498,7 @@ internal fun EditScreen(
                             nickname = nickname,
                             occupation = occupation,
                             link = link,
-                            image = imageByteArray?.toBase64() ?: "",
+                            image = uiState.image ?: "",
                             cardType = selectedCardType,
                         ),
                     )

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -390,10 +390,10 @@ internal fun EditScreen(
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
 ) {
-    var nickname by remember { mutableStateOf(uiState.nickname) }
-    var occupation by remember { mutableStateOf(uiState.occupation) }
-    var link by remember { mutableStateOf(uiState.link) }
-    var selectedCardType by remember { mutableStateOf(uiState.cardType) }
+    var nickname by rememberSaveable { mutableStateOf(uiState.nickname) }
+    var occupation by rememberSaveable { mutableStateOf(uiState.occupation) }
+    var link by rememberSaveable { mutableStateOf(uiState.link) }
+    var selectedCardType by rememberSaveable { mutableStateOf(uiState.cardType) }
 
     val isValidInputs by remember(uiState.image) {
         derivedStateOf {

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreenPresenter.kt
@@ -1,10 +1,12 @@
 package io.github.droidkaigi.confsched.profilecard
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import conference_app_2024.feature.profilecard.generated.resources.add_validate_format
 import conference_app_2024.feature.profilecard.generated.resources.droidkaigi_logo
@@ -55,17 +57,21 @@ internal sealed interface CardScreenEvent : ProfileCardScreenEvent {
     data object Edit : CardScreenEvent
 }
 
-internal fun ProfileCard.toEditUiState(): ProfileCardUiState.Edit {
+internal fun ProfileCard.toEditUiState(
+    profileImageInEditString: String?,
+): ProfileCardUiState.Edit {
     return when (this) {
         is ProfileCard.Exists -> ProfileCardUiState.Edit(
             nickname = nickname,
             occupation = occupation,
             link = link,
-            image = image,
+            image = profileImageInEditString,
             cardType = cardType,
         )
 
-        ProfileCard.DoesNotExists, ProfileCard.Loading -> ProfileCardUiState.Edit()
+        ProfileCard.DoesNotExists, ProfileCard.Loading -> ProfileCardUiState.Edit(
+            image = profileImageInEditString,
+        )
     }
 }
 
@@ -112,16 +118,36 @@ internal fun profileCardScreenPresenter(
 
     val navigateToCropImage by rememberUpdatedState(onNavigateToCropImage)
     val profileCard: ProfileCard by rememberUpdatedState(repository.profileCard())
+    val profileImageInEdit: ProfileImage? by rememberUpdatedState(repository.profileImageInEdit())
+    val profileImageInEditString: String? by remember {
+        derivedStateOf {
+            profileImageInEdit?.bytes?.toBase64()
+        }
+    }
     var isLoading: Boolean by remember { mutableStateOf(false) }
-    val editUiState: ProfileCardUiState.Edit by rememberUpdatedState(profileCard.toEditUiState())
+    val editUiState: ProfileCardUiState.Edit by rememberUpdatedState(
+        profileCard.toEditUiState(
+            profileImageInEditString = profileImageInEditString,
+        ),
+    )
     val cardUiState: ProfileCardUiState.Card? by rememberUpdatedState(profileCard.toCardUiState())
     var cardError by remember { mutableStateOf(ProfileCardError()) }
-    var uiType: ProfileCardUiType by remember { mutableStateOf(ProfileCardUiType.Loading) }
+    var uiType: ProfileCardUiType by rememberSaveable { mutableStateOf(ProfileCardUiType.Loading) }
 
     // at first launch, if you have a profile card, show card ui
     SafeLaunchedEffect(profileCard) {
-        uiType = when (profileCard) {
-            is ProfileCard.Exists -> ProfileCardUiType.Card
+        if (uiType != ProfileCardUiType.Loading) return@SafeLaunchedEffect
+
+        uiType = when (val card = profileCard) {
+            is ProfileCard.Exists -> {
+                repository.setProfileImageInEdit(
+                    ProfileImage(
+                        bytes = card.image.decodeBase64Bytes(),
+                    )
+                )
+                ProfileCardUiType.Card
+            }
+
             ProfileCard.DoesNotExists -> ProfileCardUiType.Edit
             ProfileCard.Loading -> ProfileCardUiType.Loading
         }
@@ -184,6 +210,13 @@ internal fun profileCardScreenPresenter(
                 cardError = cardError.copy(
                     imageError = if (event.image.isEmpty()) emptyImageErrorString else "",
                 )
+                if (event.image.isEmpty()) {
+                    repository.clearProfileImageInEdit()
+                } else {
+                    repository.setProfileImageInEdit(
+                        ProfileImage(bytes = event.image.decodeBase64Bytes()),
+                    )
+                }
             }
 
             is EditScreenEvent.CropImage -> {

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/ImageCropAreaSelector.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/ImageCropAreaSelector.kt
@@ -1,0 +1,88 @@
+package io.github.droidkaigi.confsched.profilecard.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.center
+import androidx.compose.ui.geometry.toRect
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import com.preat.peekaboo.image.picker.toImageBitmap
+import io.github.droidkaigi.confsched.model.ProfileImage
+import io.github.droidkaigi.confsched.profilecard.TransformCalculator
+
+@Composable
+internal fun ImageCropAreaSelector(
+    profileImage: ProfileImage,
+    transformCalculator: TransformCalculator,
+    scale: () -> Float,
+    offset: () -> Offset,
+    onTransform: (scale: Float, offset: Offset) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val strokeWidth = with(LocalDensity.current) { 2.dp.toPx() }
+    val strokeOuterColor = MaterialTheme.colorScheme.onSurface
+    val strokeInnerColor = MaterialTheme.colorScheme.surface
+
+    Image(
+        modifier = modifier
+            .fillMaxSize()
+            .pointerInput(profileImage) {
+                detectTransformGestures { _, pan, zoom, _ ->
+                    val (newScale, newOffset) = transformCalculator.calculateNext(
+                        oldScale = scale(),
+                        oldOffset = offset(),
+                        zoom = zoom,
+                        pan = pan,
+                    )
+
+                    onTransform(newScale, newOffset)
+                }
+            }
+            .drawWithContent {
+                drawContent()
+
+                val length = transformCalculator.cropRectLength
+                val outerRect = Size(length, length)
+                    .toRect()
+                    .translate(size.center)
+                    .translate(-length / 2, -length / 2)
+                val innerRect = outerRect.deflate(strokeWidth)
+
+                drawRect(
+                    color = strokeOuterColor,
+                    topLeft = outerRect.topLeft,
+                    size = outerRect.size,
+                    style = Stroke(width = strokeWidth),
+                )
+                drawRect(
+                    color = strokeInnerColor,
+                    topLeft = innerRect.topLeft,
+                    size = innerRect.size,
+                    style = Stroke(width = strokeWidth),
+                )
+            }
+            .graphicsLayer {
+                val currentScale = scale()
+                val currentOffset = offset()
+
+                scaleX = currentScale
+                scaleY = currentScale
+                translationX = -currentOffset.x * currentScale
+                translationY = -currentOffset.y * currentScale
+            },
+        bitmap = profileImage.bytes.toImageBitmap(),
+        contentDescription = null,
+        contentScale = ContentScale.Fit,
+    )
+}

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/PhotoPickButton.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/PhotoPickButton.kt
@@ -5,9 +5,9 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import com.preat.peekaboo.image.picker.ImagePickerLauncher
 import com.preat.peekaboo.image.picker.SelectionMode
 import com.preat.peekaboo.image.picker.rememberImagePickerLauncher
-import com.preat.peekaboo.image.picker.toImageBitmap
 import kotlinx.coroutines.CoroutineScope
 
 @Composable
@@ -17,15 +17,10 @@ internal fun PhotoPickerButton(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    val imagePicker = rememberSingleImagePickerLauncher {
-        val imageBitmap = it.toImageBitmap()
-
-        if (imageBitmap.height != imageBitmap.width) {
-            onCropImage(it)
-        } else {
-            onSelectedImage(it)
-        }
-    }
+    val imagePicker = rememberCroppingImagePickerLauncher(
+        onSelectedImage = onSelectedImage,
+        onCropImage = onCropImage,
+    )
 
     OutlinedButton(
         onClick = imagePicker::launch,
@@ -37,7 +32,14 @@ internal fun PhotoPickerButton(
 }
 
 @Composable
-private fun rememberSingleImagePickerLauncher(
+internal expect fun rememberCroppingImagePickerLauncher(
+    scope: CoroutineScope = rememberCoroutineScope(),
+    onCropImage: (ByteArray) -> Unit,
+    onSelectedImage: (ByteArray) -> Unit,
+): ImagePickerLauncher
+
+@Composable
+internal fun rememberSingleImagePickerLauncher(
     scope: CoroutineScope = rememberCoroutineScope(),
     onResult: (ByteArray) -> Unit,
 ) = rememberImagePickerLauncher(

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/PhotoPickButton.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/PhotoPickButton.kt
@@ -7,15 +7,25 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import com.preat.peekaboo.image.picker.SelectionMode
 import com.preat.peekaboo.image.picker.rememberImagePickerLauncher
+import com.preat.peekaboo.image.picker.toImageBitmap
 import kotlinx.coroutines.CoroutineScope
 
 @Composable
 internal fun PhotoPickerButton(
     onSelectedImage: (ByteArray) -> Unit,
+    onCropImage: (ByteArray) -> Unit,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    val imagePicker = rememberSingleImagePickerLauncher(onResult = onSelectedImage)
+    val imagePicker = rememberSingleImagePickerLauncher {
+        val imageBitmap = it.toImageBitmap()
+
+        if (imageBitmap.height != imageBitmap.width) {
+            onCropImage(it)
+        } else {
+            onSelectedImage(it)
+        }
+    }
 
     OutlinedButton(
         onClick = imagePicker::launch,

--- a/feature/profilecard/src/iosMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardViewController.kt
+++ b/feature/profilecard/src/iosMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardViewController.kt
@@ -28,6 +28,7 @@ fun profileCardViewController(
         contentPadding = PaddingValues(
             bottom = 30.dp, // Height of bottom tab bar
         ),
+        onNavigateToCropImage = { /* no action for iOS side */ },
     )
 }
 
@@ -39,5 +40,8 @@ fun profileCardScreenPresenterStateFlow(
     events = events,
     repositories = repositories,
 ) {
-    profileCardScreenPresenter(events)
+    profileCardScreenPresenter(
+        onNavigateToCropImage = { /* no action for iOS side */ },
+        events = events,
+    )
 }

--- a/feature/profilecard/src/iosMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/SingleImagePickerLauncher.kt
+++ b/feature/profilecard/src/iosMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/SingleImagePickerLauncher.kt
@@ -1,0 +1,16 @@
+package io.github.droidkaigi.confsched.profilecard.component
+
+import androidx.compose.runtime.Composable
+import com.preat.peekaboo.image.picker.ImagePickerLauncher
+import kotlinx.coroutines.CoroutineScope
+
+@Composable
+internal actual fun rememberCroppingImagePickerLauncher(
+    scope: CoroutineScope,
+    onCropImage: (ByteArray) -> Unit,
+    onSelectedImage: (ByteArray) -> Unit,
+): ImagePickerLauncher {
+    return rememberSingleImagePickerLauncher(scope) {
+        onSelectedImage(it)
+    }
+}


### PR DESCRIPTION
## Issue
#413 

## Overview (Required)
- Add CropImageScreen to crop image to square
  - There is no design corresponding to this screen, right?
- If selected image is not square, transition to CropImageScreen
  - otherwise, apply selected image
- I tried to implement in iOS, but due to some problems I couldn't complete. So temporarily split process
  - in iOS with compose multiplatform, when backing from CropImageScreen, the state of bottom navigation is cleared (app goes to TimeTable)
    - it happens other case, i.e., Contributers, Stuff, ....
    - we can continue editing during first time, but not once we create profile
  - Simply, it takes time to implement features because I am not familiar with SwiftUI
- Multi language support is left due to large diff

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)

see videos

Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/3f2e9c46-4d1c-44d7-9068-ff4030bcd106" width="300" > | <video src="https://github.com/user-attachments/assets/4e711411-f23c-4ced-affd-b8cde79499f8" width="300" >

for various images
<video src="https://github.com/user-attachments/assets/c4777314-2618-456a-b0b7-2c58df09e58c" width="300" >

in landscape screen
<video src="https://github.com/user-attachments/assets/3c8dc325-f72c-4e6c-b83c-c298097d3ee5" width="300" >

cropping in iOS (currently unavailable due to the above issue)
<video src="https://github.com/user-attachments/assets/ac30ed52-19b3-4cc8-b15f-98d40c1a9050" width="300" >
