### PR TITLE
:memo: The method with the prefix “Preview” has been renamed so that the suffix has “Preview”.

### DIFF
--- a/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
+++ b/feature/eventmap/src/commonMain/kotlin/io/github/droidkaigi/confsched/eventmap/EventMapScreen.kt
@@ -207,7 +207,7 @@ private fun EventMap(
 
 @Composable
 @Preview
-fun PreviewEventMapScreen() {
+fun EventMapScreenPreview() {
     EventMapScreen(
         uiState = EventMapUiState.Exists(
             userMessageStateHolder = rememberUserMessageStateHolder(),

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreen.kt
@@ -189,7 +189,7 @@ fun SearchScreen(
 
 @Preview
 @Composable
-fun SearchScreenPreview_Empty() {
+fun EmptySearchScreenPreview() {
     KaigiTheme {
         SearchScreen(
             uiState = SearchScreenUiState.Empty(

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
@@ -225,7 +225,7 @@ private fun TimetableScreen(
 
 @Preview
 @Composable
-fun PreviewTimetableScreenDark() {
+fun TimetableScreenDarkPreview() {
     CompositionLocalProvider(LocalClock provides FakeClock) {
         KaigiTheme {
             TimetableScreen(

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridItem.kt
@@ -494,7 +494,7 @@ object TimetableGridItemSizes {
 
 @Preview
 @Composable
-fun PreviewTimetableGridItem() {
+fun TimetableGridItemPreview() {
     KaigiTheme {
         Surface {
             TimetableGridItem(
@@ -509,7 +509,7 @@ fun PreviewTimetableGridItem() {
 
 @Preview
 @Composable
-fun PreviewTimetableGridLongTitleItem() {
+fun TimetableGridLongTitleItemPreview() {
     val fake = Session.fake()
 
     val localDensity = LocalDensity.current
@@ -538,7 +538,7 @@ fun PreviewTimetableGridLongTitleItem() {
 
 @Preview
 @Composable
-fun PreviewTimetableGridMultiSpeakersItem() {
+fun TimetableGridMultiSpeakersItemPreview() {
     KaigiTheme {
         Surface {
             TimetableGridItem(
@@ -552,7 +552,7 @@ fun PreviewTimetableGridMultiSpeakersItem() {
 
 @Preview
 @Composable
-fun PreviewTimetableGridItemWelcomeTalk() {
+fun TimetableGridItemWelcomeTalkPreview() {
     KaigiTheme {
         Surface {
             TimetableGridItem(
@@ -597,7 +597,7 @@ fun PreviewTimetableGridItemWelcomeTalk() {
 
 @Preview
 @Composable
-fun PreviewTimetableGridItemMoreLongTitleItem() {
+fun TimetableGridItemMoreLongTitleItemPreview() {
     KaigiTheme {
         Surface {
             TimetableGridItem(

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridTab.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableGridTab.kt
@@ -123,7 +123,7 @@ private fun FloorText(
 
 @Preview
 @Composable
-fun PreviewTimetableDayTab() {
+fun TimetableDayTabPreview() {
     KaigiTheme {
         Surface {
             TimetableDayTab(


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- The Preview method names are inconsistent, with the name “Preview” appearing in either the prefix or suffix.
- If possible, we would like to unify the name so that it is attached only to either the suffix or the prefix.