### PR TITLE
:memo: [Proposal][SearchScreenTest] The robots were separated according to their roles.

### DIFF
--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/action/SearchScreenActionRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/action/SearchScreenActionRobot.kt
@@ -1,0 +1,115 @@
+package io.github.droidkaigi.confsched.testing.robot.action
+
+import androidx.compose.ui.test.filter
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performTextInput
+import io.github.droidkaigi.confsched.droidkaigiui.Inject
+import io.github.droidkaigi.confsched.sessions.component.DropdownFilterChipTestTagPrefix
+import io.github.droidkaigi.confsched.sessions.component.SearchFiltersFilterCategoryChipTestTag
+import io.github.droidkaigi.confsched.sessions.component.SearchFiltersFilterDayChipTestTag
+import io.github.droidkaigi.confsched.sessions.component.SearchFiltersFilterLanguageChipTestTag
+import io.github.droidkaigi.confsched.sessions.component.SearchFiltersLazyRowTestTag
+import io.github.droidkaigi.confsched.sessions.component.SearchTextFieldAppBarTextFieldTestTag
+import io.github.droidkaigi.confsched.testing.robot.DefaultScreenRobot
+import io.github.droidkaigi.confsched.testing.robot.ScreenRobot
+import io.github.droidkaigi.confsched.testing.robot.core.SearchScreenCoreRobot.Category
+import io.github.droidkaigi.confsched.testing.robot.core.SearchScreenCoreRobot.ConferenceDay
+import io.github.droidkaigi.confsched.testing.robot.TimetableItemCardRobot.Language
+import io.github.droidkaigi.confsched.testing.robot.core.DemoSearchWord
+import io.github.droidkaigi.confsched.testing.utils.hasTestTag
+
+class SearchScreenActionRobot @Inject constructor(
+    private val screenRobot: DefaultScreenRobot,
+) : ScreenRobot by screenRobot {
+    fun inputDemoSearchWord() {
+        inputSearchWord(DemoSearchWord)
+    }
+
+    private fun inputSearchWord(text: String) {
+        composeTestRule
+            .onNodeWithTag(SearchTextFieldAppBarTextFieldTestTag)
+            .performTextInput(text)
+        waitUntilIdle()
+    }
+
+    fun scrollToFilterLanguageChip() {
+        composeTestRule
+            .onNode(hasTestTag(SearchFiltersLazyRowTestTag))
+            .performScrollToNode(hasTestTag(SearchFiltersFilterLanguageChipTestTag))
+        waitUntilIdle()
+    }
+
+    fun clickFilterDayChip() {
+        composeTestRule
+            .onNode(hasTestTag(SearchFiltersFilterDayChipTestTag))
+            .performClick()
+        waitUntilIdle()
+    }
+
+    fun clickFilterCategoryChip() {
+        composeTestRule
+            .onNode(hasTestTag(SearchFiltersFilterCategoryChipTestTag))
+            .performClick()
+        waitUntilIdle()
+    }
+
+    fun clickFilterLanguageChip() {
+        composeTestRule
+            .onNode(hasTestTag(SearchFiltersFilterLanguageChipTestTag))
+            .performClick()
+        waitUntilIdle()
+    }
+
+    fun clickConferenceDay(
+        clickDay: ConferenceDay,
+    ) {
+        composeTestRule
+            .onAllNodes(
+                hasTestTag(
+                    testTag = DropdownFilterChipTestTagPrefix,
+                    substring = true,
+                ),
+            )
+            .filter(matcher = hasText(clickDay.dateText))
+            .onFirst()
+            .performClick()
+        waitUntilIdle()
+    }
+
+    fun clickCategory(
+        category: Category,
+    ) {
+        composeTestRule
+            .onAllNodes(
+                hasTestTag(
+                    testTag = DropdownFilterChipTestTagPrefix,
+                    substring = true,
+                ),
+            )
+            .filter(matcher = hasText(category.categoryName))
+            .onFirst()
+            .performClick()
+        waitUntilIdle()
+    }
+
+    fun clickLanguage(
+        language: Language,
+    ) {
+        composeTestRule
+            .onAllNodes(
+                hasTestTag(
+                    testTag = DropdownFilterChipTestTagPrefix,
+                    substring = true,
+                ),
+            )
+            .filter(matcher = hasText(language.tagName))
+            .onFirst()
+            .performClick()
+        waitUntilIdle()
+    }
+}

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/core/SearchScreenCoreRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/core/SearchScreenCoreRobot.kt
@@ -1,0 +1,58 @@
+package io.github.droidkaigi.confsched.testing.robot.core
+
+import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
+import io.github.droidkaigi.confsched.droidkaigiui.Inject
+import io.github.droidkaigi.confsched.sessions.SearchScreen
+import io.github.droidkaigi.confsched.testing.robot.DefaultDeviceSetupRobot
+import io.github.droidkaigi.confsched.testing.robot.DefaultScreenRobot
+import io.github.droidkaigi.confsched.testing.robot.DefaultTimetableItemCardRobot
+import io.github.droidkaigi.confsched.testing.robot.DefaultTimetableServerRobot
+import io.github.droidkaigi.confsched.testing.robot.DeviceSetupRobot
+import io.github.droidkaigi.confsched.testing.robot.ScreenRobot
+import io.github.droidkaigi.confsched.testing.robot.action.SearchScreenActionRobot
+import io.github.droidkaigi.confsched.testing.robot.verify.SearchScreenVerifyRobot
+import io.github.droidkaigi.confsched.testing.robot.TimetableItemCardRobot
+import io.github.droidkaigi.confsched.testing.robot.TimetableServerRobot
+
+const val DemoSearchWord = "Demo"
+
+class SearchScreenCoreRobot @Inject constructor(
+    private val screenRobot: DefaultScreenRobot,
+    private val timetableServerRobot: DefaultTimetableServerRobot,
+    private val deviceSetupRobot: DefaultDeviceSetupRobot,
+    timetableItemRobot: DefaultTimetableItemCardRobot,
+) : ScreenRobot by screenRobot,
+    TimetableServerRobot by timetableServerRobot,
+    DeviceSetupRobot by deviceSetupRobot,
+    TimetableItemCardRobot by timetableItemRobot {
+    @Inject lateinit var actionRobot: SearchScreenActionRobot
+    @Inject lateinit var verifyRobot: SearchScreenVerifyRobot
+
+    enum class ConferenceDay(
+        val day: Int,
+        val dateText: String,
+    ) {
+        Day1(1, "9/12"),
+        Day2(2, "9/13"),
+    }
+
+    enum class Category(
+        val categoryName: String,
+    ) {
+        AppArchitecture("App Architecture en"),
+        JetpackCompose("Jetpack Compose en"),
+        Other("Other en"),
+    }
+
+    fun setupSearchScreenContent() {
+        robotTestRule.setContent {
+            KaigiTheme {
+                SearchScreen(
+                    onTimetableItemClick = {},
+                    onBackClick = {},
+                )
+            }
+        }
+        waitUntilIdle()
+    }
+}

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/verify/SearchScreenVerifyRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched/testing/robot/verify/SearchScreenVerifyRobot.kt
@@ -1,162 +1,34 @@
-package io.github.droidkaigi.confsched.testing.robot
+package io.github.droidkaigi.confsched.testing.robot.verify
 
 import androidx.compose.ui.test.assertAll
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
-import androidx.compose.ui.test.filter
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollToNode
-import androidx.compose.ui.test.performTextInput
-import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.droidkaigiui.Inject
 import io.github.droidkaigi.confsched.droidkaigiui.component.TimetableItemCardTestTag
 import io.github.droidkaigi.confsched.droidkaigiui.component.TimetableItemCardTitleTextTestTag
