### PR TITLE
[iOS] Remove unnecessary modifier about maxWidth.

### DIFF
--- a/app-ios/Sources/TimetableFeature/TimetableGridCard.swift
+++ b/app-ios/Sources/TimetableFeature/TimetableGridCard.swift
@@ -61,7 +61,6 @@ public struct TimetableGridCard: View {
                     }
                 }
             }
-            .frame(maxWidth: .infinity)
             .padding(12)
             .frame(maxWidth: 192 * CGFloat(cellCount) + CGFloat(12 * (cellCount - 1)))
             .frame(height: 153)


### PR DESCRIPTION
## Issue
- None.（※ I found a solution and improved it.）

## Overview (Required)
- Remove `.frame(maxWidth: .infinity)`
  - Since `.frame(maxWidth: 192 * CGFloat(cellCount) + CGFloat(12 * (cellCount - 1)))` is set, this setting is not necessary.