### PR TITLE
Align TimetableItemTag content for SearchScreen with Figma

### DIFF
--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/CustomSemanticsProperties.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/CustomSemanticsProperties.kt
@@ -1,0 +1,8 @@
+package io.github.droidkaigi.confsched.droidkaigiui
+
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import io.github.droidkaigi.confsched.model.Lang
+
+object CustomSemanticsProperties {
+    val SessionLanguage = SemanticsPropertyKey<Lang>("SessionLanguage")
+}

--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/CustomSemanticsProperties.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/CustomSemanticsProperties.kt
@@ -1,8 +1,0 @@
-package io.github.droidkaigi.confsched.droidkaigiui
-
-import androidx.compose.ui.semantics.SemanticsPropertyKey
-import io.github.droidkaigi.confsched.model.Lang
-
-object CustomSemanticsProperties {
-    val SessionLanguage = SemanticsPropertyKey<Lang>("SessionLanguage")
-}

--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/TimetableItemCard.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/TimetableItemCard.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -56,6 +57,7 @@ import conference_app_2024.core.droidkaigiui.generated.resources.not_bookmarked
 import io.github.droidkaigi.confsched.designsystem.theme.LocalRoomTheme
 import io.github.droidkaigi.confsched.designsystem.theme.ProvideRoomTheme
 import io.github.droidkaigi.confsched.designsystem.theme.primaryFixed
+import io.github.droidkaigi.confsched.droidkaigiui.CustomSemanticsProperties
 import io.github.droidkaigi.confsched.droidkaigiui.DroidKaigiUiRes
 import io.github.droidkaigi.confsched.droidkaigiui.animation.LocalFavoriteAnimationScope
 import io.github.droidkaigi.confsched.droidkaigiui.previewOverride
