### PR TITLE
:wrench: [IosOrientationSensorManager] Reverse the pitch value to match the left-hand coordinate system.

### DIFF
--- a/core/droidkaigiui/src/iosMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/OrientationSensorManager.ios.kt
+++ b/core/droidkaigiui/src/iosMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/OrientationSensorManager.ios.kt
@@ -35,7 +35,8 @@ internal class IosOrientationSensorManager(
                 onOrientationChanged(
                     Orientation(
                         azimuth = motion.attitude.yaw.toFloat(),
-                        pitch = motion.attitude.pitch.toFloat(),
+                        // Unlike Android, iOS uses a left-handed coordinate system, so we need to invert the pitch value.
+                        pitch = -motion.attitude.pitch.toFloat(),
                         roll = motion.attitude.roll.toFloat(),
                     ),
                 )


### PR DESCRIPTION
## Issue
- close #960

## Overview (Required)
- Everything is written in the Issue.
- Even if you take a Before/After video using ADB or xcrun, it's meaningless because you can't see how the device is being moved in your hands after all.
- Also, I couldn't take a video because there was a risk that the video would include images of my living environment if I used the camera. 🙇 

- I'm sorry that it takes a long time to build the actual device, but if you try installing the main one and this branch one, you'll see that the movement when tilting the device has been corrected and is consistent between Android and iOS.
- Please merge after you have seen the fix on the actual device. 🙏 