### PR TITLE
implementation foundation:1.8.0-alpha01 instead of resolutionStrategy

### DIFF
--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpComposePlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched/primitive/KmpComposePlugin.kt
@@ -48,6 +48,7 @@ class KmpComposePlugin : Plugin<Project> {
                             dependencies {
                                 implementation(libs.library("androidxActivityActivityCompose"))
                                 implementation(libs.library("composeUiToolingPreview"))
+                                implementation(libs.library("composeFoundation"))
                             }
                         }
                 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,13 +21,3 @@ buildscript {
         }
     }
 }
-
-allprojects {
-    configurations.all {
-        resolutionStrategy {
-            // When the fixed version is released, remove this block
-            // https://issuetracker.google.com/issues/341880461
-            force("androidx.compose.foundation:foundation:1.8.0-alpha01")
-        }
-    }
-}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ composeMultiplatform = "1.7.0-beta01"
 rin = "0.1.0"
 composeInvestigator = "1.5.10-0.2.1"
 composeMaterial3 = "1.3.0"
+composeFoundation = "1.8.0-alpha01"
 composeHiltNavigation = "1.2.0"
 androidxLifecycle = "2.8.4"
 androidxActivity = "1.9.1"
@@ -102,6 +103,7 @@ composeAnimation = { module = "androidx.compose.animation:animation" }
 composeAnimationGraphics = { module = "androidx.compose.animation:animation-graphics" }
 composeMaterial = { module = "androidx.compose.material:material" }
 composeMaterial3 = { module = "androidx.compose.material3:material3", version.ref = "composeMaterial3" }
+composeFoundation = { module = "androidx.compose.foundation:foundation", version.ref = "composeFoundation" }
 composeMaterialWindowSize = "dev.chrisbanes.material3:material3-window-size-class-multiplatform:0.5.0"
 composeMaterialIcon = { module = "androidx.compose.material:material-icons-extended" }
 composeUiTestManifest = { module = "androidx.compose.ui:ui-test-manifest" }


### PR DESCRIPTION
## Issue
- close #995

## Overview (Required)
- define composeFoundation in version catalog
- implementation composeFoundation in KmpComposePlugin androidMain dependencies
- remove resolutionStrategy

## Links
- 
