### PR TITLE
Fix bug that canceled special session's message is not showed

### DIFF
--- a/app-ios/Sources/CommonComponents/Timetable/TimetableCard.swift
+++ b/app-ios/Sources/CommonComponents/Timetable/TimetableCard.swift
@@ -80,12 +80,16 @@ public struct TimetableCard: View {
                             .lineLimit(1)
                     }
                 }
-                if let timetableItemSession = timetableItem as? TimetableItem.Session,
-                   let sessionMessage = timetableItemSession.message?.currentLangTitle,
-                   !sessionMessage.isEmpty {
+
+                let message: String? = switch timetableItem {
+                case let session as TimetableItem.Session: session.message?.currentLangTitle
+                case let special as TimetableItem.Special: special.message?.currentLangTitle
+                default: nil
+                }
+                if let message, !message.isEmpty {
                     HStack(spacing: 8) {
                         Image(.icInfoFill)
-                        Text(sessionMessage)
+                        Text(message)
                             .textStyle(.bodySmall)
                             .multilineTextAlignment(.leading)
                             .foregroundStyle(AssetColors.Error.error.swiftUIColor)


### PR DESCRIPTION
## Issue
- close #987 

## Overview (Required)
- Fix bug that canceled special session's message is not showed

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/1df213a0-08a9-4056-985f-019bc329d585" width="300" /> | <img src="https://github.com/user-attachments/assets/d693448d-d3dc-4bb9-b84f-e5cbe9f75125" width="300" />


