### PR TITLE
:wrench: [SettingsScreen]The accessibility text was cut off, so I fixed it.

### DIFF
--- a/feature/settings/src/commonMain/kotlin/io/github/droidkaigi/confsched/settings/section/SettingsAccessibility.kt
+++ b/feature/settings/src/commonMain/kotlin/io/github/droidkaigi/confsched/settings/section/SettingsAccessibility.kt
@@ -1,6 +1,5 @@
 package io.github.droidkaigi.confsched.settings.section
 
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material3.HorizontalDivider
@@ -34,9 +33,7 @@ fun LazyListScope.accessibility(
 ) {
     item {
         Text(
-            modifier = Modifier
-                .height(40.dp)
-                .padding(top = 16.dp),
+            modifier = Modifier.padding(top = 16.dp),
             text = stringResource(SettingsRes.string.section_title_accessibility),
             style = MaterialTheme.typography.titleMedium,
         )


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- Because the height of the text was a fixed value, when the font size was increased, the text was cut off and became unreadable.
- This makes it _less accessible_.

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/5a3eceb3-59f0-4ca4-b172-56ed6e2d30ae" width="300" /> | <img src="https://github.com/user-attachments/assets/d5112e39-bb2e-4579-b319-9cd4f13f23ca" width="300" />