### PR TITLE
Improved accessibility on the ProfileCardScreen

### DIFF
--- a/feature/profilecard/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/profilecard/src/commonMain/composeResources/values-ja/strings.xml
@@ -14,6 +14,8 @@
     <string name="enter_validate_format">%1$sを入力してください</string>
     <string name="add_validate_format">%1$sを追加してください</string>
     <string name="url_is_invalid">URLの形式が正しくありません</string>
+    <string name="flip">裏返す</string>
+    <string name="qrcode">QRコード</string>
     <string name="share">共有する</string>
     <string name="edit">編集する</string>
     <string name="share_description">DroidKaigiのプロフィールカードを作成しました！イベントでつながりましょう。#DroidKaigi</string>

--- a/feature/profilecard/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/profilecard/src/commonMain/composeResources/values-ja/strings.xml
@@ -10,6 +10,7 @@
     <string name="link">リンク</string>
     <string name="image">画像</string>
     <string name="add_image">画像を追加</string>
+    <string name="delete">削除する</string>
     <string name="enter_validate_format">%1$sを入力してください</string>
     <string name="add_validate_format">%1$sを追加してください</string>
     <string name="url_is_invalid">URLの形式が正しくありません</string>

--- a/feature/profilecard/src/commonMain/composeResources/values/strings.xml
+++ b/feature/profilecard/src/commonMain/composeResources/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="link">Link</string>
     <string name="image">Image</string>
     <string name="add_image">Add Image</string>
+    <string name="delete">Delete</string>
     <string name="enter_validate_format">Please enter a %1$s</string>
     <string name="add_validate_format">Please add %1$s</string>
     <string name="url_is_invalid">The URL format is incorrect</string>

--- a/feature/profilecard/src/commonMain/composeResources/values/strings.xml
+++ b/feature/profilecard/src/commonMain/composeResources/values/strings.xml
@@ -14,6 +14,8 @@
     <string name="enter_validate_format">Please enter a %1$s</string>
     <string name="add_validate_format">Please add %1$s</string>
     <string name="url_is_invalid">The URL format is incorrect</string>
