### PR TITLE
:wrench: Revert Fix bottom space from DayTab offsets in Timetable Screen.

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableGrid.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableGrid.kt
@@ -139,7 +139,7 @@ fun TimetableGrid(
     val animatedScope = LocalAnimatedVisibilityScope.current
 
     Row(
-        modifier = modifier
+        modifier = Modifier
             .testTag(TimetableGridTestTag)
             .padding(
                 top = contentPadding.calculateTopPadding(),
@@ -171,6 +171,7 @@ fun TimetableGrid(
                 timetableState = timetableState,
                 timeLine = timeLine,
                 selectedDay = selectedDay,
+                modifier = modifier,
                 contentPadding = PaddingValues(
                     top = 16.dp + contentPadding.calculateTopPadding(),
                     bottom = 16.dp + 80.dp + contentPadding.calculateBottomPadding(),

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableList.kt
@@ -93,6 +93,9 @@ internal fun TimetableList(
 
     LazyColumn(
         modifier = modifier.testTag(TimetableListTestTag)
+            .offset {
+                IntOffset(x = 0, y = nestedScrollStateHolder.uiState.dayTabOffsetY.toInt())
+            }
             .nestedScroll(nestedScrollConnection),
         state = scrollState,
         verticalArrangement = Arrangement.spacedBy(32.dp),

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableSheet.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/section/TimetableSheet.kt
@@ -1,7 +1,7 @@
 package io.github.droidkaigi.confsched.sessions.section
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
@@ -20,9 +20,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -31,7 +29,6 @@ import io.github.droidkaigi.confsched.model.DroidKaigi2024Day
 import io.github.droidkaigi.confsched.model.TimeLine
 import io.github.droidkaigi.confsched.model.TimetableItem
 import io.github.droidkaigi.confsched.sessions.component.TimetableDayTab
-import io.github.droidkaigi.confsched.sessions.component.TimetableNestedScrollStateHolder
 import io.github.droidkaigi.confsched.sessions.component.rememberTimetableNestedScrollStateHolder
 import io.github.droidkaigi.confsched.sessions.section.TimetableUiState.Empty
 import io.github.droidkaigi.confsched.sessions.section.TimetableUiState.GridTimetable
@@ -74,8 +71,9 @@ fun Timetable(
     Surface(
         modifier = modifier.padding(contentPadding.calculateTopPadding()),
     ) {
-        Box(
-            modifier = Modifier.fillMaxSize(),
+        Column(
+            modifier = Modifier
+                .fillMaxSize(),
         ) {
             TimetableDayTab(
                 selectedDay = selectedDay,
@@ -102,7 +100,9 @@ fun Timetable(
                         scrollState = scrollStates.getValue(selectedDay),
                         onTimetableItemClick = onTimetableItemClick,
                         onBookmarkClick = onFavoriteClick,
-                        modifier = timetableModifier(nestedScrollStateHolder),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .weight(1f),
                         contentPadding = PaddingValues(
                             bottom = contentPadding.calculateBottomPadding(),
                             start = contentPadding.calculateStartPadding(layoutDirection),
@@ -119,7 +119,9 @@ fun Timetable(
                         timeLine = uiState.timeLine,
                         selectedDay = selectedDay,
                         onTimetableItemClick = onTimetableItemClick,
-                        modifier = timetableModifier(nestedScrollStateHolder),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .weight(1f),
                         contentPadding = PaddingValues(
                             bottom = contentPadding.calculateBottomPadding(),
                             start = contentPadding.calculateStartPadding(layoutDirection),
@@ -157,20 +159,4 @@ private fun rememberGridTimetableStates(): Map<DroidKaigi2024Day, TimetableState
         rememberTimetableGridState()
     }
     return remember { timetableStateMap }
-}
-
-@Composable
-private fun timetableModifier(
-    nestedScrollStateHolder: TimetableNestedScrollStateHolder,
-): Modifier {
-    val density = LocalDensity.current
-
-    return Modifier
-        .padding(
-            top = with(density) {
-                (nestedScrollStateHolder.uiState.scrollConnectionMinOffset + nestedScrollStateHolder.uiState.dayTabOffsetY).toDp()
-            },
-        )
-        .fillMaxSize()
-        .background(Color.Transparent)
 }


### PR DESCRIPTION
## Issue
- close #955

## Overview (Required)
- We have tried to make the necessary corrections, but there is no prospect of being able to make the corrections by the deadline.
- Unfortunately, we have no choice but to revert. 😞 

- @takahirom @kktaro We apologize for not being able to provide you with the ideal revision response. 🙇 

## Links
- https://github.com/DroidKaigi/conference-app-2024/pull/919

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/4a5f1a9f-b73c-46a2-ac36-36c388f0ef5a" width="300" > | <video src="https://github.com/user-attachments/assets/62832fc0-2b6e-464c-9203-decf13a05e33" width="300" >