-import io.github.droidkaigi.confsched.sessions.SearchScreen
 import io.github.droidkaigi.confsched.sessions.component.DropdownFilterChipTestTagPrefix
-import io.github.droidkaigi.confsched.sessions.component.SearchFiltersFilterCategoryChipTestTag
-import io.github.droidkaigi.confsched.sessions.component.SearchFiltersFilterDayChipTestTag
-import io.github.droidkaigi.confsched.sessions.component.SearchFiltersFilterLanguageChipTestTag
-import io.github.droidkaigi.confsched.sessions.component.SearchFiltersLazyRowTestTag
 import io.github.droidkaigi.confsched.sessions.component.SearchTextFieldAppBarTextFieldTestTag
 import io.github.droidkaigi.confsched.sessions.section.TimetableListTestTag
+import io.github.droidkaigi.confsched.testing.robot.DefaultScreenRobot
+import io.github.droidkaigi.confsched.testing.robot.ScreenRobot
+import io.github.droidkaigi.confsched.testing.robot.core.SearchScreenCoreRobot.Category
+import io.github.droidkaigi.confsched.testing.robot.core.SearchScreenCoreRobot.ConferenceDay
 import io.github.droidkaigi.confsched.testing.robot.TimetableItemCardRobot.Language
+import io.github.droidkaigi.confsched.testing.robot.core.DemoSearchWord
 import io.github.droidkaigi.confsched.testing.utils.assertCountAtLeast
 import io.github.droidkaigi.confsched.testing.utils.assertTextDoesNotContain
 import io.github.droidkaigi.confsched.testing.utils.hasTestTag
 
