### PR TITLE
Fix the floor information for session rooms 

### DIFF
--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/TimetableRoom.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched/model/TimetableRoom.kt
@@ -22,14 +22,15 @@ data class TimetableRoom(
 val TimetableRoom.nameAndFloor: String
     get() {
         val basementFloorString = MultiLangText(jaTitle = "地下1階", enTitle = "B1F")
+        val floor1FString = MultiLangText(jaTitle = "1階", enTitle = "1F")
         val floor = when (type) {
-            RoomType.RoomF -> basementFloorString.currentLangTitle
-            RoomType.RoomG -> basementFloorString.currentLangTitle
+            RoomType.RoomF -> floor1FString.currentLangTitle
+            RoomType.RoomG -> floor1FString.currentLangTitle
             RoomType.RoomH -> basementFloorString.currentLangTitle
-            RoomType.RoomI -> "1F"
-            RoomType.RoomJ -> "1F"
+            RoomType.RoomI -> basementFloorString.currentLangTitle
+            RoomType.RoomJ -> basementFloorString.currentLangTitle
             // Assume the room on the first day.
-            RoomType.RoomIJ -> "1F"
+            RoomType.RoomIJ -> basementFloorString.currentLangTitle
         }
         return "${name.currentLangTitle} ($floor)"
     }


### PR DESCRIPTION
fix floor information

## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- I fixed a problem where the floor information for session rooms wasn't showing up correctly.
- Flamingo (B1F) --> Flamingo (1F)
- Giraffe (B1F) --> Giraffe (1F)

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
| Before | After |
| :--: | :--: | 
| ![Screenshot_20240906_114318](https://github.com/user-attachments/assets/825fa7dc-59f9-472b-a9e0-a17dd07e4d6b) | ![Screenshot_20240906_113327](https://github.com/user-attachments/assets/4f6dfe0e-478d-411a-985b-591cea7dd001) |

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
