### PR TITLE
Fix the position of the loading spinner in StaffScreen

### DIFF
--- a/feature/staff/src/commonMain/kotlin/io/github/droidkaigi/confsched/staff/StaffScreen.kt
+++ b/feature/staff/src/commonMain/kotlin/io/github/droidkaigi/confsched/staff/StaffScreen.kt
@@ -123,22 +123,22 @@ fun StaffScreen(
             }
         },
     ) { padding ->
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(top = padding.calculateTopPadding())
-                .let {
-                    if (scrollBehavior != null) {
-                        it.nestedScroll(scrollBehavior.nestedScrollConnection)
-                    } else {
-                        it
-                    }
-                }
-                .testTag(StaffScreenLazyColumnTestTag),
-            contentPadding = PaddingValues(bottom = 40.dp + padding.calculateBottomPadding()),
-        ) {
-            when (uiState) {
-                is StaffUiState.Exists -> {
+        when (uiState) {
+            is StaffUiState.Exists -> {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(top = padding.calculateTopPadding())
+                        .let {
+                            if (scrollBehavior != null) {
+                                it.nestedScroll(scrollBehavior.nestedScrollConnection)
+                            } else {
+                                it
+                            }
+                        }
+                        .testTag(StaffScreenLazyColumnTestTag),
+                    contentPadding = PaddingValues(bottom = 40.dp + padding.calculateBottomPadding()),
+                ) {
                     items(uiState.staff) { staff ->
                         StaffItem(
                             staff = staff,
@@ -149,15 +149,13 @@ fun StaffScreen(
                         )
                     }
                 }
-                is StaffUiState.Loading -> {
-                    item {
-                        Box(
-                            contentAlignment = Alignment.Center,
-                            modifier = Modifier.padding(padding).fillMaxSize(),
-                        ) {
-                            CircularProgressIndicator()
-                        }
-                    }
+            }
+            is StaffUiState.Loading -> {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier.padding(padding).fillMaxSize(),
+                ) {
+                    CircularProgressIndicator()
                 }
             }
         }


### PR DESCRIPTION
## Issue
- close #1022 

## Overview (Required)
- I adjusted the position of the loading spinner in StaffScreen with ContributorScreen

## Links
- https://github.com/DroidKaigi/conference-app-2024/issues/1022

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After | ContributorScreen
:--: | :--: | :--:
<img src="https://github.com/user-attachments/assets/16e528ce-50bb-4c56-ba5f-f0e0ff4ef9f6" width="300" /> | <img src="https://github.com/user-attachments/assets/998bbdce-1222-4c64-a2f8-99829ba1bec3" width="300" /> | <img src="https://github.com/user-attachments/assets/c2bd5042-f673-408c-b66d-d0bf5dc53a22" width="300">

<!--
## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
-->