-const val DemoSearchWord = "Demo"
-
-class SearchScreenRobot @Inject constructor(
+class SearchScreenVerifyRobot @Inject constructor(
     private val screenRobot: DefaultScreenRobot,
-    private val timetableServerRobot: DefaultTimetableServerRobot,
-    private val deviceSetupRobot: DefaultDeviceSetupRobot,
-    timetableItemRobot: DefaultTimetableItemCardRobot,
-) : ScreenRobot by screenRobot,
-    TimetableServerRobot by timetableServerRobot,
-    DeviceSetupRobot by deviceSetupRobot,
-    TimetableItemCardRobot by timetableItemRobot {
-    enum class ConferenceDay(
-        val day: Int,
-        val dateText: String,
-    ) {
-        Day1(1, "9/12"),
-        Day2(2, "9/13"),
-    }
-
-    enum class Category(
-        val categoryName: String,
-    ) {
-        AppArchitecture("App Architecture en"),
-        JetpackCompose("Jetpack Compose en"),
-        Other("Other en"),
-    }
-
-    fun setupSearchScreenContent() {
-        robotTestRule.setContent {
-            KaigiTheme {
-                SearchScreen(
-                    onTimetableItemClick = {},
-                    onBackClick = {},
-                )
-            }
-        }
-        waitUntilIdle()
-    }
-
-    fun inputDemoSearchWord() {
-        inputSearchWord(DemoSearchWord)
-    }
-
-    private fun inputSearchWord(text: String) {
-        composeTestRule
-            .onNodeWithTag(SearchTextFieldAppBarTextFieldTestTag)
-            .performTextInput(text)
-        waitUntilIdle()
-    }
-
-    fun scrollToFilterLanguageChip() {
-        composeTestRule
-            .onNode(hasTestTag(SearchFiltersLazyRowTestTag))
-            .performScrollToNode(hasTestTag(SearchFiltersFilterLanguageChipTestTag))
-        waitUntilIdle()
-    }
-
-    fun clickFilterDayChip() {
-        composeTestRule
-            .onNode(hasTestTag(SearchFiltersFilterDayChipTestTag))
-            .performClick()
-        waitUntilIdle()
-    }
-
-    fun clickFilterCategoryChip() {
-        composeTestRule
-            .onNode(hasTestTag(SearchFiltersFilterCategoryChipTestTag))
-            .performClick()
-        waitUntilIdle()
-    }
-
-    fun clickFilterLanguageChip() {
-        composeTestRule
-            .onNode(hasTestTag(SearchFiltersFilterLanguageChipTestTag))
-            .performClick()
-        waitUntilIdle()
-    }
-
-    fun clickConferenceDay(
-        clickDay: ConferenceDay,
-    ) {
-        composeTestRule
-            .onAllNodes(
-                hasTestTag(
-                    testTag = DropdownFilterChipTestTagPrefix,
-                    substring = true,
-                ),
-            )
-            .filter(matcher = hasText(clickDay.dateText))
-            .onFirst()
-            .performClick()
-        waitUntilIdle()
-    }
-
-    fun clickCategory(
-        category: Category,
-    ) {
-        composeTestRule
-            .onAllNodes(
-                hasTestTag(
-                    testTag = DropdownFilterChipTestTagPrefix,
-                    substring = true,
-                ),
-            )
-            .filter(matcher = hasText(category.categoryName))
-            .onFirst()
-            .performClick()
-        waitUntilIdle()
-    }
-
-    fun clickLanguage(
-        language: Language,
-    ) {
-        composeTestRule
-            .onAllNodes(
-                hasTestTag(
-                    testTag = DropdownFilterChipTestTagPrefix,
-                    substring = true,
-                ),
-            )
-            .filter(matcher = hasText(language.tagName))
-            .onFirst()
-            .performClick()
-        waitUntilIdle()
-    }
-
+) : ScreenRobot by screenRobot {
     fun checkDisplayedFilterDayChip() {
         composeTestRule
             .onAllNodes(

--- a/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
+++ b/feature/sessions/src/androidUnitTest/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreenTest.kt
@@ -5,9 +5,9 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import io.github.droidkaigi.confsched.testing.DescribedBehavior
 import io.github.droidkaigi.confsched.testing.describeBehaviors
 import io.github.droidkaigi.confsched.testing.execute
-import io.github.droidkaigi.confsched.testing.robot.SearchScreenRobot
-import io.github.droidkaigi.confsched.testing.robot.SearchScreenRobot.Category
-import io.github.droidkaigi.confsched.testing.robot.SearchScreenRobot.ConferenceDay
+import io.github.droidkaigi.confsched.testing.robot.core.SearchScreenCoreRobot
+import io.github.droidkaigi.confsched.testing.robot.core.SearchScreenCoreRobot.Category
+import io.github.droidkaigi.confsched.testing.robot.core.SearchScreenCoreRobot.ConferenceDay
 import io.github.droidkaigi.confsched.testing.robot.TimetableItemCardRobot.Language
 import io.github.droidkaigi.confsched.testing.robot.TimetableServerRobot.ServerStatus
 import io.github.droidkaigi.confsched.testing.robot.runRobot
@@ -21,26 +21,26 @@ import javax.inject.Inject
 @RunWith(ParameterizedRobolectricTestRunner::class)
 @HiltAndroidTest
 class SearchScreenTest(
-    private val testCase: DescribedBehavior<SearchScreenRobot>,
+    private val testCase: DescribedBehavior<SearchScreenCoreRobot>,
 ) {
     @get:Rule
     @BindValue val robotTestRule: RobotTestRule = RobotTestRule(testInstance = this)
 
     @Inject
-    lateinit var searchScreenRobot: SearchScreenRobot
+    lateinit var searchScreenCoreRobot: SearchScreenCoreRobot
 
     @Test
     fun runTest() {
-        runRobot(searchScreenRobot) {
-            testCase.execute(searchScreenRobot)
+        runRobot(searchScreenCoreRobot) {
+            testCase.execute(searchScreenCoreRobot)
         }
     }
 
     companion object {
         @JvmStatic
         @ParameterizedRobolectricTestRunner.Parameters(name = "{0}")
-        fun behaviors(): List<DescribedBehavior<SearchScreenRobot>> {
-            return describeBehaviors<SearchScreenRobot>(name = "SearchScreen") {
+        fun behaviors(): List<DescribedBehavior<SearchScreenCoreRobot>> {
+            return describeBehaviors<SearchScreenCoreRobot>(name = "SearchScreen") {
                 describe("when server is operational") {
                     doIt {
                         setupTimetableServer(ServerStatus.Operational)
@@ -48,46 +48,60 @@ class SearchScreenTest(
                     }
                     itShould("no timetable items are displayed") {
                         captureScreenWithChecks {
-                            checkTimetableListExists()
-                            checkTimetableListItemsNotDisplayed()
+                            runRobot(verifyRobot) {
+                                checkTimetableListExists()
+                                checkTimetableListItemsNotDisplayed()
+                            }
                         }
                     }
                     describe("input search word to TextField") {
                         doIt {
-                            inputDemoSearchWord()
+                            runRobot(actionRobot) {
+                                inputDemoSearchWord()
+                            }
                         }
                         itShould("show search word and filtered items") {
                             captureScreenWithChecks {
-                                checkDemoSearchWordDisplayed()
-                                checkTimetableListItemsHasDemoText()
-                                checkTimetableListDisplayed()
-                                checkTimetableListItemsDisplayed()
+                                runRobot(verifyRobot) {
+                                    checkDemoSearchWordDisplayed()
+                                    checkTimetableListItemsHasDemoText()
+                                    checkTimetableListDisplayed()
+                                    checkTimetableListItemsDisplayed()
+                                }
                             }
                         }
                     }
                     describe("when filter day chip click") {
                         doIt {
-                            clickFilterDayChip()
+                            runRobot(actionRobot) {
+                                clickFilterDayChip()
+                            }
                         }
                         itShould("show drop down menu") {
                             captureScreenWithChecks {
-                                checkDisplayedFilterDayChip()
+                                runRobot(verifyRobot) {
+                                    checkDisplayedFilterDayChip()
+                                }
                             }
                         }
                         ConferenceDay.entries.forEach { conference ->
                             describe("when click conference day ${conference.day}") {
                                 doIt {
-                                    clickConferenceDay(
-                                        clickDay = conference,
-                                    )
+                                    runRobot(actionRobot) {
+                                        clickConferenceDay(
+                                            clickDay = conference,
+                                        )
+                                    }
                                 }
                                 itShould("selected day ${conference.day}") {
                                     captureScreenWithChecks {
-                                        checkTimetableListItemByConferenceDay(
-                                            checkDay = conference,
-                                        )
-                                        checkTimetableListDisplayed()
-                                        checkTimetableListItemsDisplayed()
+                                        runRobot(verifyRobot) {
+                                            checkTimetableListItemByConferenceDay(
+                                                checkDay = conference,
+                                            )
+                                            checkTimetableListDisplayed()
+                                            checkTimetableListItemsDisplayed()
+                                        }
                                     }
                                 }
                             }
@@ -95,25 +109,33 @@ class SearchScreenTest(
                     }
                     describe("when filter category chip click") {
                         doIt {
-                            clickFilterCategoryChip()
+                            runRobot(actionRobot) {
+                                clickFilterCategoryChip()
+                            }
                         }
                         itShould("show drop down menu") {
                             captureScreenWithChecks {
-                                checkDisplayedFilterCategoryChip()
+                                runRobot(verifyRobot) {
+                                    checkDisplayedFilterCategoryChip()
+                                }
                             }
                         }
                         Category.entries.forEach { category ->
                             describe("when click category ${category.categoryName}") {
                                 doIt {
-                                    clickCategory(
-                                        category = category,
-                                    )
+                                    runRobot(actionRobot) {
+                                        clickCategory(
+                                            category = category,
+                                        )
+                                    }
                                 }
                                 itShould("selected category ${category.categoryName}") {
                                     captureScreenWithChecks {
-                                        checkTimetableListItemByCategory(category)
-                                        checkTimetableListDisplayed()
-                                        checkTimetableListItemsDisplayed()
+                                        runRobot(verifyRobot) {
+                                            checkTimetableListItemByCategory(category)
+                                            checkTimetableListDisplayed()
+                                            checkTimetableListItemsDisplayed()
+                                        }
                                     }
                                 }
                             }
@@ -121,26 +143,34 @@ class SearchScreenTest(
                     }
                     describe("when filter language chip click") {
                         doIt {
-                            scrollToFilterLanguageChip()
-                            clickFilterLanguageChip()
+                            runRobot(actionRobot) {
+                                scrollToFilterLanguageChip()
+                                clickFilterLanguageChip()
+                            }
                         }
                         itShould("show drop down menu") {
                             captureScreenWithChecks {
-                                checkDisplayedFilterLanguageChip()
+                                runRobot(verifyRobot) {
+                                    checkDisplayedFilterLanguageChip()
+                                }
                             }
                         }
                         Language.entries.forEach { language ->
                             describe("when click language ${language.name}") {
                                 doIt {
-                                    clickLanguage(
-                                        language = language,
-                                    )
+                                    runRobot(actionRobot) {
+                                        clickLanguage(
+                                            language = language,
+                                        )
+                                    }
                                 }
                                 itShould("selected language ${language.name}") {
                                     captureScreenWithChecks {
                                         checkTimetableListItemByLanguage(language)
-                                        checkTimetableListDisplayed()
-                                        checkTimetableListItemsDisplayed()
+                                        runRobot(verifyRobot) {
+                                            checkTimetableListDisplayed()
+                                            checkTimetableListItemsDisplayed()
+                                        }
                                     }
                                 }
                             }
@@ -156,21 +186,27 @@ class SearchScreenTest(
                     }
                     itShould("no timetable items are displayed") {
                         captureScreenWithChecks {
-                            checkTimetableListExists()
-                            checkTimetableListItemsNotDisplayed()
+                            runRobot(verifyRobot) {
+                                checkTimetableListExists()
+                                checkTimetableListItemsNotDisplayed()
+                            }
                         }
                     }
 
                     describe("input search word to TextField") {
                         doIt {
-                            inputDemoSearchWord()
+                            runRobot(actionRobot) {
+                                inputDemoSearchWord()
+                            }
                         }
                         itShould("show search word and filtered items") {
                             captureScreenWithChecks {
-                                checkDemoSearchWordDisplayed()
-                                checkTimetableListItemsHasDemoText()
-                                checkTimetableListDisplayed()
-                                checkTimetableListItemsDisplayed()
+                                runRobot(verifyRobot) {
+                                    checkDemoSearchWordDisplayed()
+                                    checkTimetableListItemsHasDemoText()
+                                    checkTimetableListDisplayed()
+                                    checkTimetableListItemsDisplayed()
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- As the robot was becoming bloated, I thought it might be a good idea to separate it into three parts: a robot that performs setup, a robot that operates the semantics tree, and a robot that performs checks, so I tried introducing it into SearchScreenTest.