### PR TITLE
Changed the display position of EmptySearchResultBody to the center vertically.

### DIFF
--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreen.kt
@@ -168,7 +168,7 @@ fun SearchScreen(
                 onChangeSearchWord = onSearchWordChanged,
                 onClickClear = onClearSearchWordClick,
                 onClickBack = onBackClick,
-                modifier = modifier
+                modifier = Modifier
                     .onGloballyPositioned { coordinates ->
                         topAppBarHeight.value = coordinates.size.height
                     },
@@ -206,8 +206,12 @@ fun SearchScreen(
                         contentAlignment = Alignment.Center,
                         modifier = Modifier
                             .fillMaxSize()
-                            .offset(y = -(topAppBarHeightDp + searchFiltersHeightDp
-                                + spacerHeight) / 2),
+                            .offset(
+                                y = -(
+                                    topAppBarHeightDp + searchFiltersHeightDp +
+                                        spacerHeight
+                                    ) / 2,
+                            ),
                     ) {
                         EmptySearchResultBody(
                             searchWord = uiState.searchWord,

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/EmptySearchResultBody.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/component/EmptySearchResultBody.kt
@@ -3,8 +3,9 @@ package io.github.droidkaigi.confsched.sessions.component
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -25,8 +26,10 @@ fun EmptySearchResultBody(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier
-            .fillMaxSize()
+        modifier =
+        modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
             .padding(20.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(32.dp, Alignment.CenterVertically),


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Empty view of the search screen is not aligned center vertically.
In figma, UFO image and description is centered in whole screen (including app top bar and search filters bar).

| figma | emulated device |
|---|---|
| <img src="https://github.com/user-attachments/assets/6664b80b-6fb8-41b6-a424-d60647876bd9" width="300">|<img src="https://github.com/user-attachments/assets/50c10d3a-b38c-4920-886a-d869e7e22dc4" width="300">|

## Links
- Related issues
  - https://github.com/DroidKaigi/conference-app-2024/issues/853

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After | After: `show layout bounds`</br>mode ON
:--: | :--: | :--:
<img src="https://github.com/user-attachments/assets/c4cd6f3e-944c-42d0-be97-d2934f9309c8" width="300" /> | <img src="https://github.com/user-attachments/assets/7ac12d5c-5de9-463e-922e-114b13835efd" width="300" /> | <img src="https://github.com/user-attachments/assets/7e332795-319c-4a70-9be2-7bf37a34ced6" width="300" />

## Movie (Optional)
Before | After
:--: | :--: 
<video src="" width="300" > | <video src="" width="300" >