+    <string name="flip">Flip</string>
+    <string name="qrcode">QR code</string>
     <string name="share">Share</string>
     <string name="edit">Edit</string>
     <string name="share_description">Check out my DroidKaigi Profile Card! Let's connect at the event. #DroidKaigi</string>

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -830,17 +830,15 @@ internal fun CardScreen(
                             .testTag(ProfileCardShareButtonTestTag)
                             .padding(horizontal = 16.dp, vertical = 8.dp),
                     ) {
-                        val shareLabel = stringResource(ProfileCardRes.string.share)
-
                         Icon(
                             painter = painterResource(ProfileCardRes.drawable.icon_share),
-                            contentDescription = shareLabel,
+                            contentDescription = null,
                             tint = Color.Black,
                             modifier = Modifier.size(18.dp),
                         )
                         Spacer(Modifier.width(8.dp))
                         Text(
-                            text = shareLabel,
+                            text = stringResource(ProfileCardRes.string.share),
                             modifier = Modifier.padding(8.dp),
                             style = MaterialTheme.typography.labelLarge,
                             color = Color.Black,

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -3,7 +3,6 @@ package io.github.droidkaigi.confsched.profilecard
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -21,6 +20,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
@@ -700,12 +700,12 @@ private fun CardTypeImage(
 
     Image(
         painter = painterResource(ProfileCardRes.drawable.card_type),
-        contentDescription = null,
+        contentDescription = cardType.toString(),
         modifier = modifier
             .selectedBorder(isSelected, selectedBorderColor, painter)
             .clip(RoundedCornerShape(2.dp))
             .background(colorMap[cardType]!!)
-            .clickable { onClickImage(cardType) }
+            .selectable(isSelected) { onClickImage(cardType) }
             .padding(top = 36.dp, start = 30.dp, end = 30.dp, bottom = 36.dp),
     )
 }

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -97,6 +97,7 @@ import com.preat.peekaboo.image.picker.toImageBitmap
 import conference_app_2024.feature.profilecard.generated.resources.add_image
 import conference_app_2024.feature.profilecard.generated.resources.card_type
 import conference_app_2024.feature.profilecard.generated.resources.create_card
+import conference_app_2024.feature.profilecard.generated.resources.delete
 import conference_app_2024.feature.profilecard.generated.resources.edit
 import conference_app_2024.feature.profilecard.generated.resources.icon_share
 import conference_app_2024.feature.profilecard.generated.resources.image
@@ -627,7 +628,7 @@ private fun ImagePickerWithError(
                     Icon(
                         modifier = Modifier.padding(4.dp),
                         imageVector = Icons.Default.Close,
-                        contentDescription = null,
+                        contentDescription = stringResource(ProfileCardRes.string.delete),
                     )
                 }
             }

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/FlipCard.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/FlipCard.kt
@@ -23,11 +23,14 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import conference_app_2024.feature.profilecard.generated.resources.flip
 import io.github.droidkaigi.confsched.droidkaigiui.WithDeviceOrientation
+import io.github.droidkaigi.confsched.profilecard.ProfileCardRes
 import io.github.droidkaigi.confsched.profilecard.ProfileCardUiState.Card
 import io.github.droidkaigi.confsched.profilecard.hologramaticEffect
 import io.github.droidkaigi.confsched.profilecard.tiltEffect
 import kotlinx.coroutines.delay
+import org.jetbrains.compose.resources.stringResource
 
 const val ProfileCardFlipCardTestTag = "ProfileCardFlipCardTestTag"
 
@@ -57,7 +60,9 @@ internal fun FlipCard(
             modifier = modifier
                 .testTag(ProfileCardFlipCardTestTag)
                 .size(width = 300.dp, height = 380.dp)
-                .clickable { isFlipped = isFlipped.not() }
+                .clickable(onClickLabel = stringResource(ProfileCardRes.string.flip)) {
+                    isFlipped = isFlipped.not()
+                }
                 .draggable(
                     orientation = Orientation.Horizontal,
                     state = rememberDraggableState { delta ->

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/FlipCardBack.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/component/FlipCardBack.kt
@@ -21,6 +21,7 @@ import conference_app_2024.feature.profilecard.generated.resources.card_back_ora
 import conference_app_2024.feature.profilecard.generated.resources.card_back_pink
 import conference_app_2024.feature.profilecard.generated.resources.card_back_white
 import conference_app_2024.feature.profilecard.generated.resources.card_back_yellow
+import conference_app_2024.feature.profilecard.generated.resources.qrcode
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched.model.ProfileCard
 import io.github.droidkaigi.confsched.model.ProfileCardType.Flamingo
@@ -34,6 +35,7 @@ import io.github.droidkaigi.confsched.profilecard.ProfileCardRes
 import io.github.droidkaigi.confsched.profilecard.ProfileCardUiState.Card
 import io.github.droidkaigi.confsched.profilecard.toCardUiState
 import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import qrcode.QRCode
 
@@ -70,7 +72,7 @@ internal fun FlipCardBack(
         )
         Image(
             painter = painter,
-            contentDescription = null,
+            contentDescription = stringResource(ProfileCardRes.string.qrcode),
             modifier = Modifier.size(160.dp),
         )
     }


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Improved accessibility(TalkBack) on the ProfileCardScreen

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
※ The TalkBack speech output can be found at the bottom of each screenshot

Description |Before | After
:--: | :--:| :--:
Added a description for the delete button |<img src="https://github.com/user-attachments/assets/0ce638ef-9046-455b-b840-a8365747def2" width="300" /> | <img src="https://github.com/user-attachments/assets/ef70d95d-ca6b-4d00-8284-538f4b58671c" width="300" />
Added selection state and description for the theme |<img src="https://github.com/user-attachments/assets/4a0c10e9-ffba-4d41-aad9-213866c33166" width="300" /> | <img src="https://github.com/user-attachments/assets/94eac540-45d2-4444-b6a3-713bfd0b7884" width="300" />
Added selection state and description for the theme |<img src="https://github.com/user-attachments/assets/d6a64c35-d5cb-4dcf-84f1-33c7d354cf86" width="300" /> | <img src="https://github.com/user-attachments/assets/3cf2ecc6-c30b-4aea-ba98-a383488fdf49" width="300" />
Added a click label for the FlipCard  |<img src="https://github.com/user-attachments/assets/9cddfd4a-e74b-4213-8c5e-a9368a98632b" width="300" /> | <img src="https://github.com/user-attachments/assets/7fefa3a3-0c4e-4e45-a49f-9bf2379e4ca8" width="300" />
Added a description for the QR Code | not focusable | <img src="https://github.com/user-attachments/assets/cc77b028-5104-4ba2-bc05-e0012d686e0e" width="300" />
removed duplicate spoken content |<img src="https://github.com/user-attachments/assets/e2385898-1837-4bb8-a7a8-4715c6ec5b4c" width="300" /> | <img src="https://github.com/user-attachments/assets/c5696f29-43b6-4504-a93a-fb5bb8a816ce" width="300" />


## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
