### PR TITLE
Prevent TotalContributor animation from recomposition on scroll

### DIFF
--- a/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched/contributors/component/ContributorsCountItem.kt
+++ b/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched/contributors/component/ContributorsCountItem.kt
@@ -16,7 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -31,7 +31,7 @@ internal fun ContributorsCountItem(
     totalContributor: Int,
     modifier: Modifier = Modifier,
 ) {
-    var targetValue by remember { mutableStateOf(0) }
+    var targetValue by rememberSaveable { mutableStateOf(0) }
     val animatedTotalContributor by animateIntAsState(
         targetValue = targetValue,
         animationSpec = tween(


### PR DESCRIPTION
## Issue
- close #1001

## Overview (Required)
- Changed `targetValue` from `remember` to `rememberSaveable` 
  - I thought this problem was caused by recomposition by scrolling. 
  - To avoid this I used `rememberSaveable`.

## Links

## Screenshot (Optional if screenshot test is present or unrelated to UI)

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/5f2fabf4-9416-4e0e-aa6d-480137502c8f" width="300" > | <video src="https://github.com/user-attachments/assets/47832be0-6ca4-45b9-b7fa-9b6e15c425ca" width="300" >
