### PR TITLE
[ProfileCardScreen] Design enhancement

### DIFF
--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -416,6 +416,10 @@ internal fun EditScreen(
                 nickname = it
                 onChangeNickname(it)
             },
+            onInputClear = {
+                nickname = ""
+                onChangeNickname("")
+            },
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
         )
         InputFieldWithError(
@@ -426,6 +430,10 @@ internal fun EditScreen(
             onValueChange = {
                 occupation = it
                 onChangeOccupation(it)
+            },
+            onInputClear = {
+                occupation = ""
+                onChangeOccupation("")
             },
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
         )
@@ -439,6 +447,10 @@ internal fun EditScreen(
             onValueChange = {
                 link = it
                 onChangeLink(it)
+            },
+            onInputClear = {
+                link = ""
+                onChangeLink("")
             },
             keyboardOptions = KeyboardOptions(
                 imeAction = ImeAction.Done,
@@ -531,6 +543,7 @@ private fun InputFieldWithError(
     errorMessage: String,
     textFieldTestTag: String,
     onValueChange: (String) -> Unit,
+    onInputClear: () -> Unit,
     modifier: Modifier = Modifier,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
@@ -554,9 +567,7 @@ private fun InputFieldWithError(
             trailingIcon = {
                 if (value.isNotEmpty()) {
                     IconButton(
-                        onClick = {
-                            // TODO
-                        },
+                        onClick = onInputClear,
                         modifier = Modifier
                             .padding(
                                 top = 8.dp,

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -555,14 +555,14 @@ private fun InputFieldWithError(
                 if (value.isNotEmpty()) {
                     IconButton(
                         onClick = {
-                            //TODO
+                            // TODO
                         },
                         modifier = Modifier
                             .padding(
                                 top = 8.dp,
                                 bottom = 8.dp,
                                 end = 4.dp,
-                            )
+                            ),
                     ) {
                         Icon(
                             modifier = Modifier.padding(8.dp),

--- a/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
+++ b/feature/profilecard/src/commonMain/kotlin/io/github/droidkaigi/confsched/profilecard/ProfileCardScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.Cancel
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -550,6 +551,27 @@ private fun InputFieldWithError(
             value = value,
             textStyle = MaterialTheme.typography.bodyLarge,
             onValueChange = onValueChange,
+            trailingIcon = {
+                if (value.isNotEmpty()) {
+                    IconButton(
+                        onClick = {
+                            //TODO
+                        },
+                        modifier = Modifier
+                            .padding(
+                                top = 8.dp,
+                                bottom = 8.dp,
+                                end = 4.dp,
+                            )
+                    ) {
+                        Icon(
+                            modifier = Modifier.padding(8.dp),
+                            imageVector = Icons.Outlined.Cancel,
+                            contentDescription = stringResource(ProfileCardRes.string.delete),
+                        )
+                    }
+                }
+            },
             isError = isError,
             shape = RoundedCornerShape(4.dp),
             keyboardOptions = keyboardOptions,


### PR DESCRIPTION
## Issue
- [Link](https://github.com/DroidKaigi/conference-app-2024/pull/971)

## Overview (Required)
- Clear icon placed for profile screen's EditText(clear function not yet implemented)
 

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/6f6bf04a-336f-4ed5-8c0a-6ccaaa613bcb" width="300" /> | <img src="https://github.com/user-attachments/assets/179a84e6-814d-4955-9097-7291f82b9e7c" width="300" />


## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
