### PR TITLE
Move v35-only theme declaration into the correct themes.xml

### DIFF
--- a/app-android/src/main/res/values-v35/themes.xml
+++ b/app-android/src/main/res/values-v35/themes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.KaigiApp.Licenses" parent="Theme.AppCompat.DayNight.DarkActionBar">
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+</resources>

--- a/app-android/src/main/res/values/themes.xml
+++ b/app-android/src/main/res/values/themes.xml
@@ -6,6 +6,6 @@
     </style>
 
     <style name="Theme.KaigiApp.Licenses" parent="Theme.AppCompat.DayNight.DarkActionBar">
-        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+        <!-- Overridden by v35 -->
     </style>
 </resources>


### PR DESCRIPTION
## Issue
- close #967

## Overview (Required)
- Lint complains about the usage of `android:windowOptOutEdgeToEdgeEnforcement`, a new property introduced in Android 15
- Introduce a resource folder for v35-specific files and move this declaration into `themes.xml` in that folder

## Links
- https://qiita.com/Nabe1216/items/cea8f7043f57bfd20bca

## Screenshots

Output of `./gradlew :app-android:lintDevDebug`

|Before|After|
|---|---|
|<img width="350" alt="Screenshot 2024-09-05 at 18 40 34" src="https://github.com/user-attachments/assets/c7751333-c841-49d7-bd11-a528665fd4ec">|<img width="350" alt="Screenshot 2024-09-05 at 18 43 23" src="https://github.com/user-attachments/assets/5d28943a-bed6-4f9a-a30b-5e1acc87f0fc">|

