### PR TITLE
:wrench: [ClickableLinkText] Processing has been simplified.

### DIFF
--- a/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/component/ClickableLinkText.kt
+++ b/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched/designsystem/component/ClickableLinkText.kt
@@ -7,14 +7,11 @@ import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.LayoutCoordinates
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
@@ -105,19 +102,7 @@ fun ClickableLinkText(
         findUrlResults = findResults,
     )
 
-    val layoutResult = remember { mutableStateOf<LayoutCoordinates?>(null) }
-
-    val density = LocalDensity.current
-
-    val isOverflowing by remember {
-        derivedStateOf {
-            val actualHeight = layoutResult.value?.size?.height?.toFloat() ?: 0f
-            val expectedHeight = with(density) {
-                style.fontSize.toPx() + style.lineHeight.toPx() * (maxLines - 1)
-            }
-            actualHeight > expectedHeight
-        }
-    }
+    var isOverflowing by remember { mutableStateOf(false) }
 
     LaunchedEffect(isOverflowing) {
         onOverflow(isOverflowing)
@@ -127,14 +112,14 @@ fun ClickableLinkText(
         modifier = modifier
             .animateContentSize(
                 animationSpec = tween(ClickableTextExpandAnimateDurationMillis, easing = EaseInQuart),
-            )
-            .onGloballyPositioned { coordinates ->
-                layoutResult.value = coordinates
-            },
+            ),
         text = annotatedString,
         style = style,
         overflow = overflow,
         maxLines = maxLines,
+        onTextLayout = { textLayoutResult ->
+            isOverflowing = textLayoutResult.hasVisualOverflow
+        },
         onClick = { offset ->
             findResults.forEach { matchResult ->
                 annotatedString.getStringAnnotations(


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- I made some of the processing I implemented last year easier to understand.

## Links
- https://github.com/DroidKaigi/conference-app-2023/pull/706

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/07c558de-f8a8-46fa-842d-f52768858598" width="300" > | <video src="https://github.com/user-attachments/assets/b06c519b-fcfc-4913-82bb-174ea8923f99" width="300" >