### PR TITLE
:wastebasket: DropUnlessResumed is causing navigation issues on AboutScreen, so DropUnlessResumed is removed.

### DIFF
--- a/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/TimetableItemCard.kt
+++ b/core/droidkaigiui/src/commonMain/kotlin/io/github/droidkaigi/confsched/droidkaigiui/component/TimetableItemCard.kt
@@ -52,7 +52,6 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.compose.dropUnlessResumed
 import conference_app_2024.core.droidkaigiui.generated.resources.bookmarked
 import conference_app_2024.core.droidkaigiui.generated.resources.image
 import conference_app_2024.core.droidkaigiui.generated.resources.not_bookmarked
@@ -120,7 +119,7 @@ fun TimetableItemCard(
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = ripple(color = LocalRoomTheme.current.primaryColor),
-                    onClick = dropUnlessResumed { onTimetableItemClick(timetableItem) },
+                    onClick = { onTimetableItemClick(timetableItem) },
                 ),
         ) {
             val contentPadding = 12.dp

--- a/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutContentColumn.kt
+++ b/feature/about/src/commonMain/kotlin/io/github/droidkaigi/confsched/about/component/AboutContentColumn.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.dropUnlessResumed
 import conference_app_2024.feature.about.generated.resources.staff
 import io.github.droidkaigi.confsched.about.AboutRes
 import io.github.droidkaigi.confsched.designsystem.theme.KaigiTheme
@@ -40,7 +39,7 @@ fun AboutContentColumn(
             .fillMaxWidth()
             .height(73.dp)
             .testTag(testTag)
-            .clickable(onClick = dropUnlessResumed(block = onClickAction)),
+            .clickable(onClick = onClickAction),
     ) {
         Row(
             modifier = Modifier

--- a/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched/contributors/ContributorsScreen.kt
+++ b/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched/contributors/ContributorsScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import conference_app_2024.feature.contributors.generated.resources.contributor_title
@@ -46,7 +45,7 @@ fun NavGraphBuilder.contributorsScreens(
 ) {
     composable(contributorsScreenRoute) {
         ContributorsScreen(
-            onNavigationIconClick = dropUnlessResumed(block = onNavigationIconClick),
+            onNavigationIconClick = onNavigationIconClick,
             onContributorsItemClick = onContributorItemClick,
         )
     }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/SearchScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
@@ -52,7 +51,7 @@ fun NavGraphBuilder.searchScreens(
         ) {
             SearchScreen(
                 onTimetableItemClick = onTimetableItemClick,
-                onBackClick = dropUnlessResumed(block = onBackClick),
+                onBackClick = onBackClick,
             )
         }
     }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableItemDetailScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
-import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
@@ -71,11 +70,11 @@ fun NavGraphBuilder.sessionScreens(
             LocalAnimatedVisibilityScope provides this@composable,
         ) {
             TimetableItemDetailScreen(
-                onNavigationIconClick = dropUnlessResumed(block = onNavigationIconClick),
+                onNavigationIconClick = onNavigationIconClick,
                 onLinkClick = onLinkClick,
                 onCalendarRegistrationClick = onCalendarRegistrationClick,
                 onShareClick = onShareClick,
-                onFavoriteListClick = dropUnlessResumed(block = onFavoriteListClick),
+                onFavoriteListClick = onFavoriteListClick,
             )
         }
     }

--- a/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/commonMain/kotlin/io/github/droidkaigi/confsched/sessions/TimetableScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavGraphBuilder
@@ -165,7 +164,7 @@ private fun TimetableScreen(
                             maxLines = 1,
                         )
                         IconButton(
-                            onClick = dropUnlessResumed(block = onSearchClick),
+                            onClick = onSearchClick,
                         ) {
                             Icon(
                                 imageVector = Icons.Default.Search,

--- a/feature/settings/src/commonMain/kotlin/io/github/droidkaigi/confsched/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/io/github/droidkaigi/confsched/settings/SettingsScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import conference_app_2024.feature.settings.generated.resources.settings_title
@@ -38,7 +37,7 @@ fun NavGraphBuilder.settingsScreens(
 ) {
     composable(settingsScreenRoute) {
         SettingsScreen(
-            onNavigationIconClick = dropUnlessResumed(block = onNavigationIconClick),
+            onNavigationIconClick = onNavigationIconClick,
         )
     }
 }

--- a/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/SponsorsScreen.kt
+++ b/feature/sponsors/src/commonMain/kotlin/io/github/droidkaigi/confsched/sponsors/SponsorsScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import conference_app_2024.feature.sponsors.generated.resources.content_description_back
@@ -42,7 +41,7 @@ fun NavGraphBuilder.sponsorsScreens(
 ) {
     composable(sponsorsScreenRoute) {
         SponsorsScreen(
-            onNavigationIconClick = dropUnlessResumed(block = onNavigationIconClick),
+            onNavigationIconClick = onNavigationIconClick,
             onSponsorsItemClick = onSponsorsItemClick,
         )
     }

--- a/feature/staff/src/commonMain/kotlin/io/github/droidkaigi/confsched/staff/StaffScreen.kt
+++ b/feature/staff/src/commonMain/kotlin/io/github/droidkaigi/confsched/staff/StaffScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import conference_app_2024.feature.staff.generated.resources.staff_title
@@ -49,7 +48,7 @@ fun NavGraphBuilder.staffScreens(
 ) {
     composable(staffScreenRoute) {
         StaffScreen(
-            onNavigationIconClick = dropUnlessResumed(block = onNavigationIconClick),
+            onNavigationIconClick = onNavigationIconClick,
             onStaffItemClick = onStaffItemClick,
         )
     }


### PR DESCRIPTION
## Issue
- close #1016

## Overview (Required)
- When the same item in the BottomNavigation is tapped, lifecycleOwner.lifecycle.currentState becomes DESTROYED and becomes impossible to tap.
- If you scroll, it will return to RESUMED and become tapable again.
- Because the number of days remaining until DroidKaigi is limited, there is no time to spare to deal with this phenomenon in a fundamental way.
- For now, it would be best to remove it.

<video src="https://github.com/user-attachments/assets/c8800ef5-8b5c-459b-a64e-5ee850ae88e8" width="300">

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/a495820e-06c7-4c8f-9a67-2de71c0cd0e7" width="300" > | <video src="https://github.com/user-attachments/assets/358627b2-4582-4fdd-a454-4ce24fd84787" width="300" >