### PR TITLE
Change NavRail position to center on large screen

### DIFF
--- a/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/MainScreen.kt
+++ b/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/MainScreen.kt
@@ -228,7 +228,7 @@ fun MainScreen(
     Row(
         modifier = modifier.fillMaxSize(),
         verticalAlignment = Alignment.CenterVertically,
-        ) {
+    ) {
         AnimatedVisibility(visible = navigationType == NavigationRail) {
             GlassLikeNavRail(
                 hazeState = hazeState,

--- a/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/MainScreen.kt
+++ b/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/MainScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -224,7 +225,10 @@ fun MainScreen(
 
     val scaffoldPadding = remember { mutableStateOf(PaddingValues(0.dp)) }
 
-    Row(modifier = modifier.fillMaxSize()) {
+    Row(
+        modifier = modifier.fillMaxSize(),
+        verticalAlignment = Alignment.CenterVertically,
+        ) {
         AnimatedVisibility(visible = navigationType == NavigationRail) {
             GlassLikeNavRail(
                 hazeState = hazeState,

--- a/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeNavRail.kt
+++ b/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeNavRail.kt
@@ -13,8 +13,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.CircleShape

--- a/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeNavRail.kt
+++ b/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeNavRail.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.selectableGroup
@@ -74,7 +75,8 @@ fun GlassLikeNavRail(
     modifier: Modifier = Modifier,
 ) {
     Box(
-        modifier = modifier.size(width = 64.dp, height = 320.dp)
+        modifier = modifier
+            .size(width = 64.dp, height = 420.dp)
             .run {
                 if (isBlurSupported()) {
                     hazeChild(state = hazeState, shape = CircleShape).border(

--- a/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeNavRail.kt
+++ b/feature/main/src/commonMain/kotlin/io/github/droidkaigi/confsched/main/section/GlassLikeNavRail.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.CircleShape


### PR DESCRIPTION
## Issue
- On devices with large screens, the NavRail was positioned in the upper left corner.
- On foldable devices, the size of the NavRail seemed small.

## Overview (Required)
- NavRail height changed to 420 dp.
- NavRail centered vertically on the left side of the screen.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/8df1906a-9687-44e1-a3c7-4b298da3610f" width="300" />|<img src="https://github.com/user-attachments/assets/f08f5b82-da37-4f42-b33e-c1051a1188f5" width="300" /> |
<img src="https://github.com/user-attachments/assets/7fd34780-7d90-466a-b1c8-5cdadc3a6e64" width="300" />|<img src="https://github.com/user-attachments/assets/9f670e37-7b23-4267-9b08-0810f611a00b" width="300" /> | 
<img src="https://github.com/user-attachments/assets/8c19a1e7-1856-40b7-be48-918755beb4a6" width="300" />|<img src="https://github.com/user-attachments/assets/b2f3d16e-eb1e-4813-87fe-b8259502cd1a" width="300" /> | 


## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
