### PR TITLE
:recycle: [IosComposeKaigiApp.kt] Modified to use SharedTransitionLayout in the same way as KaigiApp.kt.

### DIFF
--- a/app-ios-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/shared/IosComposeKaigiApp.kt
+++ b/app-ios-shared/src/commonMain/kotlin/io/github/droidkaigi/confsched/shared/IosComposeKaigiApp.kt
@@ -1,5 +1,7 @@
 package io.github.droidkaigi.confsched.shared
 
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
@@ -36,6 +38,7 @@ import io.github.droidkaigi.confsched.designsystem.theme.dotGothic16FontFamily
 import io.github.droidkaigi.confsched.droidkaigiui.NavHostWithSharedAxisX
 import io.github.droidkaigi.confsched.droidkaigiui.SnackbarMessageEffect
 import io.github.droidkaigi.confsched.droidkaigiui.UserMessageStateHolder
+import io.github.droidkaigi.confsched.droidkaigiui.compositionlocal.LocalSharedTransitionScope
 import io.github.droidkaigi.confsched.droidkaigiui.compositionlocal.LocalSnackbarHostState
 import io.github.droidkaigi.confsched.eventmap.eventMapScreenRoute
 import io.github.droidkaigi.confsched.eventmap.eventMapScreens
@@ -190,69 +193,80 @@ fun KaigiApp(
     }
 }
 
+@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 private fun KaigiNavHost(
     windowSize: WindowSizeClass,
     externalNavController: ExternalNavController,
     onLicenseScreenRequest: () -> Unit,
     onAccessCalendarIsDenied: () -> Unit,
+    modifier: Modifier = Modifier,
     navController: NavHostController = rememberNavController(),
     mainNestedNavController: NavHostController = rememberNavController(),
 ) {
-    NavHostWithSharedAxisX(navController = navController, startDestination = mainScreenRoute) {
-        mainScreen(
-            windowSize = windowSize,
-            navController = navController,
-            mainNestedNavController = mainNestedNavController,
-            externalNavController = externalNavController,
-            onLicenseScreenRequest = onLicenseScreenRequest,
-        )
-        sessionScreens(
-            onNavigationIconClick = navController::popBackStack,
-            onLinkClick = externalNavController::navigate,
-            onCalendarRegistrationClick = { timetableItem ->
-                externalNavController.navigateToCalendarRegistration(
-                    timetableItem = timetableItem,
-                    onAccessCalendarIsDenied = onAccessCalendarIsDenied,
+    SharedTransitionLayout(modifier = modifier) {
+        CompositionLocalProvider(
+            LocalSharedTransitionScope provides this,
+        ) {
+            NavHostWithSharedAxisX(
+                navController = navController,
+                startDestination = mainScreenRoute,
+            ) {
+                mainScreen(
+                    windowSize = windowSize,
+                    navController = navController,
+                    mainNestedNavController = mainNestedNavController,
+                    externalNavController = externalNavController,
+                    onLicenseScreenRequest = onLicenseScreenRequest,
                 )
-            },
-            onShareClick = externalNavController::onShareClick,
-            onFavoriteListClick = {
-                navController.navigate(
-                    favoritesScreenWithNavigationIconRoute
+                sessionScreens(
+                    onNavigationIconClick = navController::popBackStack,
+                    onLinkClick = externalNavController::navigate,
+                    onCalendarRegistrationClick = { timetableItem ->
+                        externalNavController.navigateToCalendarRegistration(
+                            timetableItem = timetableItem,
+                            onAccessCalendarIsDenied = onAccessCalendarIsDenied,
+                        )
+                    },
+                    onShareClick = externalNavController::onShareClick,
+                    onFavoriteListClick = {
+                        navController.navigate(
+                            favoritesScreenWithNavigationIconRoute
+                        )
+                    },
                 )
-            },
-        )
 
-        contributorsScreens(
-            onNavigationIconClick = navController::popBackStack,
-            onContributorItemClick = externalNavController::navigate,
-        )
+                contributorsScreens(
+                    onNavigationIconClick = navController::popBackStack,
+                    onContributorItemClick = externalNavController::navigate,
+                )
 
-        searchScreens(
-            onTimetableItemClick = navController::navigateToTimetableItemDetailScreen,
-            onBackClick = navController::popBackStack,
-        )
+                searchScreens(
+                    onTimetableItemClick = navController::navigateToTimetableItemDetailScreen,
+                    onBackClick = navController::popBackStack,
+                )
 
-        staffScreens(
-            onNavigationIconClick = navController::popBackStack,
-            onStaffItemClick = externalNavController::navigate,
-        )
+                staffScreens(
+                    onNavigationIconClick = navController::popBackStack,
+                    onStaffItemClick = externalNavController::navigate,
+                )
 
-        settingsScreens(
-            onNavigationIconClick = navController::popBackStack,
-        )
+                settingsScreens(
+                    onNavigationIconClick = navController::popBackStack,
+                )
 
-        sponsorsScreens(
-            onNavigationIconClick = navController::popBackStack,
-            onSponsorsItemClick = externalNavController::navigate,
-        )
+                sponsorsScreens(
+                    onNavigationIconClick = navController::popBackStack,
+                    onSponsorsItemClick = externalNavController::navigate,
+                )
 
-        favoritesScreens(
-            onNavigationIconClick = navController::popBackStack,
-            onTimetableItemClick = navController::navigateToTimetableItemDetailScreen,
-            contentPadding = PaddingValues(),
-        )
+                favoritesScreens(
+                    onNavigationIconClick = navController::popBackStack,
+                    onTimetableItemClick = navController::navigateToTimetableItemDetailScreen,
+                    contentPadding = PaddingValues(),
+                )
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Issue
- close #1014

## Overview (Required)
- As the title says.

## Links
- https://github.com/DroidKaigi/conference-app-2024/blob/82bcd5c65a2d7bafed797eaed98c1cdbc99c3822/app-android/src/main/java/io/github/droidkaigi/confsched/KaigiApp.kt#L139-L142

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/99914c88-c535-4b87-9c75-9b467ff4270e" width="300" > | <video src="https://github.com/user-attachments/assets/8b2ce731-af00-4dd3-9112-bf9a36bd9eee" width="300" >