### PR TITLE
[iOS] support Button Shapes accessibility to tabItems (fix tab design bug)

### DIFF
--- a/app-ios/Sources/App/RootView.swift
+++ b/app-ios/Sources/App/RootView.swift
@@ -69,21 +69,30 @@ public struct RootView: View {
             (tab: .about, icon: .icInfo),
             (tab: .profileCard, icon: .icProfileCard),
         ]
-        HStack(spacing: 36) {
-            ForEach(items, id: \.tab) { item in
-                let isSelected = selection == item.tab
-                Button {
-                    selection = item.tab
-                } label: {
-                    Image(item.icon).renderingMode(.template).tint(isSelected ? nil : .white)
+        
+        GeometryReader { geometry in
+            HStack(spacing: 0) {
+                ForEach(items, id: \.tab) { item in
+                    let isSelected = selection == item.tab
+                    Button {
+                        selection = item.tab
+                    } label: {
+                        Image(item.icon).renderingMode(.template).tint(isSelected ? nil : .white)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                            .contentShape(Rectangle())
+                    }
+                    .frame(maxWidth: geometry.size.width / CGFloat(items.count), maxHeight: .infinity, alignment: .center)
                 }
             }
+            .frame(width: geometry.size.width, height: geometry.size.height)
         }
-        .padding(.vertical)
-        .padding(.horizontal, 24)
+        .frame(height: 64)
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 12)
         .background(.ultraThinMaterial, in: Capsule())
         .overlay(Capsule().stroke(.gray, lineWidth: 1))
         .environment(\.colorScheme, .dark)
+        .padding(.horizontal, 48)
     }
 
     @MainActor


### PR DESCRIPTION
## Overview (Required)
- support Button Shapes accessibility to tabItems (fix tab design bug)
- This fix also expands the tap area of the tab buttons, making them easier to tap.
- I changed the width of the entire tab to be determined by padding relative to the device's width. If need to make the width larger for design purposes, can adjust the padding. (Of course, I can also revert the width setting to a fixed value.
I made the width based on padding relative to the device's width because I felt that it looks a bit nicer, as the tab width becomes wider and more responsive on larger devices. However, this is a personal preference and may vary from person to person.)

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
<img width="300" alt="before1" src="https://github.com/user-attachments/assets/90a89abb-7364-4de3-af65-2a0a781a2778"> | <img width="300" alt="after1" src="https://github.com/user-attachments/assets/7fc8f278-a555-467d-8233-26a2a4a45294">
<img width="300" alt="before2" src="https://github.com/user-attachments/assets/d27dbe49-b0bb-4975-9e58-79c855651afa"> | <img width="300" alt="after2" src="https://github.com/user-attachments/assets/243027b3-5f68-4971-a0e8-191abc009f6b">
