### PR TITLE
fix deprecated compiler options

### DIFF
--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/convention/AndroidFeaturePlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/convention/AndroidFeaturePlugin.kt
@@ -20,8 +20,8 @@ class AndroidFeaturePlugin : Plugin<Project> {
             }
 
             tasks.withType<KotlinCompile>().configureEach {
-                kotlinOptions {
-                    freeCompilerArgs = freeCompilerArgs + buildComposeMetricsParameters()
+                compilerOptions {
+                    freeCompilerArgs.addAll(buildComposeMetricsParameters())
                 }
             }
         }
@@ -35,20 +35,20 @@ fun Project.buildComposeMetricsParameters(): List<String> {
 
     val enableMetrics = (enableMetricsProvider.orNull == "true")
     if (enableMetrics) {
-        val metricsFolder = rootProject.buildDir.resolve("compose-metrics").resolve(relativePath)
+        val metricsFolder = rootProject.layout.buildDirectory.orNull?.asFile?.resolve("compose-metrics")?.resolve(relativePath)
         metricParameters.add("-P")
         metricParameters.add(
-            "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" + metricsFolder.absolutePath
+            "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" + metricsFolder?.absolutePath
         )
     }
 
     val enableReportsProvider = project.providers.gradleProperty("enableComposeCompilerReports")
     val enableReports = (enableReportsProvider.orNull == "true")
     if (enableReports) {
-        val reportsFolder = rootProject.buildDir.resolve("compose-reports").resolve(relativePath)
+        val reportsFolder = rootProject.layout.buildDirectory.orNull?.asFile?.resolve("compose-reports")?.resolve(relativePath)
         metricParameters.add("-P")
         metricParameters.add(
-            "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" + reportsFolder.absolutePath
+            "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" + reportsFolder?.absolutePath
         )
     }
     return metricParameters.toList()

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/AndroidGradleDsl.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/AndroidGradleDsl.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched.primitive
 
 import com.android.build.api.dsl.CommonExtension
+import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.TestedExtension
 import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
@@ -13,6 +14,7 @@ import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
 fun Project.androidApplication(action: BaseAppModuleExtension.() -> Unit) {
     extensions.configure(action)
@@ -24,6 +26,14 @@ fun Project.androidLibrary(action: LibraryExtension.() -> Unit) {
 
 fun Project.android(action: TestedExtension.() -> Unit) {
     extensions.configure(action)
+}
+
+fun Project.kotlinAndroidOptions(configure: KotlinAndroidProjectExtension.() -> Unit) {
+    extensions.configure(configure)
+}
+
+fun Project.libraryAndroidOptions(configure: LibraryAndroidComponentsExtension.() -> Unit) {
+    extensions.configure(configure)
 }
 
 fun Project.setupAndroid() {

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/AndroidKotlinPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/AndroidKotlinPlugin.kt
@@ -2,7 +2,6 @@ package io.github.droidkaigi.confsched.primitive
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
 
@@ -20,21 +19,19 @@ class AndroidKotlinPlugin : Plugin<Project> {
             }
 
             android {
-                kotlinAndroidOptions {
-                    kotlinAndroid {
-                        compilerOptions {
-                            // Treat all Kotlin warnings as errors (disabled by default)
-                            allWarningsAsErrors.set(properties["warningsAsErrors"] as? Boolean ?: false)
+                kotlinAndroid {
+                    compilerOptions {
+                        // Treat all Kotlin warnings as errors (disabled by default)
+                        allWarningsAsErrors.set(properties["warningsAsErrors"] as? Boolean ?: false)
 
-                            freeCompilerArgs.addAll(listOf(
+                        freeCompilerArgs.addAll(listOf(
 //                                "-opt-in=kotlin.RequiresOptIn",
-                                // Enable experimental coroutines APIs, including Flow
+                            // Enable experimental coroutines APIs, including Flow
 //                                 "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-                                "-Xcontext-receivers"
-                            ))
+                            "-Xcontext-receivers"
+                        ))
 
-                            jvmTarget.set(JVM_11)
-                        }
+                        jvmTarget.set(JVM_11)
                     }
                 }
             }
@@ -45,9 +42,4 @@ class AndroidKotlinPlugin : Plugin<Project> {
             }
         }
     }
-
-    private fun Project.kotlinAndroid(configure: org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension.() -> Unit) {
-        extensions.configure(configure)
-    }
-
 }

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/AndroidKotlinPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/AndroidKotlinPlugin.kt
@@ -1,9 +1,10 @@
 package io.github.droidkaigi.confsched.primitive
 
-import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
 
 @Suppress("unused")
 class AndroidKotlinPlugin : Plugin<Project> {
@@ -13,22 +14,28 @@ class AndroidKotlinPlugin : Plugin<Project> {
                 apply("org.jetbrains.kotlin.android")
             }
             tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
-                kotlinOptions.jvmTarget = "11"
+                compilerOptions {
+                    jvmTarget.set(JVM_11)
+                }
             }
 
             android {
-                kotlinOptions {
-                    // Treat all Kotlin warnings as errors (disabled by default)
-                    allWarningsAsErrors = properties["warningsAsErrors"] as? Boolean ?: false
+                kotlinAndroidOptions {
+                    kotlinAndroid {
+                        compilerOptions {
+                            // Treat all Kotlin warnings as errors (disabled by default)
+                            allWarningsAsErrors.set(properties["warningsAsErrors"] as? Boolean ?: false)
 
-                    freeCompilerArgs = freeCompilerArgs + listOf(
-//              "-opt-in=kotlin.RequiresOptIn",
-                        // Enable experimental coroutines APIs, including Flow
-//              "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-                        "-Xcontext-receivers"
-                    )
+                            freeCompilerArgs.addAll(listOf(
+//                                "-opt-in=kotlin.RequiresOptIn",
+                                // Enable experimental coroutines APIs, including Flow
+//                                 "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+                                "-Xcontext-receivers"
+                            ))
 
-                    jvmTarget = JavaVersion.VERSION_11.toString()
+                            jvmTarget.set(JVM_11)
+                        }
+                    }
                 }
             }
             dependencies {
@@ -38,4 +45,9 @@ class AndroidKotlinPlugin : Plugin<Project> {
             }
         }
     }
+
+    private fun Project.kotlinAndroid(configure: org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension.() -> Unit) {
+        extensions.configure(configure)
+    }
+
 }

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/AndroidKotlinPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/AndroidKotlinPlugin.kt
@@ -19,7 +19,7 @@ class AndroidKotlinPlugin : Plugin<Project> {
             }
 
             android {
-                kotlinAndroid {
+                kotlinAndroidOptions {
                     compilerOptions {
                         // Treat all Kotlin warnings as errors (disabled by default)
                         allWarningsAsErrors.set(properties["warningsAsErrors"] as? Boolean ?: false)

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpAndroidPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpAndroidPlugin.kt
@@ -16,7 +16,7 @@ class KmpAndroidPlugin : Plugin<Project> {
             kotlin {
                 androidTarget {
                     compilations.all {
-                        libraryAndroid {
+                        libraryAndroidOptions {
                             compileTaskProvider.configure {
                                 compilerOptions {
                                     jvmTarget.set(JVM_11)

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpAndroidPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpAndroidPlugin.kt
@@ -4,6 +4,7 @@ import com.google.devtools.ksp.gradle.KspTaskMetadata
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
 
 @Suppress("unused")
 class KmpAndroidPlugin : Plugin<Project> {
@@ -15,8 +16,12 @@ class KmpAndroidPlugin : Plugin<Project> {
             kotlin {
                 androidTarget {
                     compilations.all {
-                        kotlinOptions {
-                            jvmTarget = "11"
+                        libraryAndroid {
+                            compileTaskProvider.configure {
+                                compilerOptions {
+                                    jvmTarget.set(JVM_11)
+                                }
+                            }
                         }
                     }
                 }

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpComposePlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpComposePlugin.kt
@@ -54,8 +54,8 @@ class KmpComposePlugin : Plugin<Project> {
             }
 
             tasks.withType<KotlinCompile>().configureEach {
-                kotlinOptions {
-                    freeCompilerArgs = freeCompilerArgs + buildComposeMetricsParameters()
+                compilerOptions {
+                    freeCompilerArgs.addAll(buildComposeMetricsParameters())
                 }
             }
         }

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpIosPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpIosPlugin.kt
@@ -8,10 +8,12 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 @Suppress("unused")
 class KmpIosPlugin : Plugin<Project> {
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
     override fun apply(target: Project) {
         with(target) {
             with(pluginManager) {
@@ -56,9 +58,15 @@ class KmpIosPlugin : Plugin<Project> {
                 applyDefaultHierarchyTemplate()
 
                 targets.withType<KotlinNativeTarget> {
-                    // export kdoc to header file
-                    // https://kotlinlang.org/docs/native-objc-interop.html#export-of-kdoc-comments-to-generated-objective-c-headers
-                    compilations["main"].kotlinOptions.freeCompilerArgs += "-Xexport-kdoc"
+                    compilations["main"].apply {
+                        kotlin {
+                            compilerOptions {
+                                // export kdoc to header file
+                                // https://kotlinlang.org/docs/native-objc-interop.html#export-of-kdoc-comments-to-generated-objective-c-headers
+                                freeCompilerArgs.add("-Xexport-kdoc")
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpKtorfitPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpKtorfitPlugin.kt
@@ -1,6 +1,5 @@
 package io.github.droidkaigi.confsched.primitive
 
-import com.google.devtools.ksp.gradle.KspTaskNative
 import io.github.droidkaigi.confsched.primitive.Arch.ALL
 import io.github.droidkaigi.confsched.primitive.Arch.ARM
 import io.github.droidkaigi.confsched.primitive.Arch.ARM_SIMULATOR_DEBUG
@@ -10,8 +9,6 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.get
-import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink
 
 @Suppress("unused")
 class KmpKtorfitPlugin : Plugin<Project> {

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpPlugin.kt
@@ -5,10 +5,13 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 @Suppress("unused")
 class KmpPlugin : Plugin<Project> {
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
     override fun apply(target: Project) {
         with(target) {
             with(pluginManager) {
@@ -21,7 +24,7 @@ class KmpPlugin : Plugin<Project> {
                 }
             }
             tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
-                kotlinOptions.jvmTarget = "11"
+                compilerOptions.jvmTarget.set(JVM_11)
             }
             tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink>().configureEach {
                 notCompatibleWithConfigurationCache("Configuration chache not supported for a system property read at configuration time")

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KotlinGradleDsl.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KotlinGradleDsl.kt
@@ -7,11 +7,11 @@ import org.gradle.kotlin.dsl.DependencyHandlerScope
 import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
-fun Project.kotlinAndroid(configure: KotlinAndroidProjectExtension.() -> Unit) {
+fun Project.kotlinAndroidOptions(configure: KotlinAndroidProjectExtension.() -> Unit) {
     extensions.configure(configure)
 }
 
-fun Project.libraryAndroid(configure: LibraryAndroidComponentsExtension.() -> Unit) {
+fun Project.libraryAndroidOptions(configure: LibraryAndroidComponentsExtension.() -> Unit) {
     extensions.configure(configure)
 }
 

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KotlinGradleDsl.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KotlinGradleDsl.kt
@@ -1,14 +1,18 @@
 package io.github.droidkaigi.confsched.primitive
 
+import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import org.gradle.api.Project
 import org.gradle.api.artifacts.MinimalExternalModuleDependency
-import org.gradle.api.plugins.ExtensionAware
 import org.gradle.kotlin.dsl.DependencyHandlerScope
 import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
-fun Project.kotlinAndroidOptions(block: KotlinAndroidProjectExtension.() -> Unit) {
-    (this as ExtensionAware).extensions.configure(block)
+fun Project.kotlinAndroid(configure: KotlinAndroidProjectExtension.() -> Unit) {
+    extensions.configure(configure)
+}
+
+fun Project.libraryAndroid(configure: LibraryAndroidComponentsExtension.() -> Unit) {
+    extensions.configure(configure)
 }
 
 fun DependencyHandlerScope.ksp(

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KotlinGradleDsl.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KotlinGradleDsl.kt
@@ -1,19 +1,7 @@
 package io.github.droidkaigi.confsched.primitive
 
-import com.android.build.api.variant.LibraryAndroidComponentsExtension
-import org.gradle.api.Project
 import org.gradle.api.artifacts.MinimalExternalModuleDependency
 import org.gradle.kotlin.dsl.DependencyHandlerScope
-import org.gradle.kotlin.dsl.configure
-import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
-
-fun Project.kotlinAndroidOptions(configure: KotlinAndroidProjectExtension.() -> Unit) {
-    extensions.configure(configure)
-}
-
-fun Project.libraryAndroidOptions(configure: LibraryAndroidComponentsExtension.() -> Unit) {
-    extensions.configure(configure)
-}
 
 fun DependencyHandlerScope.ksp(
     artifact: MinimalExternalModuleDependency,

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KotlinGradleDsl.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KotlinGradleDsl.kt
@@ -1,13 +1,14 @@
 package io.github.droidkaigi.confsched.primitive
 
-import com.android.build.gradle.TestedExtension
+import org.gradle.api.Project
 import org.gradle.api.artifacts.MinimalExternalModuleDependency
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.kotlin.dsl.DependencyHandlerScope
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
-fun TestedExtension.kotlinOptions(block: KotlinJvmOptions.() -> Unit) {
-    (this as ExtensionAware).extensions.configure("kotlinOptions", block)
+fun Project.kotlinAndroidOptions(block: KotlinAndroidProjectExtension.() -> Unit) {
+    (this as ExtensionAware).extensions.configure(block)
 }
 
 fun DependencyHandlerScope.ksp(


### PR DESCRIPTION
## Issue
- close #933 

## Overview (Required)
- Raplace `kotlinOptions` to `compilerOptions`
- Replace `buildDir` to `layout.buildDirectory`
- Change reciever of `kotlinOptions` from `TestedExtension` to `Project`
  - TestedExtension somehow causes `Extension of type 'KotlinAndroidProjectExtension' does not exist.`
- Move dsl function `kotlinOptions`  from `KotlinGradleDsl.kt` to `AndroidGradleDsl.kt` because it now focuses only android target
- Add libraryAndroidOptions
  - kotlinAndroidOptions can be used only `org.jetbrains.kotlin.android` is applied, otherwise ` Extension of type 'KotlinAndroidProjectExtension' does not exist` happens

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
