### PR TITLE
Feature/auto scroll to current sesion

### DIFF
--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/TimetableItem.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/TimetableItem.kt
@@ -7,6 +7,7 @@ import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
@@ -78,6 +79,14 @@ public sealed class TimetableItem {
         endsAt.toTimetableTimeString()
     }
 
+    public val startsLocalTime: LocalTime by lazy {
+        startsAt.toLocalTime()
+    }
+
+    public val endsLocalTime: LocalTime by lazy {
+        endsAt.toLocalTime()
+    }
+
     private val minutesString: String by lazy {
         val minutes = (endsAt - startsAt)
             .toComponents { minutes, _, _ -> minutes }
@@ -119,9 +128,14 @@ public sealed class TimetableItem {
     }
 }
 
-public fun Instant.toTimetableTimeString(): String {
+private fun Instant.toTimetableTimeString(): String {
     val localDate = toLocalDateTime(TimeZone.currentSystemDefault())
     return "${localDate.hour}".padStart(2, '0') + ":" + "${localDate.minute}".padStart(2, '0')
+}
+
+private fun Instant.toLocalTime(): LocalTime {
+    val localDateTime = toLocalDateTime(TimeZone.currentSystemDefault())
+    return localDateTime.time
 }
 
 public fun Session.Companion.fake(): Session {

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/TimetableItem.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/TimetableItem.kt
@@ -71,13 +71,11 @@ public sealed class TimetableItem {
     }
 
     public val startsTimeString: String by lazy {
-        val localDate = startsAt.toLocalDateTime(TimeZone.currentSystemDefault())
-        "${localDate.hour}".padStart(2, '0') + ":" + "${localDate.minute}".padStart(2, '0')
+        startsAt.toTimetableTimeString()
     }
 
     public val endsTimeString: String by lazy {
-        val localDate = endsAt.toLocalDateTime(TimeZone.currentSystemDefault())
-        "${localDate.hour}".padStart(2, '0') + ":" + "${localDate.minute}".padStart(2, '0')
+        endsAt.toTimetableTimeString()
     }
 
     private val minutesString: String by lazy {
@@ -119,6 +117,11 @@ public sealed class TimetableItem {
             else -> language.langOfSpeaker
         }
     }
+}
+
+public fun Instant.toTimetableTimeString(): String {
+    val localDate = toLocalDateTime(TimeZone.currentSystemDefault())
+    return "${localDate.hour}".padStart(2, '0') + ":" + "${localDate.minute}".padStart(2, '0')
 }
 
 public fun Session.Companion.fake(): Session {

--- a/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
+++ b/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
@@ -185,46 +185,6 @@ class TimetableScreenTest(private val testCase: DescribedBehavior<TimetableScree
                         dateTime = LocalDateTime(
                             year = 2024,
                             monthNumber = 9,
-                            dayOfMonth = 12,
-                            hour = 16,
-                            minute = 45,
-                        ),
-                        shouldShowTimeLine = false,
-                    ),
-                    TimeLineTestSpec(
-                        dateTime = LocalDateTime(
-                            year = 2024,
-                            monthNumber = 9,
-                            dayOfMonth = 12,
-                            hour = 23,
-                            minute = 0,
-                        ),
-                        shouldShowTimeLine = true,
-                    ),
-                ).forEach { case ->
-                    val formattedDateTime =
-                        case.dateTime.format(LocalDateTime.Format { byUnicodePattern("yyyy-MM-dd HH-mm") })
-                    describe("when the current datetime is $formattedDateTime") {
-                        doIt {
-                            setupTimetableServer(ServerStatus.Operational)
-                            setupTimetableScreenContent(case.dateTime)
-                        }
-
-                        val formattedTime =
-                            case.dateTime.time.format(LocalTime.Format { byUnicodePattern("HH-mm") })
-                        val description = "show an timetable item of the current time at $formattedTime"
-                        itShould(description) {
-                            captureScreenWithChecks {
-                                checkTimetableListDisplayed()
-                            }
-                        }
-                    }
-                }
-                listOf(
-                    TimeLineTestSpec(
-                        dateTime = LocalDateTime(
-                            year = 2024,
-                            monthNumber = 9,
                             dayOfMonth = 11,
                             hour = 10,
                             minute = 0,
@@ -245,6 +205,16 @@ class TimetableScreenTest(private val testCase: DescribedBehavior<TimetableScree
                         dateTime = LocalDateTime(
                             year = 2024,
                             monthNumber = 9,
+                            dayOfMonth = 12,
+                            hour = 23,
+                            minute = 0,
+                        ),
+                        shouldShowTimeLine = false,
+                    ),
+                    TimeLineTestSpec(
+                        dateTime = LocalDateTime(
+                            year = 2024,
+                            monthNumber = 9,
                             dayOfMonth = 13,
                             hour = 11,
                             minute = 0,
@@ -258,19 +228,28 @@ class TimetableScreenTest(private val testCase: DescribedBehavior<TimetableScree
                         doIt {
                             setupTimetableServer(ServerStatus.Operational)
                             setupTimetableScreenContent(case.dateTime)
-                            clickTimetableUiTypeChangeButton()
                         }
-
                         val formattedTime =
                             case.dateTime.time.format(LocalTime.Format { byUnicodePattern("HH-mm") })
-                        val description = if (case.shouldShowTimeLine) {
-                            "show an indicator of the current time at $formattedTime"
-                        } else {
-                            "not show an indicator of the current time"
-                        }
-                        itShould(description) {
+                        val timetableListDescription = "show an timetable item of the current time at $formattedTime"
+                        itShould(timetableListDescription) {
                             captureScreenWithChecks {
-                                checkTimetableGridDisplayed()
+                                checkTimetableListDisplayed()
+                            }
+                        }
+                        describe("switch to grid timetable") {
+                            doIt {
+                                clickTimetableUiTypeChangeButton()
+                            }
+                            val timetableGridDescription = if (case.shouldShowTimeLine) {
+                                "show an indicator of the current time at $formattedTime"
+                            } else {
+                                "not show an indicator of the current time"
+                            }
+                            itShould(timetableGridDescription) {
+                                captureScreenWithChecks {
+                                    checkTimetableGridDisplayed()
+                                }
                             }
                         }
                     }

--- a/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
+++ b/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenTest.kt
@@ -185,6 +185,46 @@ class TimetableScreenTest(private val testCase: DescribedBehavior<TimetableScree
                         dateTime = LocalDateTime(
                             year = 2024,
                             monthNumber = 9,
+                            dayOfMonth = 12,
+                            hour = 16,
+                            minute = 45,
+                        ),
+                        shouldShowTimeLine = false,
+                    ),
+                    TimeLineTestSpec(
+                        dateTime = LocalDateTime(
+                            year = 2024,
+                            monthNumber = 9,
+                            dayOfMonth = 12,
+                            hour = 23,
+                            minute = 0,
+                        ),
+                        shouldShowTimeLine = true,
+                    ),
+                ).forEach { case ->
+                    val formattedDateTime =
+                        case.dateTime.format(LocalDateTime.Format { byUnicodePattern("yyyy-MM-dd HH-mm") })
+                    describe("when the current datetime is $formattedDateTime") {
+                        doIt {
+                            setupTimetableServer(ServerStatus.Operational)
+                            setupTimetableScreenContent(case.dateTime)
+                        }
+
+                        val formattedTime =
+                            case.dateTime.time.format(LocalTime.Format { byUnicodePattern("HH-mm") })
+                        val description = "show an timetable item of the current time at $formattedTime"
+                        itShould(description) {
+                            captureScreenWithChecks {
+                                checkTimetableListDisplayed()
+                            }
+                        }
+                    }
+                }
+                listOf(
+                    TimeLineTestSpec(
+                        dateTime = LocalDateTime(
+                            year = 2024,
+                            monthNumber = 9,
                             dayOfMonth = 11,
                             hour = 10,
                             minute = 0,

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenPresenter.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenPresenter.kt
@@ -174,8 +174,8 @@ fun searchScreenPresenter(
                 timetableListUiState = TimetableListUiState(
                     timetableItemMap = filteredSessions.groupBy {
                         TimetableListUiState.TimeSlot(
-                            startTimeString = it.startsTimeString,
-                            endTimeString = it.endsTimeString,
+                            startTime = it.startsAt,
+                            endTime = it.endsAt,
                         )
                     }.mapValues { entries ->
                         entries.value.sortedWith(

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenPresenter.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenPresenter.kt
@@ -174,8 +174,8 @@ fun searchScreenPresenter(
                 timetableListUiState = TimetableListUiState(
                     timetableItemMap = filteredSessions.groupBy {
                         TimetableListUiState.TimeSlot(
-                            startTime = it.startsAt,
-                            endTime = it.endsAt,
+                            startTime = it.startsLocalTime,
+                            endTime = it.endsLocalTime,
                         )
                     }.mapValues { entries ->
                         entries.value.sortedWith(

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenPresenter.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenPresenter.kt
@@ -101,8 +101,8 @@ fun timetableSheet(
                     ),
                 ).timetableItems.groupBy {
                     TimetableListUiState.TimeSlot(
-                        startTime = it.startsAt,
-                        endTime = it.endsAt,
+                        startTime = it.startsLocalTime,
+                        endTime = it.endsLocalTime,
                     )
                 }.mapValues { entries ->
                     entries.value.sortedWith(

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenPresenter.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreenPresenter.kt
@@ -101,8 +101,8 @@ fun timetableSheet(
                     ),
                 ).timetableItems.groupBy {
                     TimetableListUiState.TimeSlot(
-                        startTimeString = it.startsTimeString,
-                        endTimeString = it.endsTimeString,
+                        startTime = it.startsAt,
+                        endTime = it.endsAt,
                     )
                 }.mapValues { entries ->
                     entries.value.sortedWith(

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/SearchList.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/SearchList.kt
@@ -24,6 +24,7 @@ fun SearchList(
         contentPadding = contentPadding,
         highlightWord = highlightWord,
         modifier = modifier,
+        enableAutoScrolling = false,
         timetableItemTagsContent = { timetableItem ->
             timetableItem.day?.monthAndDay()?.let { monthAndDay ->
                 TimetableItemTag(tagText = monthAndDay)

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableGrid.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableGrid.kt
@@ -253,8 +253,11 @@ fun TimetableGrid(
     val currentTimeDotRadius = with(timetableState.density) { TimetableSizes.currentTimeDotRadius.toPx() }
 
     LaunchedEffect(Unit) {
-        val progressingSession =
-            timetable.timetableItems.timetableItems.find { clock.now() in it.startsAt..it.endsAt }
+        val progressingSession = timetable.timetableItems.timetableItems
+            .windowed(2, 1, true)
+            .find { clock.now() in it.first().startsAt..it.last().startsAt }
+            ?.first()
+
         progressingSession?.let { session ->
             val timeZone = TimeZone.of("UTC+9")
             val period = with(session.startsAt) {

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
@@ -116,7 +116,7 @@ internal fun TimetableList(
             val progressingSessionIndex = uiState.timetableItemMap.keys
                 .insertDummyEndOfTheDayItem() // Insert dummy at a position after last session to allow scrolling
                 .windowed(2, 1, true)
-                .indexOfFirst { clock.now().toLocalTime() in it.first().startTime..it.last().startTime }
+                .indexOfFirst { clock.now().toLocalTime() in it.first().startTime..<it.last().startTime }
 
             progressingSessionIndex.takeIf { it != -1 }?.let {
                 scrollState.scrollToItem(it)

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
@@ -106,7 +106,7 @@ internal fun TimetableList(
         nestedScrollStateHolder = nestedScrollStateHolder,
     )
 
-    LaunchedEffect(uiState) {
+    LaunchedEffect(Unit) {
         if (enableAutoScrolling) {
             val progressingSessionIndex = uiState.timetableItemMap.keys
                 .run {

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
@@ -77,7 +77,9 @@ internal fun TimetableList(
     contentPadding: PaddingValues,
     timetableItemTagsContent: @Composable RowScope.(TimetableItem) -> Unit,
     modifier: Modifier = Modifier,
-    nestedScrollStateHolder: TimetableNestedScrollStateHolder = rememberTimetableNestedScrollStateHolder(true),
+    nestedScrollStateHolder: TimetableNestedScrollStateHolder = rememberTimetableNestedScrollStateHolder(
+        true
+    ),
     highlightWord: String = "",
     enableAutoScrolling: Boolean = true,
 ) {
@@ -100,8 +102,12 @@ internal fun TimetableList(
 
     LaunchedEffect(Unit) {
         if (enableAutoScrolling) {
-            val progressingSessionIndex =
-                uiState.timetableItemMap.keys.indexOfFirst { clock.now() in it.startTime..it.endTime }
+            val progressingSessionIndex = uiState.timetableItemMap.keys
+                .windowed(2, 1, true)
+                .indexOfFirst {
+                    clock.now() in it.first().startTime..it.last().startTime
+                }
+
             progressingSessionIndex.takeIf { it != -1 }?.let {
                 scrollState.animateScrollToItem(it)
             }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableSheet.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableSheet.kt
@@ -118,6 +118,7 @@ fun Timetable(
                             end = contentPadding.calculateEndPadding(layoutDirection),
                         ),
                         scrolledToCurrentTimeState = scrolledToCurrentTimeState,
+                        enableAutoScrolling = clock.now() in selectedDay.start..selectedDay.end,
                         timetableItemTagsContent = { timetableItem ->
                             timetableItem.language.labels.forEach { label ->
                                 TimetableItemTag(tagText = label)

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableSheet.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableSheet.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -67,7 +68,14 @@ fun Timetable(
     }
     val layoutDirection = LocalLayoutDirection.current
 
-    val nestedScrollStateHolder = rememberTimetableNestedScrollStateHolder(isListTimetable = uiState is ListTimetable)
+    val nestedScrollStateHolder =
+        rememberTimetableNestedScrollStateHolder(isListTimetable = uiState is ListTimetable)
+    val scrolledToCurrentTimeState = rememberSaveable(
+        saver = listSaver(
+            save = { listOf(it.inTimetableList, it.inTimetableGrid) },
+            restore = { ScrolledToCurrentTimeState(it[0], it[1]) },
+        ),
+    ) { ScrolledToCurrentTimeState() }
 
     Surface(
         modifier = modifier.padding(contentPadding.calculateTopPadding()),
@@ -109,6 +117,7 @@ fun Timetable(
                             start = contentPadding.calculateStartPadding(layoutDirection),
                             end = contentPadding.calculateEndPadding(layoutDirection),
                         ),
+                        scrolledToCurrentTimeState = scrolledToCurrentTimeState,
                         timetableItemTagsContent = { timetableItem ->
                             timetableItem.language.labels.forEach { label ->
                                 TimetableItemTag(tagText = label)
@@ -132,6 +141,7 @@ fun Timetable(
                             bottom = contentPadding.calculateBottomPadding(),
                             start = contentPadding.calculateStartPadding(layoutDirection),
                         ),
+                        scrolledToCurrentTimeState = scrolledToCurrentTimeState,
                     )
                 }
 
@@ -165,4 +175,22 @@ private fun rememberGridTimetableStates(): Map<DroidKaigi2024Day, TimetableState
         rememberTimetableGridState()
     }
     return remember { timetableStateMap }
+}
+
+class ScrolledToCurrentTimeState(
+    inTimetableList: Boolean = false,
+    inTimetableGrid: Boolean = false,
+) {
+    var inTimetableList: Boolean by mutableStateOf(inTimetableList)
+        private set
+    var inTimetableGrid: Boolean by mutableStateOf(inTimetableGrid)
+        private set
+
+    fun scrolledInTimetableList() {
+        inTimetableList = true
+    }
+
+    fun scrolledInTimetableGrid() {
+        inTimetableGrid = true
+    }
 }


### PR DESCRIPTION
## Issue
- close #509 

## Overview (Required)
When the screen opens, it scrolls to the item with the current time. The timetablegrid also scrolls.

- If it is a breaking time between sessions, it scrolls to the previous session.
- If it is after the end of the day's sessions, it scrolls to the last session.
- Allow the user to save their position when they perform a scroll operation.
- I also created a ui test.

It does not retain the scroll position when returning from the grid view, but this is an existing issue. I will not take action this time.
I wanted to animate the scrolling, but it seemed to cause a nasty bug, so it is out of the scope of this PR.

The work has been made by @yjyoon-dev until the middle of the work. Thanks.


## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
I have changed the date and time in the system settings.

Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/6c9325fb-a398-4a72-821f-1183bfc31902" width="300" > | <video src="https://github.com/user-attachments/assets/125fd1d4-7244-49ce-bd8b-09257dac1c3e" width="300" >