@@ -98,6 +100,10 @@ fun TimetableItemCard(
         Row(
             modifier = modifier
                 .testTag(TimetableItemCardTestTag)
+                .semantics {
+                    this[CustomSemanticsProperties.SessionLanguage] =
+                        timetableItem.language.toLang()
+                }
                 .border(
                     border = BorderStroke(
                         width = 1.dp,

--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/TimetableItemCard.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/TimetableItemCard.kt
@@ -71,10 +71,10 @@ const val TimetableItemCardBookmarkedIconTestTag = "TimetableItemCardBookmarkedI
 const val TimetableItemCardTestTag = "TimetableListItem"
 const val TimetableItemCardTitleTextTestTag = "TimetableItemCardTitleText"
 
-private val timetableItemSemanticsKey = SemanticsPropertyKey<TimetableItem>("TimetableItem")
+private val timetableItemCardSemanticsKey = SemanticsPropertyKey<TimetableItem>("TimetableItem")
 
 @Suppress("UnusedReceiverParameter")
-val SemanticsProperties.TimetableItem get() = timetableItemSemanticsKey
+val SemanticsProperties.TimetableItemCard get() = timetableItemCardSemanticsKey
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -107,7 +107,7 @@ fun TimetableItemCard(
             modifier = modifier
                 .testTag(TimetableItemCardTestTag)
                 .semantics {
-                    this[SemanticsProperties.TimetableItem] = timetableItem
+                    this[SemanticsProperties.TimetableItemCard] = timetableItem
                 }
                 .border(
                     border = BorderStroke(

--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/TimetableItemCard.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/TimetableItemCard.kt
@@ -43,6 +43,8 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -57,7 +59,6 @@ import conference_app_2024.core.droidkaigiui.generated.resources.not_bookmarked
 import io.github.droidkaigi.confsched.designsystem.theme.LocalRoomTheme
 import io.github.droidkaigi.confsched.designsystem.theme.ProvideRoomTheme
 import io.github.droidkaigi.confsched.designsystem.theme.primaryFixed
-import io.github.droidkaigi.confsched.droidkaigiui.CustomSemanticsProperties
 import io.github.droidkaigi.confsched.droidkaigiui.DroidKaigiUiRes
 import io.github.droidkaigi.confsched.droidkaigiui.animation.LocalFavoriteAnimationScope
 import io.github.droidkaigi.confsched.droidkaigiui.previewOverride
@@ -69,6 +70,11 @@ const val TimetableItemCardBookmarkButtonTestTag = "TimetableItemCardBookmarkBut
 const val TimetableItemCardBookmarkedIconTestTag = "TimetableItemCardBookmarkedIcon"
 const val TimetableItemCardTestTag = "TimetableListItem"
 const val TimetableItemCardTitleTextTestTag = "TimetableItemCardTitleText"
+
+private val timetableItemSemanticsKey = SemanticsPropertyKey<TimetableItem>("TimetableItem")
+
+@Suppress("UnusedReceiverParameter")
+val SemanticsProperties.TimetableItem get() = timetableItemSemanticsKey
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -101,8 +107,7 @@ fun TimetableItemCard(
             modifier = modifier
                 .testTag(TimetableItemCardTestTag)
                 .semantics {
-                    this[CustomSemanticsProperties.SessionLanguage] =
-                        timetableItem.language.toLang()
+                    this[SemanticsProperties.TimetableItem] = timetableItem
                 }
                 .border(
                     border = BorderStroke(

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/SearchScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/SearchScreenRobot.kt
@@ -26,9 +26,8 @@ import io.github.droidkaigi.confsched.sessions.component.SearchFiltersFilterLang
 import io.github.droidkaigi.confsched.sessions.component.SearchFiltersLazyRowTestTag
 import io.github.droidkaigi.confsched.sessions.component.SearchTextFieldAppBarTextFieldTestTag
 import io.github.droidkaigi.confsched.sessions.section.TimetableListTestTag
+import io.github.droidkaigi.confsched.testing.robot.TimetableItemCardRobot.Language
 import io.github.droidkaigi.confsched.testing.utils.assertCountAtLeast
-import io.github.droidkaigi.confsched.testing.utils.assertSessionLanguageDoesNotEqual
-import io.github.droidkaigi.confsched.testing.utils.assertSessionLanguageEquals
 import io.github.droidkaigi.confsched.testing.utils.assertTextDoesNotContain
 import io.github.droidkaigi.confsched.testing.utils.hasTestTag
 
@@ -38,9 +37,11 @@ class SearchScreenRobot @Inject constructor(
     private val screenRobot: DefaultScreenRobot,
     private val timetableServerRobot: DefaultTimetableServerRobot,
     private val deviceSetupRobot: DefaultDeviceSetupRobot,
+    timetableItemRobot: DefaultTimetableItemCardRobot,
 ) : ScreenRobot by screenRobot,
     TimetableServerRobot by timetableServerRobot,
-    DeviceSetupRobot by deviceSetupRobot {
+    DeviceSetupRobot by deviceSetupRobot,
+    TimetableItemCardRobot by timetableItemRobot {
     enum class ConferenceDay(
         val day: Int,
         val dateText: String,
@@ -55,14 +56,6 @@ class SearchScreenRobot @Inject constructor(
         AppArchitecture("App Architecture en"),
         JetpackCompose("Jetpack Compose en"),
         Other("Other en"),
-    }
-
-    enum class Language(
-        val tagName: String,
-    ) {
-        MIXED("MIXED"),
-        JAPANESE("JA"),
-        ENGLISH("EN"),
     }
 
     fun setupSearchScreenContent() {
@@ -230,25 +223,6 @@ class SearchScreenRobot @Inject constructor(
                 value = containText,
                 substring = true,
             )
-        waitUntilIdle()
-    }
-
-    fun checkTimetableListItemByLanguage(
-        language: Language,
-    ) {
-        val doesNotContains = Language.entries.filterNot { it == language }
-
-        composeTestRule
-            .onAllNodes(hasTestTag(TimetableItemCardTestTag))
-            .onFirst()
-            .assertSessionLanguageEquals(language.tagName)
-
-        doesNotContains.forEach { doesNotContain ->
-            composeTestRule
-                .onAllNodes(hasTestTag(TimetableItemCardTestTag))
-                .onFirst()
-                .assertSessionLanguageDoesNotEqual(doesNotContain.tagName)
-        }
         waitUntilIdle()
     }
 

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/SearchScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/SearchScreenRobot.kt
@@ -27,6 +27,8 @@ import io.github.droidkaigi.confsched.sessions.component.SearchFiltersLazyRowTes
 import io.github.droidkaigi.confsched.sessions.component.SearchTextFieldAppBarTextFieldTestTag
 import io.github.droidkaigi.confsched.sessions.section.TimetableListTestTag
 import io.github.droidkaigi.confsched.testing.utils.assertCountAtLeast
+import io.github.droidkaigi.confsched.testing.utils.assertSessionLanguageDoesNotEqual
+import io.github.droidkaigi.confsched.testing.utils.assertSessionLanguageEquals
 import io.github.droidkaigi.confsched.testing.utils.assertTextDoesNotContain
 import io.github.droidkaigi.confsched.testing.utils.hasTestTag
 
@@ -239,13 +241,13 @@ class SearchScreenRobot @Inject constructor(
         composeTestRule
             .onAllNodes(hasTestTag(TimetableItemCardTestTag))
             .onFirst()
-            .assertTextContains(language.tagName)
+            .assertSessionLanguageEquals(language.tagName)
 
         doesNotContains.forEach { doesNotContain ->
             composeTestRule
                 .onAllNodes(hasTestTag(TimetableItemCardTestTag))
                 .onFirst()
-                .assertTextDoesNotContain(doesNotContain.tagName)
+                .assertSessionLanguageDoesNotEqual(doesNotContain.tagName)
         }
         waitUntilIdle()
     }

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/utils/Matchers.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/utils/Matchers.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SemanticsNodeInteractionCollection
 import androidx.compose.ui.text.TextLayoutResult
+import io.github.droidkaigi.confsched.droidkaigiui.CustomSemanticsProperties
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 
@@ -81,6 +82,36 @@ fun SemanticsNodeInteraction.assertLineCount(expectedCount: Int) {
             assertTrue(
                 "Node has unexpected line count (expected $expectedCount, but was ${result?.lineCount})",
                 result?.lineCount == expectedCount,
+			)
+		}
+}
+
+fun SemanticsNodeInteraction.assertSessionLanguageEquals(expected: String) {
+    fetchSemanticsNode()
+        .let { node ->
+            val actual = node
+                .config
+                .getOrNull(CustomSemanticsProperties.SessionLanguage)
+                ?.tagName
+
+            assertTrue(
+                "Node language $actual does not match expected language $expected",
+                actual == expected,
+            )
+        }
+}
+
+fun SemanticsNodeInteraction.assertSessionLanguageDoesNotEqual(value: String) {
+    fetchSemanticsNode()
+        .let { node ->
+            val actual = node
+                .config
+                .getOrNull(CustomSemanticsProperties.SessionLanguage)
+                ?.tagName
+
+            assertFalse(
+                "Node language matches language $value unexpectedly",
+                actual == value,
             )
         }
 }

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/utils/Matchers.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/utils/Matchers.kt
@@ -3,12 +3,12 @@ package io.github.droidkaigi.confsched.testing.utils
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SemanticsNodeInteractionCollection
 import androidx.compose.ui.text.TextLayoutResult
-import io.github.droidkaigi.confsched.droidkaigiui.component.TimetableItem
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 
@@ -86,30 +86,19 @@ fun SemanticsNodeInteraction.assertLineCount(expectedCount: Int) {
         }
 }
 
-fun SemanticsNodeInteraction.assertSessionLanguageEquals(expected: String) {
+fun <T> SemanticsNodeInteraction.assertSemanticsProperty(
+    key: SemanticsPropertyKey<T>,
+    condition: (T?) -> Boolean,
+) {
     fetchSemanticsNode()
         .let { node ->
             val actual = node
                 .config
-                .getOrNull(SemanticsProperties.TimetableItem)
+                .getOrNull(key)
 
             assertTrue(
-                "Node language $actual does not match expected language $expected",
-                actual?.language?.toLang()?.tagName == expected,
-            )
-        }
-}
-
-fun SemanticsNodeInteraction.assertSessionLanguageDoesNotEqual(value: String) {
-    fetchSemanticsNode()
-        .let { node ->
-            val actual = node
-                .config
-                .getOrNull(SemanticsProperties.TimetableItem)
-
-            assertFalse(
-                "Node language matches language $value unexpectedly",
-                actual?.language?.toLang()?.tagName == value,
+                "Node has unexpected value for semantics property $key: $actual",
+                condition(actual),
             )
         }
 }

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/utils/Matchers.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/utils/Matchers.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SemanticsNodeInteractionCollection
 import androidx.compose.ui.text.TextLayoutResult
-import io.github.droidkaigi.confsched.droidkaigiui.CustomSemanticsProperties
+import io.github.droidkaigi.confsched.droidkaigiui.component.TimetableItem
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 
@@ -82,8 +82,8 @@ fun SemanticsNodeInteraction.assertLineCount(expectedCount: Int) {
             assertTrue(
                 "Node has unexpected line count (expected $expectedCount, but was ${result?.lineCount})",
                 result?.lineCount == expectedCount,
-			)
-		}
+            )
+        }
 }
 
 fun SemanticsNodeInteraction.assertSessionLanguageEquals(expected: String) {
@@ -91,12 +91,11 @@ fun SemanticsNodeInteraction.assertSessionLanguageEquals(expected: String) {
         .let { node ->
             val actual = node
                 .config
-                .getOrNull(CustomSemanticsProperties.SessionLanguage)
-                ?.tagName
+                .getOrNull(SemanticsProperties.TimetableItem)
 
             assertTrue(
                 "Node language $actual does not match expected language $expected",
-                actual == expected,
+                actual?.language?.toLang()?.tagName == expected,
             )
         }
 }
@@ -106,12 +105,11 @@ fun SemanticsNodeInteraction.assertSessionLanguageDoesNotEqual(value: String) {
         .let { node ->
             val actual = node
                 .config
-                .getOrNull(CustomSemanticsProperties.SessionLanguage)
-                ?.tagName
+                .getOrNull(SemanticsProperties.TimetableItem)
 
             assertFalse(
                 "Node language matches language $value unexpectedly",
-                actual == value,
+                actual?.language?.toLang()?.tagName == value,
             )
         }
 }

--- a/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
+++ b/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
@@ -8,7 +8,7 @@ import io.github.droidkaigi.confsched.testing.execute
 import io.github.droidkaigi.confsched.testing.robot.SearchScreenRobot
 import io.github.droidkaigi.confsched.testing.robot.SearchScreenRobot.Category
 import io.github.droidkaigi.confsched.testing.robot.SearchScreenRobot.ConferenceDay
-import io.github.droidkaigi.confsched.testing.robot.SearchScreenRobot.Language
+import io.github.droidkaigi.confsched.testing.robot.TimetableItemCardRobot.Language
 import io.github.droidkaigi.confsched.testing.robot.TimetableServerRobot.ServerStatus
 import io.github.droidkaigi.confsched.testing.robot.runRobot
 import io.github.droidkaigi.confsched.testing.rules.RobotTestRule

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/SearchList.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/SearchList.kt
@@ -2,8 +2,10 @@ package io.github.droidkaigi.confsched.sessions.section
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import io.github.droidkaigi.confsched.droidkaigiui.component.TimetableItemTag
 import io.github.droidkaigi.confsched.model.TimetableItem
 
 @Composable
@@ -23,5 +25,13 @@ fun SearchList(
         contentPadding = contentPadding,
         highlightWord = highlightWord,
         modifier = modifier,
+        timetableItemTagsContent = { timetableItem ->
+            timetableItem.day?.monthAndDay()?.let { monthAndDay ->
+                TimetableItemTag(
+                    tagText = monthAndDay,
+                    tagColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
     )
 }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
@@ -17,7 +18,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
@@ -71,6 +71,7 @@ internal fun TimetableList(
     onBookmarkClick: (TimetableItem, Boolean) -> Unit,
     onTimetableItemClick: (TimetableItem) -> Unit,
     contentPadding: PaddingValues,
+    timetableItemTagsContent: @Composable RowScope.(TimetableItem) -> Unit,
     modifier: Modifier = Modifier,
     nestedScrollStateHolder: TimetableNestedScrollStateHolder = rememberTimetableNestedScrollStateHolder(true),
     highlightWord: String = "",
@@ -178,12 +179,7 @@ internal fun TimetableList(
                                             tagColor = LocalRoomTheme.current.primaryColor,
                                             modifier = Modifier.background(LocalRoomTheme.current.containerColor),
                                         )
-                                        timetableItem.language.labels.forEach { label ->
-                                            TimetableItemTag(
-                                                tagText = label,
-                                                tagColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                                            )
-                                        }
+                                        timetableItemTagsContent(timetableItem)
                                     },
                                     onTimetableItemClick = onTimetableItemClick,
                                 )

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableSheet.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableSheet.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -26,6 +27,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import io.github.droidkaigi.confsched.droidkaigiui.component.TimetableItemTag
 import io.github.droidkaigi.confsched.droidkaigiui.compositionlocal.LocalClock
 import io.github.droidkaigi.confsched.model.DroidKaigi2024Day
 import io.github.droidkaigi.confsched.model.TimeLine
@@ -108,6 +110,14 @@ fun Timetable(
                             start = contentPadding.calculateStartPadding(layoutDirection),
                             end = contentPadding.calculateEndPadding(layoutDirection),
                         ),
+                        timetableItemTagsContent = { timetableItem ->
+                            timetableItem.language.labels.forEach { label ->
+                                TimetableItemTag(
+                                    tagText = label,
+                                    tagColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        },
                     )
                 }
 


### PR DESCRIPTION


## Issue
- close #931

## Overview (Required)
- Hoist the additional tag composable upwards, so that TimetableList and SearchScreen can use different content

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/56fa8dc9-1d87-4739-a75f-f9b89050728c" width="300" > | <video src="https://github.com/user-attachments/assets/ab9b829d-37ce-4599-9d7f-7cef3d9daa6c" width="300" >







