### PR TITLE
Fixed the color of the icon in empty favorite sheet

### DIFF
--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/section/FavoriteSheet.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/section/FavoriteSheet.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import conference_app_2024.feature.favorites.generated.resources.empty_description
 import conference_app_2024.feature.favorites.generated.resources.empty_guide
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
+import io.github.droidkaigi.confsched.designsystem.theme.primaryFixed
 import io.github.droidkaigi.confsched.favorites.FavoritesRes
 import io.github.droidkaigi.confsched.favorites.component.FavoriteFilters
 import io.github.droidkaigi.confsched.favorites.section.FavoritesSheetUiState.FavoriteListUiState.TimeSlot
@@ -154,7 +155,7 @@ private fun EmptyView(modifier: Modifier = Modifier) {
                 modifier = Modifier.size(36.dp),
                 imageVector = Icons.Filled.Favorite,
                 contentDescription = null,
-                tint = Color.Green,
+                tint = MaterialTheme.colorScheme.primaryFixed,
             )
         }
         Spacer(Modifier.height(12.dp))


### PR DESCRIPTION
## Issue
- close #958 

## Overview (Required)
- Fixed the tint of the icon in the EmptyView of the Favorites screen

## Links
- https://www.figma.com/design/XUk8WMbKCeIdWD5cz9P9JC/DroidKaigi-2024-App-UI?node-id=55521-44698&t=U0Y9WYLKYOmTCVrL-4

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/bf2a54c1-d74a-426d-a0ee-a94a37366ba2" width="300" /> | <img src="https://github.com/user-attachments/assets/39a063a6-fcba-4317-b0d9-862d1b01e8a6" width="300" />



## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
