### PR TITLE
[iOS] Prevent contributors counting animation from firing on scroll

### DIFF
--- a/app-ios/Sources/ContributorFeature/ContributorsCountItem.swift
+++ b/app-ios/Sources/ContributorFeature/ContributorsCountItem.swift
@@ -34,6 +34,8 @@ struct ContributorsCountItem: View {
     }
     
     func animate() {
+        if tracker >= totalContributor { return }
+
         let interval = duration / Double(totalContributor)
         Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { time in
             tracker += 1


### PR DESCRIPTION
## Issue
- close #1001

## Overview (Required)
- This PR prevents the contributors counting animation from firing on scroll

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/d381db0d-b5f1-4937-bcdd-80fed490eee0" width="300" > | <video src="https://github.com/user-attachments/assets/880cd7bb-4bdc-480b-9f8e-21aab69f9f55" width="300" >
