### PR TITLE
Refactor TimetableItemTag API to use consistent colors

### DIFF
--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/TimetableItemTag.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/TimetableItemTag.kt
@@ -22,14 +22,45 @@ import org.jetbrains.compose.resources.vectorResource
 @Composable
 fun TimetableItemTag(
     tagText: String,
-    tagColor: Color,
     modifier: Modifier = Modifier,
-    icon: DrawableResource? = null,
+) {
+    TimetableItemTag(
+        tagText = tagText,
+        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        borderColor = MaterialTheme.colorScheme.outline,
+        icon = null,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun TimetableItemTag(
+    tagText: String,
+    tagColor: Color,
+    icon: DrawableResource?,
+    modifier: Modifier = Modifier,
+) {
+    TimetableItemTag(
+        tagText = tagText,
+        contentColor = tagColor,
+        borderColor = tagColor,
+        icon = icon,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun TimetableItemTag(
+    tagText: String,
+    contentColor: Color,
+    borderColor: Color,
+    icon: DrawableResource?,
+    modifier: Modifier = Modifier,
 ) {
     Row(
         modifier = modifier
             .border(
-                border = BorderStroke(width = 1.dp, color = tagColor),
+                border = BorderStroke(width = 1.dp, color = borderColor),
                 shape = RoundedCornerShape(2.dp),
             )
             .padding(
@@ -44,11 +75,11 @@ fun TimetableItemTag(
                 modifier = Modifier.size(12.dp),
                 imageVector = vectorResource(ico),
                 contentDescription = "",
-                tint = tagColor,
+                tint = contentColor,
             )
         }
         Text(
-            color = tagColor,
+            color = contentColor,
             text = tagText,
             style = MaterialTheme.typography.labelMedium,
             maxLines = 1,

--- a/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/section/FavoriteList.kt
+++ b/feature/favorites/src/commonMain/kotlin/io/github/droidkaigi/confsched/favorites/section/FavoriteList.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
@@ -131,16 +130,10 @@ fun FavoriteList(
                                             modifier = Modifier.background(LocalRoomTheme.current.containerColor),
                                         )
                                         timetableItem.language.labels.forEach { label ->
-                                            TimetableItemTag(
-                                                tagText = label,
-                                                tagColor = MaterialTheme.colorScheme.outline,
-                                            )
+                                            TimetableItemTag(tagText = label)
                                         }
                                         timetableItem.day?.let {
-                                            TimetableItemTag(
-                                                tagText = "9/${it.dayOfMonth}",
-                                                tagColor = MaterialTheme.colorScheme.outline,
-                                            )
+                                            TimetableItemTag(tagText = "9/${it.dayOfMonth}")
                                         }
                                     },
                                     timetableItem = timetableItem,

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailHeadline.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/TimetableItemDetailHeadline.kt
@@ -47,6 +47,7 @@ import conference_app_2024.feature.sessions.generated.resources.select_language
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.designsystem.theme.LocalRoomTheme
 import io.github.droidkaigi.confsched.droidkaigiui.component.TimetableItemTag
+import io.github.droidkaigi.confsched.droidkaigiui.icon
 import io.github.droidkaigi.confsched.droidkaigiui.rememberAsyncImagePainter
 import io.github.droidkaigi.confsched.model.Lang
 import io.github.droidkaigi.confsched.model.TimetableItem
@@ -66,11 +67,12 @@ fun TimetableItemDetailHeadline(
     onLanguageSelect: (Lang) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val roomTheme = LocalRoomTheme.current
     val currentLang = currentLang ?: timetableItem.language.toLang()
+
     Column(
         modifier = modifier
-            // FIXME: Implement and use a theme color instead of fixed colors like RoomColors.primary and RoomColors.primaryDim
-            .background(LocalRoomTheme.current.dimColor)
+            .background(roomTheme.dimColor)
             .padding(horizontal = 8.dp)
             .fillMaxWidth(),
     ) {
@@ -78,14 +80,14 @@ fun TimetableItemDetailHeadline(
             TimetableItemTag(
                 modifier = Modifier.align(Alignment.CenterVertically),
                 tagText = timetableItem.room.name.currentLangTitle,
-                tagColor = LocalRoomTheme.current.primaryColor,
+                tagColor = roomTheme.primaryColor,
+                icon = timetableItem.room.icon,
             )
             timetableItem.language.labels.forEach { label ->
                 Spacer(modifier = Modifier.padding(4.dp))
                 TimetableItemTag(
                     modifier = Modifier.align(Alignment.CenterVertically),
                     tagText = label,
-                    tagColor = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
             Spacer(modifier = Modifier.weight(1f))

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/SearchList.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/SearchList.kt
@@ -2,7 +2,6 @@ package io.github.droidkaigi.confsched.sessions.section
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import io.github.droidkaigi.confsched.droidkaigiui.component.TimetableItemTag
@@ -27,10 +26,7 @@ fun SearchList(
         modifier = modifier,
         timetableItemTagsContent = { timetableItem ->
             timetableItem.day?.monthAndDay()?.let { monthAndDay ->
-                TimetableItemTag(
-                    tagText = monthAndDay,
-                    tagColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+                TimetableItemTag(tagText = monthAndDay)
             }
         },
     )

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableSheet.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableSheet.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -112,10 +111,7 @@ fun Timetable(
                         ),
                         timetableItemTagsContent = { timetableItem ->
                             timetableItem.language.labels.forEach { label ->
-                                TimetableItemTag(
-                                    tagText = label,
-                                    tagColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
+                                TimetableItemTag(tagText = label)
                             }
                         },
                     )


### PR DESCRIPTION
## Issue
- close #930

## Overview (Required)
- There are now two variants of this component
- The first requires color+icon and is used for the colored 'room' tags
- Any other usage in the app uses the same grayish color and no icon, so expose that as a second variant


## Screenshot (Optional if screenshot test is present or unrelated to UI)

Note the subtle change for the gray tags.

Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/08d42e08-f50c-419d-93a1-bb01f4b306e9" width="300" /> | <img src="https://github.com/user-attachments/assets/40251587-9da7-40cd-a2b0-5ed5c11cc1c2" width="300" />
Incorrect outline color | 

Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/ad1fcf14-6355-4df1-bbbc-1c3d4a0878ed" width="300" /> | <img src="https://github.com/user-attachments/assets/6d8f2dc1-ec44-416e-b4fe-4d3d920f71dc" width="300" />
Missing icon, incorrect outline color |

Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/0ea36903-3c83-4897-99ea-d9267f3fb66b" width="300" /> | <img src="https://github.com/user-attachments/assets/8d749314-9208-4232-afe8-b255a483399a" width="300" />
Incorrect outline color | 

Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/d36b8f67-3525-41f3-9b74-001b3bf8c83d" width="300" /> | <img src="https://github.com/user-attachments/assets/3ecc4e52-8e94-4d65-8160-4922258b9225" width="300" />
Incorrect outline color | 

