### PR TITLE
Suppresses KMP "actual" and "expect" class warnings

### DIFF
--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpPlugin.kt
@@ -38,7 +38,12 @@ class KmpPlugin : Plugin<Project> {
                     }
                 }
                 compilerOptions {
-                    freeCompilerArgs.add("-Xcontext-receivers")
+                    freeCompilerArgs.addAll(
+                        listOf(
+                            "-Xcontext-receivers",
+                            "-Xexpect-actual-classes",
+                        )
+                    )
                 }
             }
         }


### PR DESCRIPTION
## Issue
- close #1008

## Overview (Required)
- Suppresses warnings about "actual" and "expect" class declarations

## Links
- https://kotlinlang.org/docs/multiplatform-expect-actual.html#expected-and-actual-classes

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/2cfb3ffb-c07b-424a-9432-2d9bca21d0ec" width="300" /> | <img src="https://github.com/user-attachments/assets/2dbfc3f8-0321-4436-b60d-92f9535f7504" width="300" />